### PR TITLE
feat: ARP nudge — keep the upstream gateway's ARP entry for the CARP VIP fresh

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.0
+PLUGIN_VERSION=         1.1
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # NOTE: the py<XY>-scapy version MUST match the OPNsense base Python of your target release.

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -123,16 +123,17 @@ OPNsense CARP answers ARP + egresses data as usual. The VIP becomes failover-cap
   **hostname (12)** per keeper (advanced) for ISPs that only lease when they see a specific value. Empty
   = not sent. Give the keeper its *own* client-id — do not copy the WAN interface's, or the server may
   treat them as one client.
-- **ARP nudge (optional, advanced):** periodically broadcast an ARP *request* from the VIP (with its CARP
+- **ARP nudge (on by default, advanced):** periodically broadcast an ARP *request* from the VIP (with its CARP
   MAC) for the upstream gateway, refreshing the gateway's ARP entry for the VIP. Some ISP gateways/BNGs
   ignore gratuitous ARP (spoofing protection) and **never re-ARP an expired entry** — the symptom is that
   traffic NATed to the VIP works right after a CARP event or DHCP exchange, then **silently blackholes
   some minutes later** (outbound packets leave, nothing returns; even the gateway stops answering pings
   from the VIP). A DHCP RENEW does *not* refresh such a gateway's ARP cache, but a received ARP request
-  does. Suggested interval: 240 s (well under typical 15–20 min ARP timeouts). The nudge is only sent
-  while this node is CARP **master** for the VIP (never from a backup, which would steal the VIP's
-  traffic), and the gateway address is taken from DHCP option 3 (fallback: the DHCP server address).
-  0 = off (default).
+  does. Default interval: 240 s (well under typical 15–20 min ARP timeouts) — one broadcast ARP per
+  interval is negligible next to CARP's one advertisement per second, and harmless on gateways that
+  behave normally, so it is **on by default**. The nudge is only sent while this node is CARP **master**
+  for the VIP (never from a backup, which would steal the VIP's traffic), and the gateway address is
+  taken from DHCP option 3 (fallback: the DHCP server address). Set 0 to disable.
 - **Self-healing:** the daemon never exits on a transient DHCP/interface fault — it catches errors, keeps
   its heartbeat fresh (so CARP does not falsely demote the node) and retries.
 

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -123,6 +123,16 @@ OPNsense CARP answers ARP + egresses data as usual. The VIP becomes failover-cap
   **hostname (12)** per keeper (advanced) for ISPs that only lease when they see a specific value. Empty
   = not sent. Give the keeper its *own* client-id — do not copy the WAN interface's, or the server may
   treat them as one client.
+- **ARP nudge (optional, advanced):** periodically broadcast an ARP *request* from the VIP (with its CARP
+  MAC) for the upstream gateway, refreshing the gateway's ARP entry for the VIP. Some ISP gateways/BNGs
+  ignore gratuitous ARP (spoofing protection) and **never re-ARP an expired entry** — the symptom is that
+  traffic NATed to the VIP works right after a CARP event or DHCP exchange, then **silently blackholes
+  some minutes later** (outbound packets leave, nothing returns; even the gateway stops answering pings
+  from the VIP). A DHCP RENEW does *not* refresh such a gateway's ARP cache, but a received ARP request
+  does. Suggested interval: 240 s (well under typical 15–20 min ARP timeouts). The nudge is only sent
+  while this node is CARP **master** for the VIP (never from a backup, which would steal the VIP's
+  traffic), and the gateway address is taken from DHCP option 3 (fallback: the DHCP server address).
+  0 = off (default).
 - **Self-healing:** the daemon never exits on a transient DHCP/interface fault — it catches errors, keeps
   its heartbeat fresh (so CARP does not falsely demote the node) and retries.
 

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -134,6 +134,11 @@ OPNsense CARP answers ARP + egresses data as usual. The VIP becomes failover-cap
   behave normally, so it is **on by default**. The nudge is only sent while this node is CARP **master**
   for the VIP (never from a backup, which would steal the VIP's traffic), and the gateway address is
   taken from DHCP option 3 (fallback: the DHCP server address). Set 0 to disable.
+  **Becoming master** (failover, or a link flap re-electing CARP) triggers an immediate nudge *and* an
+  early lease RENEW — upstream ARP and DHCP-snooping state may just have been disturbed, so neither
+  waits for its normal timer. A **manual nudge** is available for troubleshooting: the ⚡ button on the
+  status page (shown on the CARP master), or `kill -USR1` on the keeper daemon — it fires within a
+  second and shows up in the log.
 - **Self-healing:** the daemon never exits on a transient DHCP/interface fault — it catches errors, keeps
   its heartbeat fresh (so CARP does not falsely demote the node) and retries.
 
@@ -209,6 +214,18 @@ ARP nudge). This is the core reason the lease lives on the CARP MAC rather than 
 - WAN is the typical — but not required — placement.
 - You must own the MAC/reservation you keep a lease for; holding a foreign lease is an ISP violation.
 - Requires **root** (raw L2/BPF socket) and depends on **Scapy**.
+
+### Design notes — considered and deliberately not included
+
+- **DHCP option 82 (relay/circuit-id):** inserted by the ISP's access node, not by the client —
+  nothing for a DHCP client to support.
+- **RFC 5227 address-conflict detection:** CARP already arbitrates the VIP between our own nodes; a
+  rogue host on the ISP segment claiming the address is beyond what a subscriber device can police.
+- **DAI/ARP rate-limit accommodation:** access gear typically rate-limits ARP at ≥15 pps; one nudge
+  per 240 s is four orders of magnitude below — no pacing logic needed.
+- **Unicast DHCP RENEW:** the keeper renews by broadcast with the broadcast flag set, and the
+  promiscuous sniffer also captures unicast replies — both server behaviours are covered without a
+  unicast sending mode.
 
 ## License
 

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -54,7 +54,8 @@ Then find it under **Interfaces → Virtual IPs DHCP**.
 After installing, the plugin lives under **Interfaces → Virtual IPs DHCP**, with three pages:
 
 - **Settings** — the keeper table (add / edit / enable keepers).
-- **Status** — effective configuration + runtime (bound lease, heartbeat age, CARP demotion), and per-keeper mode.
+- **Status** — effective configuration + runtime (bound lease, heartbeat age, ARP nudge age/target,
+  CARP demotion), per-keeper mode, and a ⚡ button to send a manual ARP nudge (on the CARP master).
 - **Log** — the keeper log (searchable/filterable, with a clear button).
 
 The privilege that grants access is **“Interfaces: Virtual IPs DHCP”**.
@@ -136,9 +137,9 @@ OPNsense CARP answers ARP + egresses data as usual. The VIP becomes failover-cap
   taken from DHCP option 3 (fallback: the DHCP server address). Set 0 to disable.
   **Becoming master** (failover, or a link flap re-electing CARP) triggers an immediate nudge *and* an
   early lease RENEW — upstream ARP and DHCP-snooping state may just have been disturbed, so neither
-  waits for its normal timer (the early renew applies even with the nudge disabled). A **manual nudge** is available for troubleshooting: the ⚡ button on the
-  status page (shown on the CARP master), or `kill -USR1` on the keeper daemon — it fires within a
-  second and shows up in the log.
+  waits for its normal timer (the early renew applies even with the nudge disabled). A **manual
+  nudge** is available for troubleshooting: the ⚡ button on the status page (shown on the CARP
+  master), or `kill -USR1` on the keeper daemon — it fires within a second and shows up in the log.
 - **Self-healing:** the daemon never exits on a transient DHCP/interface fault — it catches errors, keeps
   its heartbeat fresh (so CARP does not falsely demote the node) and retries.
 

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -136,7 +136,7 @@ OPNsense CARP answers ARP + egresses data as usual. The VIP becomes failover-cap
   taken from DHCP option 3 (fallback: the DHCP server address). Set 0 to disable.
   **Becoming master** (failover, or a link flap re-electing CARP) triggers an immediate nudge *and* an
   early lease RENEW — upstream ARP and DHCP-snooping state may just have been disturbed, so neither
-  waits for its normal timer. A **manual nudge** is available for troubleshooting: the ⚡ button on the
+  waits for its normal timer (the early renew applies even with the nudge disabled). A **manual nudge** is available for troubleshooting: the ⚡ button on the
   status page (shown on the CARP master), or `kill -USR1` on the keeper daemon — it fires within a
   second and shows up in the log.
 - **Self-healing:** the daemon never exits on a transient DHCP/interface fault — it catches errors, keeps

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -179,9 +179,33 @@ keeper follows. (The CARP VIP itself is intentionally *not* synced, because `adv
 The keeper *configuration* itself can optionally be synced too: tick **CARP-VIP DHCP lease keepers**
 under System → High Availability → Settings (off by default) to replicate it to the backup.
 
+## Playing nicely with ISP access-network security
+
+Carrier access equipment (BNG / access switches / OLTs) polices subscribers with a family of
+mechanisms that all key off the DHCP exchange. The plugin's strategy — a real DHCP lease held on the
+CARP virtual MAC, plus an ARP nudge that repeats exactly that binding — is designed to satisfy each
+of them:
+
+| ISP mechanism | What it does | How the plugin cooperates |
+|---|---|---|
+| **DHCP snooping** | builds the trusted IP↔MAC binding table from DHCP exchanges seen on the subscriber port | the lease is acquired and renewed *through the subscriber port* with `chaddr` = CARP MAC, so the binding matches what CARP presents on the wire |
+| **Dynamic ARP Inspection (DAI)** | drops ARP whose sender (IP, MAC) does not match the snooped binding | the nudge's sender is (leased IP, `chaddr`) — exactly the snooped binding, so it passes inspection |
+| **Gratuitous-ARP filtering** | ignores unsolicited ARP announcements (ARP-spoofing defence) — CARP's own gratuitous ARP on failover is silently dropped | the nudge is a normal ARP **request**, which the gateway must process in order to answer; that is the one ARP path such gear reliably learns from |
+| **No re-ARP on expiry** ("secured ARP") | the gateway never broadcasts who-has for a subscriber address; an expired entry silently blackholes all downstream traffic | the periodic nudge (default 240 s, well under typical 15–20 min ARP timeouts) keeps the entry permanently fresh; becoming CARP master triggers an immediate nudge so a failover or link flap never waits out the interval |
+| **IP Source Guard (IP-only)** | drops upstream packets whose source IP is not in the binding table | the leased VIP *is* in the table — fine |
+| **IP Source Guard (strict IP+MAC)** | additionally requires the source *MAC* to match the binding | ⚠ **known limitation**: FreeBSD egresses data from a CARP VIP with the interface's *physical* MAC, not the CARP MAC. Under strict IPSG, outbound VIP traffic is dropped even though the lease and ARP are healthy. Symptom: the gateway answers ARP/pings *to* the VIP, but anything *sourced from* it never gets a reply, fresh nudge or not. There is no clean per-packet fix; the workaround is spoofing the interface MAC to equal the lease MAC (see the single-IP scenario doc) |
+| **Client identity checks** | the server only leases to a known vendor-class (opt 60), client-id (61) or hostname (12) | per-keeper DHCP request options (advanced fields) |
+| **Per-subscriber MAC / session limits** | the port accepts a limited number of source MACs or DHCP sessions | mind the budget: each node's own MAC plus the CARP MAC all appear on the ISP-facing segment. With a strict one-IP/one-MAC ISP, see [docs/single-ip-wan-carp.md](docs/single-ip-wan-carp.md) |
+
+Failover interplay: because the ISP binds the lease to the CARP **virtual** MAC, a CARP failover does
+not invalidate anything upstream — the same MAC simply starts answering from the new master (CARP's
+advertisements re-teach the switch fabric within a second, and the new master sends an immediate
+ARP nudge). This is the core reason the lease lives on the CARP MAC rather than either node's own.
+
 ## Scope / caveats
 
-- **IPv4 DHCP only** (DHCPv6 out of scope for now).
+- **IPv4 DHCP only** (DHCPv6/ND out of scope for now — the ARP nudge has no IPv6 equivalent here
+  either; IPv6 neighbor discovery is a separate mechanism).
 - WAN is the typical — but not required — placement.
 - You must own the MAC/reservation you keep a lease for; holding a foreign lease is an ISP violation.
 - Requires **root** (raw L2/BPF socket) and depends on **Scapy**.

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -7,7 +7,7 @@
 # rc(8) wrapper for the CARP-VIP DHCP lease keepers (lease-keeper.py).
 # Reads /usr/local/etc/carpvipdhcp/keeper.conf (rendered by the configd template):
 # one line per enabled keeper ->
-#   REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|RUN_ONLY_ON_MASTER|FOLLOW_IP.
+#   REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|RUN_ONLY_ON_MASTER|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE.
 # Starts one supervised daemon per line, keyed by a filesystem-safe request-IP id.
 
 . /etc/rc.subr
@@ -35,7 +35,7 @@ carpvipdhcp_start()
 {
     [ -f "${conf}" ] || { echo "no config"; return 0; }
     count=0
-    while IFS='|' read -r request iface chaddr demote vhid runmaster follow vendorclass clientid hostname || [ -n "${request}" ]; do
+    while IFS='|' read -r request iface chaddr demote vhid runmaster follow vendorclass clientid hostname arpnudge || [ -n "${request}" ]; do
         [ -n "${request}" ] || continue
         case "${request}" in \#*) continue ;; esac
         if [ -z "${iface}" ] || [ -z "${chaddr}" ]; then
@@ -50,10 +50,13 @@ carpvipdhcp_start()
             --pidfile "${run_dir}/carpvipdhcp-${id}.child.pid" \
             --hbfile "${run_dir}/carpvipdhcp-${id}.hb" \
             --logfile "${log_dir}/carpvipdhcp-${id}.log"
+        # Always pass the vhid: the daemon needs it to gate the ARP nudge to the
+        # CARP master even when run-only-on-master (DHCP gating) is off.
+        [ -n "${vhid}" ] && set -- "$@" --vhid "${vhid}"
         # Run-only-on-master keepers self-gate: the daemon runs on both nodes but
         # only sends DHCP while this node is CARP master for the vhid (else stands by).
         if [ "${runmaster}" = "1" ]; then
-            set -- "$@" --vhid "${vhid}" --only-when-master
+            set -- "$@" --only-when-master
         fi
         # Follow mode: accept a changed ISP address and rewrite the CARP VIP to match.
         if [ "${follow}" = "1" ]; then
@@ -63,6 +66,10 @@ carpvipdhcp_start()
         [ -n "${vendorclass}" ] && set -- "$@" --vendor-class "${vendorclass}"
         [ -n "${clientid}" ] && set -- "$@" --client-id "${clientid}"
         [ -n "${hostname}" ] && set -- "$@" --hostname "${hostname}"
+        # ARP nudge: keep the upstream gateway's ARP entry for the VIP fresh (0/empty = off).
+        if [ -n "${arpnudge}" ] && [ "${arpnudge}" != "0" ]; then
+            set -- "$@" --arp-nudge "${arpnudge}"
+        fi
         # -f detach; -r supervise/restart on crash; -R 5 restart delay; -P supervisor pidfile.
         /usr/sbin/daemon -f -r -R 5 -P "${pidfile}" -t "${name}-${id}" "${keeper}" "$@"
         count=$((count + 1))

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -50,8 +50,8 @@ carpvipdhcp_start()
             --pidfile "${run_dir}/carpvipdhcp-${id}.child.pid" \
             --hbfile "${run_dir}/carpvipdhcp-${id}.hb" \
             --logfile "${log_dir}/carpvipdhcp-${id}.log"
-        # Always pass the vhid: the daemon needs it to gate the ARP nudge to the
-        # CARP master even when run-only-on-master (DHCP gating) is off.
+        # The vhid identifies the keeper's CARP VIP; individual daemon features
+        # (DHCP gating, the ARP-nudge master check) decide whether to gate on it.
         [ -n "${vhid}" ] && set -- "$@" --vhid "${vhid}"
         # Run-only-on-master keepers self-gate: the daemon runs on both nodes but
         # only sends DHCP while this node is CARP master for the vhid (else stands by).
@@ -66,10 +66,7 @@ carpvipdhcp_start()
         [ -n "${vendorclass}" ] && set -- "$@" --vendor-class "${vendorclass}"
         [ -n "${clientid}" ] && set -- "$@" --client-id "${clientid}"
         [ -n "${hostname}" ] && set -- "$@" --hostname "${hostname}"
-        # ARP nudge: keep the upstream gateway's ARP entry for the VIP fresh (0/empty = off).
-        if [ -n "${arpnudge}" ] && [ "${arpnudge}" != "0" ]; then
-            set -- "$@" --arp-nudge "${arpnudge}"
-        fi
+        [ -n "${arpnudge}" ] && set -- "$@" --arp-nudge "${arpnudge}"
         # -f detach; -r supervise/restart on crash; -R 5 restart delay; -P supervisor pidfile.
         /usr/sbin/daemon -f -r -R 5 -P "${pidfile}" -t "${name}-${id}" "${keeper}" "$@"
         count=$((count + 1))

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/Api/DiagnosticsController.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/Api/DiagnosticsController.php
@@ -76,9 +76,10 @@ class DiagnosticsController extends ApiControllerBase
         if (!$this->request->isPost()) {
             return ['status' => 'failed'];
         }
-        // Constrain to an address shape before handing it to configd; the shell
-        // script re-sanitizes to [A-Za-z0-9_] as a second line of defence.
-        if (!preg_match('/^[0-9A-Fa-f:.]{1,45}$/', (string)$id)) {
+        // Keeper ids are IPv4 request addresses (same validation as the model
+        // and follow_update.php); the shell script re-sanitizes to [A-Za-z0-9_]
+        // as a second line of defence.
+        if (filter_var((string)$id, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
             return ['status' => 'invalid'];
         }
         $raw = trim((string)(new Backend())->configdpRun('carpvipdhcp nudge', [$id]));

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/Api/DiagnosticsController.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/Api/DiagnosticsController.php
@@ -63,4 +63,26 @@ class DiagnosticsController extends ApiControllerBase
         (new Backend())->configdRun('carpvipdhcp clear_log');
         return ['status' => 'ok'];
     }
+
+    /**
+     * Ask a keeper to send an immediate ARP nudge (POST-only, state-changing).
+     * Useful when troubleshooting a suspected stale gateway ARP entry: the
+     * daemon fires within a second and the result shows up in the log page.
+     * @param string $id the keeper's request address (IPv4)
+     * @return array
+     */
+    public function nudgeAction($id = '')
+    {
+        if (!$this->request->isPost()) {
+            return ['status' => 'failed'];
+        }
+        // Constrain to an address shape before handing it to configd; the shell
+        // script re-sanitizes to [A-Za-z0-9_] as a second line of defence.
+        if (!preg_match('/^[0-9A-Fa-f:.]{1,45}$/', (string)$id)) {
+            return ['status' => 'invalid'];
+        }
+        $raw = trim((string)(new Backend())->configdpRun('carpvipdhcp nudge', [$id]));
+        $data = json_decode($raw, true);
+        return is_array($data) ? $data : ['status' => 'failed'];
+    }
 }

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
@@ -42,7 +42,7 @@
         <label>ARP nudge interval (s)</label>
         <type>text</type>
         <advanced>true</advanced>
-        <help><![CDATA[Periodically broadcast an ARP request from the VIP (with its CARP MAC) for the upstream gateway, so the gateway's ARP entry for the VIP never expires. Use when the upstream ignores gratuitous ARP and never re-ARPs an expired entry — the symptom is that traffic NATed to the VIP works right after a CARP event or DHCP exchange, then silently blackholes some minutes later (outbound packets leave, nothing returns). Suggested: 240. Only sent while this node is CARP master for the VIP. 0 = off.]]></help>
+        <help><![CDATA[Periodically broadcast an ARP request from the VIP (with its CARP MAC) for the upstream gateway, so the gateway's ARP entry for the VIP never expires. Use when the upstream ignores gratuitous ARP and never re-ARPs an expired entry — the symptom is that traffic NATed to the VIP works right after a CARP event or DHCP exchange, then silently blackholes some minutes later (outbound packets leave, nothing returns). Only sent while this node is CARP master for the VIP. Default: 240 (on) — one broadcast ARP per interval, harmless on gateways that behave normally. Set 0 to disable.]]></help>
     </field>
     <field>
         <id>keeper.chaddrOverride</id>

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
@@ -38,6 +38,13 @@
         <help><![CDATA[Optional. The plugin creates and maintains a firewall Host alias with this name, always set to this CARP VIP's current address. Point your outbound NAT translation address (and any firewall rules that must follow the address) at this alias, so they follow automatically when "Follow dynamic DHCP address" changes it (applied by a state-preserving filter reload). NOTE: inbound port-forwards cannot follow a dynamic address (the upstream only routes inbound to a reserved address). The plugin never deletes the alias. See the plugin README.]]></help>
     </field>
     <field>
+        <id>keeper.arpNudgeInterval</id>
+        <label>ARP nudge interval (s)</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help><![CDATA[Periodically broadcast an ARP request from the VIP (with its CARP MAC) for the upstream gateway, so the gateway's ARP entry for the VIP never expires. Use when the upstream ignores gratuitous ARP and never re-ARPs an expired entry — the symptom is that traffic NATed to the VIP works right after a CARP event or DHCP exchange, then silently blackholes some minutes later (outbound packets leave, nothing returns). Suggested: 240. Only sent while this node is CARP master for the VIP. 0 = off.]]></help>
+    </field>
+    <field>
         <id>keeper.chaddrOverride</id>
         <label>chaddr override</label>
         <type>text</type>

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
@@ -58,7 +58,7 @@
                     gateways that ignore gratuitous ARP and never re-ARP an expired
                     entry (traffic to the VIP silently blackholes when it expires).
                     Only sent while this node is CARP master for the VIP. On by
-                    default (240 s) -- one broadcast ARP per interval is negligible
+                    default (240 s): one broadcast ARP per interval is negligible
                     next to CARP's one advertisement per second, and the failure it
                     prevents is silent. 0 = off.
                 -->

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/CarpVipDhcp</mount>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <description>CARP-VIP DHCP lease keeper</description>
     <items>
         <keepers>
@@ -51,6 +51,21 @@
                     <ValidationMessage>Alias name must start with a letter and contain only letters, digits and underscore (max 31).</ValidationMessage>
                     <Required>N</Required>
                 </aliasName>
+
+                <!--
+                    Periodically broadcast an ARP request from (VIP, chaddr) for the
+                    upstream gateway, refreshing its ARP entry for the VIP. Needed for
+                    gateways that ignore gratuitous ARP and never re-ARP an expired
+                    entry (traffic to the VIP silently blackholes when it expires).
+                    Only sent while this node is CARP master for the VIP. 0 = off.
+                -->
+                <arpNudgeInterval type="IntegerField">
+                    <Default>0</Default>
+                    <MinimumValue>0</MinimumValue>
+                    <MaximumValue>3600</MaximumValue>
+                    <ValidationMessage>ARP nudge interval must be 0 (off) or 30-3600 seconds.</ValidationMessage>
+                    <Required>N</Required>
+                </arpNudgeInterval>
 
                 <!--
                     Optional DHCP request options for ISPs that only lease when they

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
@@ -57,10 +57,13 @@
                     upstream gateway, refreshing its ARP entry for the VIP. Needed for
                     gateways that ignore gratuitous ARP and never re-ARP an expired
                     entry (traffic to the VIP silently blackholes when it expires).
-                    Only sent while this node is CARP master for the VIP. 0 = off.
+                    Only sent while this node is CARP master for the VIP. On by
+                    default (240 s) -- one broadcast ARP per interval is negligible
+                    next to CARP's one advertisement per second, and the failure it
+                    prevents is silent. 0 = off.
                 -->
                 <arpNudgeInterval type="IntegerField">
-                    <Default>0</Default>
+                    <Default>240</Default>
                     <MinimumValue>0</MinimumValue>
                     <MaximumValue>3600</MaximumValue>
                     <ValidationMessage>ARP nudge interval must be 0 (off) or 30-3600 seconds.</ValidationMessage>

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
@@ -53,14 +53,11 @@
                 </aliasName>
 
                 <!--
-                    Periodically broadcast an ARP request from (VIP, chaddr) for the
-                    upstream gateway, refreshing its ARP entry for the VIP. Needed for
-                    gateways that ignore gratuitous ARP and never re-ARP an expired
-                    entry (traffic to the VIP silently blackholes when it expires).
-                    Only sent while this node is CARP master for the VIP. On by
-                    default (240 s): one broadcast ARP per interval is negligible
-                    next to CARP's one advertisement per second, and the failure it
-                    prevents is silent. 0 = off.
+                    Interval for broadcasting an ARP request from (VIP, chaddr) for
+                    the upstream gateway, keeping its ARP entry for the VIP fresh.
+                    Needed when the gateway ignores gratuitous ARP and never re-ARPs
+                    an expired entry; see the README's "ARP nudge" section. Only
+                    sent while CARP master. 0 = off.
                 -->
                 <arpNudgeInterval type="IntegerField">
                     <Default>240</Default>

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
@@ -99,7 +99,7 @@
         let tip = "{{ lang._('every') }}" + ' ' + k.arp_nudge + ' s'
             + (k.gw ? ' → ' + k.gw : ' (' + "{{ lang._('gateway unknown') }}" + ')');
         let cell;
-        if (k.nudge_age === null || k.nudge_age === undefined) {
+        if (k.nudge_age == null) {
             // Enabled but never sent: expected on a CARP backup, suspicious on a
             // bound master (no gateway known, or the daemon predates the setting).
             let style = (k.carp_state === 'MASTER' && k.bound) ? 'label-warning' : 'label-default';

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
@@ -98,14 +98,22 @@
         }
         let tip = "{{ lang._('every') }}" + ' ' + k.arp_nudge + ' s'
             + (k.gw ? ' → ' + k.gw : ' (' + "{{ lang._('gateway unknown') }}" + ')');
+        let cell;
         if (k.nudge_age === null || k.nudge_age === undefined) {
             // Enabled but never sent: expected on a CARP backup, suspicious on a
             // bound master (no gateway known, or the daemon predates the setting).
             let style = (k.carp_state === 'MASTER' && k.bound) ? 'label-warning' : 'label-default';
-            return '<span class="label ' + style + '" title="' + tip + '">'
+            cell = '<span class="label ' + style + '" title="' + tip + '">'
                 + "{{ lang._('never') }}" + '</span>';
+        } else {
+            cell = '<span title="' + tip + '">' + fmtAge(k.nudge_age) + '</span>';
         }
-        return '<span title="' + tip + '">' + fmtAge(k.nudge_age) + '</span>';
+        if (k.running === true && k.carp_state === 'MASTER') {
+            cell += ' <button class="btn btn-xs btn-default nudge_now" data-id="' + k.request
+                + '" title="' + "{{ lang._('Send an ARP nudge now') }}" + '">'
+                + '<i class="fa fa-bolt fa-fw"></i></button>';
+        }
+        return cell;
     }
 
     function refreshStatus() {
@@ -140,6 +148,17 @@
             $('#keeper_rows').html(rows);
         });
     }
+
+    $(document).on('click', '.nudge_now', function () {
+        let btn = $(this);
+        btn.prop('disabled', true);
+        ajaxCall('/api/carpvipdhcp/diagnostics/nudge/' + btn.data('id'), {}, function () {
+            // The nudge age refreshes on the next heartbeat write (<= 30 s);
+            // poll a little sooner for quicker feedback.
+            setTimeout(refreshStatus, 2000);
+            btn.prop('disabled', false);
+        });
+    });
 
     $(document).ready(function () {
         updateServiceControlUI('carpvipdhcp');

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
@@ -92,6 +92,22 @@
         return txt;
     }
 
+    function nudgeCell(k) {
+        if (!k.arp_nudge) {
+            return '<span class="text-muted">' + "{{ lang._('off') }}" + '</span>';
+        }
+        let tip = "{{ lang._('every') }}" + ' ' + k.arp_nudge + ' s'
+            + (k.gw ? ' → ' + k.gw : ' (' + "{{ lang._('gateway unknown') }}" + ')');
+        if (k.nudge_age === null || k.nudge_age === undefined) {
+            // Enabled but never sent: expected on a CARP backup, suspicious on a
+            // bound master (no gateway known, or the daemon predates the setting).
+            let style = (k.carp_state === 'MASTER' && k.bound) ? 'label-warning' : 'label-default';
+            return '<span class="label ' + style + '" title="' + tip + '">'
+                + "{{ lang._('never') }}" + '</span>';
+        }
+        return '<span title="' + tip + '">' + fmtAge(k.nudge_age) + '</span>';
+    }
+
     function refreshStatus() {
         ajaxGet('/api/carpvipdhcp/diagnostics/status', {}, function (data) {
             if (data === undefined) {
@@ -104,7 +120,7 @@
             let keepers = data.keepers || [];
             let rows = '';
             if (keepers.length === 0) {
-                rows = '<tr><td colspan="9" class="text-muted">'
+                rows = '<tr><td colspan="10" class="text-muted">'
                     + "{{ lang._('No keepers configured.') }}" + '</td></tr>';
             }
             keepers.forEach(function (k) {
@@ -117,6 +133,7 @@
                     + '<td>' + leaseCell(k) + '</td>'
                     + '<td>' + fmtAge(k.hb_age) + '</td>'
                     + '<td>' + leaseTimeCell(k) + '</td>'
+                    + '<td>' + nudgeCell(k) + '</td>'
                     + '<td>' + dash(k.chaddr) + '</td>'
                     + '</tr>';
             });
@@ -144,6 +161,7 @@
                     <th>{{ lang._('Lease') }}</th>
                     <th>{{ lang._('Heartbeat age') }}</th>
                     <th>{{ lang._('Lease time') }}</th>
+                    <th>{{ lang._('ARP nudge') }}</th>
                     <th>{{ lang._('Lease MAC') }}</th>
                 </tr>
             </thead>

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -146,7 +146,8 @@ class Keeper:
         self.arp_nudge = max(ARP_NUDGE_MIN, arp_nudge) if arp_nudge else 0
         self.router = None             # default gateway (DHCP opt 3, fallback: server_id)
         self._last_nudge = 0.0
-        self._nudge_logged = False
+        self._nudge_gw = None          # last nudge target we logged (log again on change)
+        self._nudge_warned = False     # warned once about a missing nudge target
         # Optional DHCP request options (empty -> not sent); built once and added to
         # every DISCOVER/REQUEST/RENEW so the server sees a consistent client identity.
         self._id_opts = []
@@ -391,8 +392,16 @@ class Keeper:
 
     def _hb(self):
         t1, t2, src = self._timing()
-        self._write_hb("%d bound=%s lease=%d t1=%d t2=%d src=%s\n"
-                       % (int(time.time()), self.yiaddr or "-", self.lease, t1, t2, src))
+        # Publish nudge state so the status page can show it: nudge=<epoch of the
+        # last sent nudge, 0 = never> and the current target gateway (if known).
+        extra = ""
+        if self.arp_nudge:
+            extra = " nudge=%d" % int(self._last_nudge)
+            gw = self.router or self.server
+            if gw:
+                extra += " gw=%s" % gw
+        self._write_hb("%d bound=%s lease=%d t1=%d t2=%d src=%s%s\n"
+                       % (int(time.time()), self.yiaddr or "-", self.lease, t1, t2, src, extra))
 
     def _hb_mismatch(self, got):
         # Write a clear marker into the heartbeat file so a supervisor/human sees the mismatch.
@@ -550,7 +559,15 @@ class Keeper:
         if not force and time.time() - self._last_nudge < self.arp_nudge:
             return
         gw = self.router or self.server
-        if not gw or not self._carp_master_now():
+        if not gw:
+            # Enabled but no target: without this warning the nudge would be a
+            # silent no-op and the operator would believe they are protected.
+            if not self._nudge_warned:
+                LOG.warning("ARP nudge enabled but no gateway known "
+                            "(no DHCP router option or server-id) -- cannot nudge")
+                self._nudge_warned = True
+            return
+        if not self._carp_master_now():
             return
         try:
             sendp(Ether(src=self.chaddr, dst="ff:ff:ff:ff:ff:ff") /
@@ -558,10 +575,10 @@ class Keeper:
                       hwdst="00:00:00:00:00:00", pdst=gw),
                   iface=self.iface, verbose=0)
             self._last_nudge = time.time()
-            if not self._nudge_logged:
+            if gw != self._nudge_gw:
                 LOG.info("ARP nudge active: who-has %s tell %s (src %s) every %ds",
                          gw, self.yiaddr, self.chaddr, self.arp_nudge)
-                self._nudge_logged = True
+                self._nudge_gw = gw
         except Exception as e:
             LOG.warning("ARP nudge failed: %s", e)
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -5,7 +5,11 @@ Keeps a DHCP lease alive for a given ``chaddr`` WITHOUT binding it to the
 interface's hardware MAC, so the leased address (typically a CARP virtual IP)
 stays routed by the ISP. The broadcast flag is set so OFFER/ACK are broadcast.
 This does lease maintenance ONLY; ARP for the address and data traffic are
-handled by CARP. By default it is ungated and runs on both HA nodes for
+handled by CARP. Optionally (--arp-nudge) it also refreshes the upstream
+gateway's ARP entry for the leased address, for gateways that ignore
+gratuitous ARP and never re-ARP an expired entry (traffic to the address
+silently blackholes until the gateway receives an ARP *request* from it).
+By default it is ungated and runs on both HA nodes for
 redundancy; opt-in run-only-on-master gating restricts it to the CARP master.
 
 Robustness:
@@ -36,7 +40,7 @@ import time
 from collections import namedtuple
 from logging.handlers import RotatingFileHandler
 
-from scapy.all import Ether, IP, UDP, BOOTP, DHCP, AsyncSniffer, sendp
+from scapy.all import ARP, Ether, IP, UDP, BOOTP, DHCP, AsyncSniffer, sendp
 
 LOG = logging.getLogger("lease-keeper")
 
@@ -66,11 +70,13 @@ T2_FACTOR = 0.875          # rebind by this fraction of the lease (RFC default)
 MIN_T1 = 30                # floor for the renew timer (very short leases)
 REBIND_MARGIN = 15         # ensure T2 is at least this far past T1
 BROADCAST_FLAG = 0x8000    # BOOTP flags: ask the server to broadcast OFFER/ACK
+ARP_NUDGE_MIN = 30         # floor for --arp-nudge so a typo cannot flood the segment
 LOG_MAX_BYTES = 512 * 1024
 LOG_BACKUPS = 3
 
 # A parsed DHCP reply, snapshotted from the sniffer thread.
-DhcpReply = namedtuple("DhcpReply", "mtype yiaddr server_id lease t1 t2")
+DhcpReply = namedtuple("DhcpReply", "mtype yiaddr server_id lease t1 t2 router",
+                       defaults=(None,))
 MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
 
 
@@ -119,7 +125,8 @@ def mac2raw(m):
 class Keeper:
     def __init__(self, iface, chaddr, request_ip=None, eth_src=None,
                  hbfile=None, release_on_exit=False, only_when_master=False, vhid=None,
-                 follow=False, vendor_class=None, client_id=None, hostname=None):
+                 follow=False, vendor_class=None, client_id=None, hostname=None,
+                 arp_nudge=0):
         self.iface = iface
         self.chaddr = chaddr.lower()
         self.chraw = mac2raw(chaddr)
@@ -130,6 +137,16 @@ class Keeper:
         self.only_when_master = only_when_master
         self.vhid = str(vhid) if vhid else None
         self.follow = follow
+        # ARP nudge: some ISP gateways ignore gratuitous ARP and never re-ARP an
+        # expired entry for the leased address (observed in the field: replies
+        # silently blackhole ~20 min after the last cache update), but they DO
+        # refresh the cache from a received ARP *request*. When enabled,
+        # periodically broadcast an ARP request from (leased IP, chaddr) for the
+        # gateway so its entry never expires.
+        self.arp_nudge = max(ARP_NUDGE_MIN, arp_nudge) if arp_nudge else 0
+        self.router = None             # default gateway (DHCP opt 3, fallback: server_id)
+        self._last_nudge = 0.0
+        self._nudge_logged = False
         # Optional DHCP request options (empty -> not sent); built once and added to
         # every DISCOVER/REQUEST/RENEW so the server sees a consistent client identity.
         self._id_opts = []
@@ -193,7 +210,7 @@ class Keeper:
             b = p[BOOTP]
             if b.xid != self.xid or b.op != BOOTREPLY:
                 return
-            mt = sid = lt = rt = bt = None
+            mt = sid = lt = rt = bt = ro = None
             for o in p[DHCP].options:
                 if isinstance(o, tuple):
                     if o[0] == "message-type":
@@ -206,7 +223,9 @@ class Keeper:
                         rt = o[1]
                     elif o[0] == "rebinding_time":
                         bt = o[1]
-            self._rx = DhcpReply(mt, b.yiaddr, sid, lt, rt, bt)
+                    elif o[0] == "router":
+                        ro = o[1]
+            self._rx = DhcpReply(mt, b.yiaddr, sid, lt, rt, bt, ro)
             self._ev.set()
         except Exception as e:
             LOG.debug("rx parse error: %s", e)
@@ -287,6 +306,7 @@ class Keeper:
                 self.yiaddr = got
                 self.lease = rx.lease or DEFAULT_LEASE
                 self.t1_server, self.t2_server = rx.t1, rx.t2
+                self.router = rx.router or self.router
                 return True
             time.sleep(min(2 * attempt, ATTEMPT_BACKOFF_CAP))
         return False
@@ -319,6 +339,7 @@ class Keeper:
                     return self._handle_changed_address(got, rx, phase, release_on_enforce=False)
                 self.lease = rx.lease or self.lease
                 self.t1_server, self.t2_server = rx.t1, rx.t2
+                self.router = rx.router or self.router
                 return True
         return False
 
@@ -431,6 +452,7 @@ class Keeper:
             self.yiaddr, self.server = got, rx.server_id or self.server
             self.lease = rx.lease or DEFAULT_LEASE
             self.t1_server, self.t2_server = rx.t1, rx.t2
+            self.router = rx.router or self.router
             return True
         # Enforce: a fixed reservation must always return request_ip.
         LOG.error("%s: IP mismatch -- ISP gave %s, requested %s (reservation problem?)",
@@ -502,6 +524,47 @@ class Keeper:
             pass
         return self._last_master
 
+    def _carp_master_now(self):
+        """True if this node currently holds CARP MASTER for our vhid (or no vhid
+        is configured). Unlike _is_master() this ignores the run-only-on-master
+        gating flag: it protects the ARP nudge, which must NEVER be sent from a
+        CARP backup (a nudge steers the switch/gateway toward this node's port).
+        Fails CLOSED: a skipped nudge is retried next interval, a wrong one
+        steals the VIP's traffic."""
+        if not self.vhid:
+            return True
+        try:
+            out = subprocess.check_output(["/sbin/ifconfig", self.iface], errors="replace")
+            if isinstance(out, bytes):
+                out = out.decode(errors="replace")
+            return ("carp: MASTER vhid %s " % self.vhid) in out
+        except (OSError, subprocess.SubprocessError):
+            return False
+
+    def _arp_nudge(self, force=False):
+        """Refresh the upstream gateway's ARP entry for the leased address by
+        broadcasting an ARP request from (yiaddr, chaddr). No-op unless enabled,
+        bound, due (or forced) and CARP master (see _carp_master_now)."""
+        if not self.arp_nudge or not self.yiaddr:
+            return
+        if not force and time.time() - self._last_nudge < self.arp_nudge:
+            return
+        gw = self.router or self.server
+        if not gw or not self._carp_master_now():
+            return
+        try:
+            sendp(Ether(src=self.chaddr, dst="ff:ff:ff:ff:ff:ff") /
+                  ARP(op=1, hwsrc=self.chaddr, psrc=self.yiaddr,
+                      hwdst="00:00:00:00:00:00", pdst=gw),
+                  iface=self.iface, verbose=0)
+            self._last_nudge = time.time()
+            if not self._nudge_logged:
+                LOG.info("ARP nudge active: who-has %s tell %s (src %s) every %ds",
+                         gw, self.yiaddr, self.chaddr, self.arp_nudge)
+                self._nudge_logged = True
+        except Exception as e:
+            LOG.warning("ARP nudge failed: %s", e)
+
     def _sleep(self, secs):
         slept = 0
         while slept < secs and not self.stop:
@@ -533,6 +596,7 @@ class Keeper:
             remaining -= chunk
             self._hb()
             self._follow_watchdog()   # re-drive a follow whose apply stalled
+            self._arp_nudge()         # keep the gateway's ARP entry for the VIP fresh
         return not self.stop
 
     def run(self):
@@ -595,6 +659,7 @@ class Keeper:
             if self.dora():
                 LOG.info("BOUND %s (lease=%ss, server=%s)", self.yiaddr, self.lease, self.server)
                 self._hb()
+                self._arp_nudge(force=True)
                 self.redora_wait = REDORA_MIN
             else:
                 LOG.warning("acquire failed -- waiting %ds", self.redora_wait)
@@ -610,6 +675,7 @@ class Keeper:
         if self.renew():
             LOG.info("RENEW ok %s (lease=%ss)", self.yiaddr, self.lease)
             self._hb()
+            self._arp_nudge(force=True)
             return
         LOG.warning("RENEW failed at T1 -- trying REBIND until T2")
         elapsed = t1
@@ -626,6 +692,7 @@ class Keeper:
         if ok:
             LOG.info("REBIND ok %s", self.yiaddr)
             self._hb()
+            self._arp_nudge(force=True)
             return
         if self.only_when_master and not self._is_master():
             return  # lost master -> top of loop releases and stands by
@@ -675,6 +742,10 @@ def main():
     ap.add_argument("--vendor-class", default=None)
     ap.add_argument("--client-id", default=None)
     ap.add_argument("--hostname", default=None)
+    ap.add_argument("--arp-nudge", type=int, default=0, metavar="SECS",
+                    help="periodically broadcast an ARP request from the leased IP "
+                         "for the gateway, so upstream gear that never re-ARPs keeps "
+                         "a fresh entry (0 = off, suggested 240)")
     ap.add_argument("--once", action="store_true")
     ap.add_argument("--release-on-exit", action="store_true")
     a = ap.parse_args()
@@ -696,7 +767,8 @@ def main():
     k = Keeper(a.iface, a.chaddr, a.request, a.eth_src,
                hbfile=a.hbfile, release_on_exit=a.release_on_exit or a.once,
                only_when_master=a.only_when_master, vhid=a.vhid, follow=a.follow,
-               vendor_class=a.vendor_class, client_id=a.client_id, hostname=a.hostname)
+               vendor_class=a.vendor_class, client_id=a.client_id, hostname=a.hostname,
+               arp_nudge=a.arp_nudge)
 
     def _sig(*_):
         LOG.info("signal received -- stopping")

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -148,6 +148,7 @@ class Keeper:
         self._last_nudge = 0.0
         self._nudge_gw = None          # last nudge target we logged (log again on change)
         self._nudge_warned = False     # warned once about a missing nudge target
+        self._was_master = None        # CARP role at the last nudge check (None = unknown yet)
         # Optional DHCP request options (empty -> not sent); built once and added to
         # every DISCOVER/REQUEST/RENEW so the server sees a consistent client identity.
         self._id_opts = []
@@ -553,9 +554,18 @@ class Keeper:
     def _arp_nudge(self, force=False):
         """Refresh the upstream gateway's ARP entry for the leased address by
         broadcasting an ARP request from (yiaddr, chaddr). No-op unless enabled,
-        bound, due (or forced) and CARP master (see _carp_master_now)."""
+        bound, due (or forced) and CARP master (see _carp_master_now). Becoming
+        master forces an immediate nudge: a failover (or a link flap, which
+        re-elects CARP) must not wait out the interval clock while upstream
+        state may just have been disturbed."""
         if not self.arp_nudge or not self.yiaddr:
             return
+        master = self._carp_master_now()
+        if master and self._was_master is False:
+            LOG.info("became CARP master for vhid %s -- sending an immediate ARP nudge",
+                     self.vhid or "-")
+            force = True
+        self._was_master = master
         if not force and time.time() - self._last_nudge < self.arp_nudge:
             return
         gw = self.router or self.server
@@ -567,7 +577,7 @@ class Keeper:
                             "(no DHCP router option or server-id) -- cannot nudge")
                 self._nudge_warned = True
             return
-        if not self._carp_master_now():
+        if not master:
             return
         try:
             sendp(Ether(src=self.chaddr, dst="ff:ff:ff:ff:ff:ff") /

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -75,8 +75,7 @@ LOG_MAX_BYTES = 512 * 1024
 LOG_BACKUPS = 3
 
 # A parsed DHCP reply, snapshotted from the sniffer thread.
-DhcpReply = namedtuple("DhcpReply", "mtype yiaddr server_id lease t1 t2 router",
-                       defaults=(None,))
+DhcpReply = namedtuple("DhcpReply", "mtype yiaddr server_id lease t1 t2 router")
 MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
 
 
@@ -137,12 +136,9 @@ class Keeper:
         self.only_when_master = only_when_master
         self.vhid = str(vhid) if vhid else None
         self.follow = follow
-        # ARP nudge: some ISP gateways ignore gratuitous ARP and never re-ARP an
-        # expired entry for the leased address (observed in the field: replies
-        # silently blackhole ~20 min after the last cache update), but they DO
-        # refresh the cache from a received ARP *request*. When enabled,
-        # periodically broadcast an ARP request from (leased IP, chaddr) for the
-        # gateway so its entry never expires.
+        # ARP nudge: keep the upstream gateway's ARP entry for the leased address
+        # fresh, for gateways that ignore gratuitous ARP and never re-ARP an
+        # expired entry (see the README's "ARP nudge" section for the full story).
         self.arp_nudge = max(ARP_NUDGE_MIN, arp_nudge) if arp_nudge else 0
         self.router = None             # default gateway (DHCP opt 3, fallback: server_id)
         self._last_nudge = 0.0
@@ -261,6 +257,13 @@ class Keeper:
                 return "NAK"
         return None
 
+    def _absorb_reply(self, rx, default_lease):
+        """Adopt lease timing and gateway (DHCP option 3) from an ACK -- the one
+        place that knows which DhcpReply fields carry keeper state."""
+        self.lease = rx.lease or default_lease
+        self.t1_server, self.t2_server = rx.t1, rx.t2
+        self.router = rx.router or self.router
+
     def dora(self):
         self.xid = random.randint(1, 0xFFFFFFFF)
         extra = [("requested_addr", self.request_ip)] if self.request_ip else []
@@ -308,9 +311,7 @@ class Keeper:
                 if self.request_ip and got != self.request_ip:
                     return self._handle_changed_address(got, rx, "DORA", release_on_enforce=True)
                 self.yiaddr = got
-                self.lease = rx.lease or DEFAULT_LEASE
-                self.t1_server, self.t2_server = rx.t1, rx.t2
-                self.router = rx.router or self.router
+                self._absorb_reply(rx, DEFAULT_LEASE)
                 return True
             time.sleep(min(2 * attempt, ATTEMPT_BACKOFF_CAP))
         return False
@@ -341,9 +342,7 @@ class Keeper:
                     # follow / enforce decision (and hardening) as the initial DORA.
                     phase = "REBIND" if rebind else "RENEW"
                     return self._handle_changed_address(got, rx, phase, release_on_enforce=False)
-                self.lease = rx.lease or self.lease
-                self.t1_server, self.t2_server = rx.t1, rx.t2
-                self.router = rx.router or self.router
+                self._absorb_reply(rx, self.lease)
                 return True
         return False
 
@@ -400,7 +399,7 @@ class Keeper:
         extra = ""
         if self.arp_nudge:
             extra = " nudge=%d" % int(self._last_nudge)
-            gw = self.router or self.server
+            gw = self._nudge_target()
             if gw:
                 extra += " gw=%s" % gw
         self._write_hb("%d bound=%s lease=%d t1=%d t2=%d src=%s%s\n"
@@ -462,9 +461,7 @@ class Keeper:
             self._follow_update(got)
             self.request_ip = got
             self.yiaddr, self.server = got, rx.server_id or self.server
-            self.lease = rx.lease or DEFAULT_LEASE
-            self.t1_server, self.t2_server = rx.t1, rx.t2
-            self.router = rx.router or self.router
+            self._absorb_reply(rx, DEFAULT_LEASE)
             return True
         # Enforce: a fixed reservation must always return request_ip.
         LOG.error("%s: IP mismatch -- ISP gave %s, requested %s (reservation problem?)",
@@ -520,29 +517,11 @@ class Keeper:
         # Run-only-on-master: we are CARP backup and intentionally hold no lease.
         self._write_hb("%d STANDBY\n" % int(time.time()))
 
-    def _is_master(self):
-        """True if we should act as a DHCP client now: gating off, or this node is
-        CARP master for our vhid. Fails open (act normally) if state is unknown."""
-        if not self.only_when_master or not self.vhid:
-            return True
-        try:
-            out = subprocess.check_output(["/sbin/ifconfig", self.iface], errors="replace")
-            if isinstance(out, bytes):
-                out = out.decode(errors="replace")
-            self._last_master = ("carp: MASTER vhid %s " % self.vhid) in out
-        except (OSError, subprocess.SubprocessError):
-            # Can't read CARP state: keep the last known decision so a transient
-            # ifconfig failure does not flap both nodes to master at once.
-            pass
-        return self._last_master
-
-    def _carp_master_now(self):
-        """True if this node currently holds CARP MASTER for our vhid (or no vhid
-        is configured). Unlike _is_master() this ignores the run-only-on-master
-        gating flag: it protects the ARP nudge, which must NEVER be sent from a
-        CARP backup (a nudge steers the switch/gateway toward this node's port).
-        Fails CLOSED: a skipped nudge is retried next interval, a wrong one
-        steals the VIP's traffic."""
+    def _probe_carp_master(self):
+        """Raw CARP-role probe for our vhid: True/False from ifconfig, None when
+        the probe itself fails; no vhid configured -> True (nothing to gate on).
+        Callers apply their own failure policy: _is_master fails open with the
+        last known role, the ARP nudge fails closed."""
         if not self.vhid:
             return True
         try:
@@ -551,30 +530,57 @@ class Keeper:
                 out = out.decode(errors="replace")
             return ("carp: MASTER vhid %s " % self.vhid) in out
         except (OSError, subprocess.SubprocessError):
-            return False
+            return None
+
+    def _is_master(self):
+        """True if we should act as a DHCP client now: gating off, or this node is
+        CARP master for our vhid. On a failed probe, keep the last known decision
+        (fail open) so a transient ifconfig failure does not flap both nodes to
+        master at once."""
+        if not self.only_when_master or not self.vhid:
+            return True
+        probed = self._probe_carp_master()
+        if probed is not None:
+            self._last_master = probed
+        return self._last_master
+
+    def _poll_carp_role(self):
+        """Watch for a backup->master transition (called on the heartbeat
+        cadence). Becoming master renews the lease early and, when enabled,
+        nudges immediately: the failover -- or the link flap that re-elected
+        CARP -- may just have disturbed the upstream gateway's ARP entry and the
+        access node's DHCP-snooping binding, so neither should wait out its
+        normal timer. Independent of the ARP nudge setting."""
+        if not self.vhid:
+            return
+        master = self._probe_carp_master()
+        if master is None:
+            return
+        if master and self._was_master is False:
+            LOG.info("became CARP master for vhid %s -- immediate ARP nudge and early lease renew",
+                     self.vhid)
+            self._renew_asap = True
+            self._arp_nudge(force=True)
+        self._was_master = master
+
+    def _nudge_target(self):
+        """The gateway whose ARP cache the nudge maintains: DHCP option 3 from
+        the last ACK, falling back to the leasing server's address."""
+        return self.router or self.server
 
     def _arp_nudge(self, force=False):
         """Refresh the upstream gateway's ARP entry for the leased address by
         broadcasting an ARP request from (yiaddr, chaddr). No-op unless enabled,
-        bound, due (or forced) and CARP master (see _carp_master_now). Becoming
-        master forces an immediate nudge: a failover (or a link flap, which
-        re-elects CARP) must not wait out the interval clock while upstream
-        state may just have been disturbed."""
+        bound, due (or forced) and CARP master -- never nudge from a backup (it
+        would steal the VIP's traffic), so a failed role probe skips the nudge
+        (fails closed; the next interval retries)."""
         if not self.arp_nudge or not self.yiaddr:
             return
-        master = self._carp_master_now()
-        if master and self._was_master is False:
-            LOG.info("became CARP master for vhid %s -- immediate ARP nudge and early lease renew",
-                     self.vhid or "-")
-            force = True
-            # A failover or link flap may also have disturbed the access node's
-            # DHCP-snooping binding; an early RENEW re-teaches it. Handled by the
-            # next _hold tick instead of waiting out T1.
-            self._renew_asap = True
-        self._was_master = master
         if not force and time.time() - self._last_nudge < self.arp_nudge:
             return
-        gw = self.router or self.server
+        if self._probe_carp_master() is not True:
+            return
+        gw = self._nudge_target()
         if not gw:
             # Enabled but no target: without this warning the nudge would be a
             # silent no-op and the operator would believe they are protected.
@@ -582,8 +588,6 @@ class Keeper:
                 LOG.warning("ARP nudge enabled but no gateway known "
                             "(no DHCP router option or server-id) -- cannot nudge")
                 self._nudge_warned = True
-            return
-        if not master:
             return
         try:
             sendp(Ether(src=self.chaddr, dst="ff:ff:ff:ff:ff:ff") /
@@ -640,7 +644,8 @@ class Keeper:
             remaining -= chunk
             self._hb()
             self._follow_watchdog()   # re-drive a follow whose apply stalled
-            self._arp_nudge()         # keep the gateway's ARP entry for the VIP fresh
+            self._poll_carp_role()    # backup->master? renew early + nudge now
+            self._arp_nudge()
         return not self.stop
 
     def run(self):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -149,6 +149,8 @@ class Keeper:
         self._nudge_gw = None          # last nudge target we logged (log again on change)
         self._nudge_warned = False     # warned once about a missing nudge target
         self._was_master = None        # CARP role at the last nudge check (None = unknown yet)
+        self._nudge_now = False        # operator asked for an immediate nudge (SIGUSR1)
+        self._renew_asap = False       # renew at the next _hold tick instead of waiting for T1
         # Optional DHCP request options (empty -> not sent); built once and added to
         # every DISCOVER/REQUEST/RENEW so the server sees a consistent client identity.
         self._id_opts = []
@@ -562,9 +564,13 @@ class Keeper:
             return
         master = self._carp_master_now()
         if master and self._was_master is False:
-            LOG.info("became CARP master for vhid %s -- sending an immediate ARP nudge",
+            LOG.info("became CARP master for vhid %s -- immediate ARP nudge and early lease renew",
                      self.vhid or "-")
             force = True
+            # A failover or link flap may also have disturbed the access node's
+            # DHCP-snooping binding; an early RENEW re-teaches it. Handled by the
+            # next _hold tick instead of waiting out T1.
+            self._renew_asap = True
         self._was_master = master
         if not force and time.time() - self._last_nudge < self.arp_nudge:
             return
@@ -601,9 +607,15 @@ class Keeper:
 
     def _sleep_gated(self, secs):
         """Sleep up to secs (1s steps). Return False early on stop or, when
-        run-only-on-master is set, on CARP-master loss (checked every GATE_POLL)."""
+        run-only-on-master is set, on CARP-master loss (checked every GATE_POLL).
+        Also services an operator-requested immediate nudge (SIGUSR1) so it fires
+        within a second instead of at the next heartbeat tick."""
         slept = 0
         while slept < secs and not self.stop:
+            if self._nudge_now:
+                self._nudge_now = False
+                self._arp_nudge(force=True)
+                self._hb()   # publish the new nudge age right away for the status page
             if self.only_when_master and slept % GATE_POLL == 0 and not self._is_master():
                 return False
             time.sleep(1)
@@ -617,6 +629,11 @@ class Keeper:
         on stop or CARP-master loss."""
         remaining = secs
         while remaining > 0 and not self.stop:
+            if self._renew_asap:
+                # Return as if T1 elapsed: the caller renews right away, which
+                # re-teaches upstream DHCP-snooping state after a master change.
+                self._renew_asap = False
+                return not self.stop
             chunk = min(HB_REFRESH, remaining)
             if not self._sleep_gated(chunk):
                 return False
@@ -802,6 +819,13 @@ def main():
         k.stop = True
     signal.signal(signal.SIGINT, _sig)
     signal.signal(signal.SIGTERM, _sig)
+
+    def _sig_nudge(*_):
+        # Operator-requested immediate ARP nudge (configd action / kill -USR1).
+        # Only sets a flag; the sleep loops service it within a second, so no
+        # network I/O happens inside the signal handler itself.
+        k._nudge_now = True
+    signal.signal(signal.SIGUSR1, _sig_nudge)
 
     if a.once:
         if not k._start_sniffer():

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/nudge_now.sh
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/nudge_now.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Ask a running keeper (by request address) to send an ARP nudge right now.
+# Sends SIGUSR1 to the daemon; the keeper services it within a second. Emits a
+# one-line JSON status for the Diagnostics API.
+#
+# The argument is mapped to the keeper's filesystem-safe id exactly like rc.d
+# and status.py do, so whatever we receive can only ever form a pidfile name
+# from [A-Za-z0-9_].
+
+id=$(printf '%s' "$1" | tr -c 'A-Za-z0-9' '_')
+pidfile="/var/run/carpvipdhcp-${id}.child.pid"
+
+if [ ! -f "${pidfile}" ]; then
+    echo '{"status": "not_running"}'
+    exit 0
+fi
+
+pid=$(cat "${pidfile}")
+case "${pid}" in
+    '' | *[!0-9]*)
+        echo '{"status": "bad_pidfile"}'
+        exit 0
+        ;;
+esac
+
+if kill -USR1 "${pid}" 2>/dev/null; then
+    echo '{"status": "ok"}'
+else
+    echo '{"status": "signal_failed"}'
+fi

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
@@ -8,6 +8,7 @@ pidfile and heartbeat file. Output:
 
 The heartbeat file is written by lease-keeper.py in one of two forms:
     <epoch> bound=<ip> lease=<seconds> t1=<seconds> t2=<seconds> src=<server|derived>
+            [nudge=<epoch|0> [gw=<ip>]]
     <epoch> MISMATCH got=<ip> want=<ip>
 """
 import json
@@ -38,7 +39,7 @@ def pid_alive(path):
 def parse_heartbeat(path):
     result = {"bound": None, "lease": None, "t1": None, "t2": None, "timing_source": None,
               "standby": False, "mismatch": False, "mismatch_got": None, "mismatch_want": None,
-              "hb_epoch": None, "hb_age": None}
+              "hb_epoch": None, "hb_age": None, "nudge_epoch": None, "nudge_age": None, "gw": None}
     try:
         raw = open(path).read().strip()
     except OSError:
@@ -72,6 +73,16 @@ def parse_heartbeat(path):
                 pass
         elif part.startswith("src="):
             result["timing_source"] = part.split("=", 1)[1]
+        elif part.startswith("nudge="):
+            # nudge=0 means "enabled but never sent yet" -> age stays None.
+            try:
+                result["nudge_epoch"] = int(part.split("=", 1)[1])
+                if result["nudge_epoch"]:
+                    result["nudge_age"] = int(time.time()) - result["nudge_epoch"]
+            except ValueError:
+                pass
+        elif part.startswith("gw="):
+            result["gw"] = part.split("=", 1)[1]
         elif part == "STANDBY":
             result["standby"] = True
         elif part == "MISMATCH":
@@ -132,6 +143,10 @@ def read_keepers(states, names):
         vhid = parts[4] if len(parts) > 4 else ""
         run_only = parts[5] if len(parts) > 5 else "0"
         follow = parts[6] if len(parts) > 6 else "0"
+        try:
+            arp_nudge = int(parts[10]) if len(parts) > 10 and parts[10] else 0
+        except ValueError:
+            arp_nudge = 0
         kid = keeper_id(request)
         pid = pid_alive("%s/carpvipdhcp-%s.pid" % (RUN_DIR, kid))
         entry = {
@@ -144,6 +159,7 @@ def read_keepers(states, names):
             "demote_on_lease_loss": demote == "1",
             "run_only_on_master": run_only == "1",
             "follow_ip": follow == "1",
+            "arp_nudge": arp_nudge,
             "running": pid is not None,
             "pid": pid,
         }

--- a/net/os-carp-vip-dhcp/src/opnsense/service/conf/actions.d/actions_carpvipdhcp.conf
+++ b/net/os-carp-vip-dhcp/src/opnsense/service/conf/actions.d/actions_carpvipdhcp.conf
@@ -31,6 +31,13 @@ parameters:
 type:script
 message:carpvipdhcp sync firewall aliases
 
+[nudge]
+command:/usr/local/opnsense/scripts/OPNsense/CarpVipDhcp/nudge_now.sh
+errors:no
+parameters:%s
+type:script_output
+message:carpvipdhcp manual ARP nudge
+
 [status]
 command:/usr/local/etc/rc.d/carpvipdhcp status
 errors:no

--- a/net/os-carp-vip-dhcp/src/opnsense/service/templates/OPNsense/CarpVipDhcp/keeper.conf
+++ b/net/os-carp-vip-dhcp/src/opnsense/service/templates/OPNsense/CarpVipDhcp/keeper.conf
@@ -1,7 +1,7 @@
 {#
     Rendered keeper table for lease-keeper.py (one line per enabled keeper).
 
-    Format per line:  REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|RUN_ONLY_ON_MASTER|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME
+    Format per line:  REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|RUN_ONLY_ON_MASTER|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE
     Everything is derived from each keeper's referenced CARP VirtualIP: we look
     the VIP up in the legacy virtualip list to get its interface (-> physical
     device) and VHID (-> chaddr 00:00:5e:00:01:VHID). chaddrOverride wins when set.
@@ -26,7 +26,7 @@
 {%       set chaddr = '' %}
 {%     endif %}
 {%     if vip.iface and chaddr %}
-{{ k.carpVip }}|{{ vip.iface }}|{{ chaddr }}|{{ k.demoteOnLeaseLoss|default('0') }}|{{ vip.vhid }}|{{ k.runOnlyOnMaster|default('0') }}|{{ k.followIp|default('0') }}|{{ k.vendorClass|default('') }}|{{ k.clientId|default('') }}|{{ k.hostname|default('') }}
+{{ k.carpVip }}|{{ vip.iface }}|{{ chaddr }}|{{ k.demoteOnLeaseLoss|default('0') }}|{{ vip.vhid }}|{{ k.runOnlyOnMaster|default('0') }}|{{ k.followIp|default('0') }}|{{ k.vendorClass|default('') }}|{{ k.clientId|default('') }}|{{ k.hostname|default('') }}|{{ k.arpNudgeInterval|default('0') }}
 {%     endif %}
 {%   endif %}
 {% endfor %}

--- a/net/os-carp-vip-dhcp/tests/conftest.py
+++ b/net/os-carp-vip-dhcp/tests/conftest.py
@@ -34,8 +34,17 @@ def _stub_scapy():
         def stop(self):
             pass
 
-    for _name in ("Ether", "IP", "UDP", "BOOTP", "DHCP", "sendp"):
-        setattr(allmod, _name, lambda *a, **k: None)
+    class _Layer:
+        """Composable no-op protocol layer: Ether(...) / IP(...) / ... works."""
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __truediv__(self, other):
+            return self
+
+    for _name in ("ARP", "Ether", "IP", "UDP", "BOOTP", "DHCP"):
+        setattr(allmod, _name, _Layer)
+    allmod.sendp = lambda *a, **k: None
     allmod.AsyncSniffer = _Sniffer
     scapy.all = allmod
     sys.modules["scapy"] = scapy

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -207,6 +207,22 @@ def test_hb_no_nudge_tokens_when_off(lk, tmp_path):
     assert "nudge=" not in hb.read_text()
 
 
+def test_nudge_fires_immediately_on_master_transition(lk):
+    keeper = _nudge_keeper(lk)
+    keeper._arp_nudge()                  # master from the start -> sends
+    first = keeper._last_nudge
+    assert first > 0
+    states = iter([False, True, True])
+    keeper._carp_master_now = lambda: next(states)
+    keeper._arp_nudge()                  # now backup -> no send, remembers the role
+    assert keeper._last_nudge == first
+    keeper._arp_nudge()                  # backup -> master: forced despite the interval
+    assert keeper._last_nudge > first
+    second = keeper._last_nudge
+    keeper._arp_nudge()                  # still master -> interval applies again
+    assert keeper._last_nudge == second
+
+
 def test_nudge_missing_gateway_warns_once(lk, caplog):
     keeper = _nudge_keeper(lk)
     keeper.server = None             # enabled + bound, but no target

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -175,3 +175,43 @@ def test_ack_router_option_defaulted(lk):
     # Existing 6-arg constructions (and old pickled replies) must keep working.
     reply = lk.DhcpReply(5, "100.64.4.7", "100.64.4.1", 1800, None, None)
     assert reply.router is None
+
+
+def test_hb_includes_nudge_state(lk, tmp_path):
+    hb = tmp_path / "hb"
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7",
+                       hbfile=str(hb), arp_nudge=240)
+    keeper.yiaddr = "100.64.4.7"
+    keeper.router = "100.64.4.1"
+    keeper._last_nudge = 1783350000.0
+    keeper._hb()
+    content = hb.read_text()
+    assert " nudge=1783350000" in content
+    assert " gw=100.64.4.1" in content
+
+
+def test_hb_nudge_never_and_no_gateway(lk, tmp_path):
+    hb = tmp_path / "hb"
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7",
+                       hbfile=str(hb), arp_nudge=240)
+    keeper._hb()
+    content = hb.read_text()
+    assert " nudge=0" in content     # enabled but never sent
+    assert "gw=" not in content      # no target known yet
+
+
+def test_hb_no_nudge_tokens_when_off(lk, tmp_path):
+    hb = tmp_path / "hb"
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=str(hb))
+    keeper._hb()
+    assert "nudge=" not in hb.read_text()
+
+
+def test_nudge_missing_gateway_warns_once(lk, caplog):
+    keeper = _nudge_keeper(lk)
+    keeper.server = None             # enabled + bound, but no target
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        keeper._arp_nudge(force=True)
+        keeper._arp_nudge(force=True)
+    warnings = [r for r in caplog.records if "no gateway known" in r.getMessage()]
+    assert len(warnings) == 1        # warned, but only once

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -216,11 +216,32 @@ def test_nudge_fires_immediately_on_master_transition(lk):
     keeper._carp_master_now = lambda: next(states)
     keeper._arp_nudge()                  # now backup -> no send, remembers the role
     assert keeper._last_nudge == first
+    assert keeper._renew_asap is False
     keeper._arp_nudge()                  # backup -> master: forced despite the interval
     assert keeper._last_nudge > first
+    assert keeper._renew_asap is True    # and the lease renews early too
     second = keeper._last_nudge
+    keeper._renew_asap = False
     keeper._arp_nudge()                  # still master -> interval applies again
     assert keeper._last_nudge == second
+
+
+def test_hold_returns_early_for_asap_renew(lk):
+    import time
+    keeper = _nudge_keeper(lk)
+    keeper._renew_asap = True
+    start = time.time()
+    assert keeper._hold(60) is True      # returns as if T1 elapsed -> caller renews
+    assert time.time() - start < 2
+    assert keeper._renew_asap is False
+
+
+def test_sigusr1_flag_services_nudge_within_a_second(lk):
+    keeper = _nudge_keeper(lk)
+    keeper._nudge_now = True             # what the SIGUSR1 handler sets
+    keeper._sleep_gated(1)
+    assert keeper._nudge_now is False
+    assert keeper._last_nudge > 0
 
 
 def test_nudge_missing_gateway_warns_once(lk, caplog):

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -97,3 +97,81 @@ def test_id_opts_built_from_args(lk):
     assert ("vendor_class_id", "MSFT 5.0") in keeper._id_opts
     assert ("client_id", b"keeper-1") in keeper._id_opts
     assert ("hostname", "vip") in keeper._id_opts
+
+
+def _nudge_keeper(lk, **kwargs):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None,
+                       arp_nudge=kwargs.pop("arp_nudge", 240), **kwargs)
+    keeper.yiaddr = "100.64.4.7"
+    keeper.server = "100.64.4.1"
+    keeper._carp_master_now = lambda: True   # not under test here (needs ifconfig)
+    return keeper
+
+
+def test_nudge_off_by_default(lk):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    assert keeper.arp_nudge == 0
+    keeper._arp_nudge(force=True)   # must be a no-op, not an error
+    assert keeper._last_nudge == 0.0
+
+
+def test_nudge_interval_floor(lk):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, arp_nudge=1)
+    assert keeper.arp_nudge == lk.ARP_NUDGE_MIN
+
+
+def test_nudge_respects_interval_and_force(lk):
+    keeper = _nudge_keeper(lk)
+    keeper._arp_nudge()
+    first = keeper._last_nudge
+    assert first > 0
+    keeper._arp_nudge()             # within the interval -> skipped
+    assert keeper._last_nudge == first
+    keeper._arp_nudge(force=True)   # forced (BOUND/RENEW/REBIND) -> sent
+    assert keeper._last_nudge > first
+
+
+def test_nudge_requires_gateway_and_lease(lk):
+    keeper = _nudge_keeper(lk)
+    keeper.server = None            # no router option and no server_id -> no target
+    keeper._arp_nudge(force=True)
+    assert keeper._last_nudge == 0.0
+    keeper.server = "100.64.4.1"
+    keeper.yiaddr = None            # not bound -> no source address
+    keeper._arp_nudge(force=True)
+    assert keeper._last_nudge == 0.0
+
+
+def test_nudge_works_from_router_option_alone(lk):
+    keeper = _nudge_keeper(lk)
+    keeper.server = None
+    keeper.router = "100.64.4.254"   # DHCP option 3 alone is a valid target
+    keeper._arp_nudge(force=True)
+    assert keeper._last_nudge > 0
+
+
+def test_nudge_gated_to_carp_master(lk):
+    keeper = _nudge_keeper(lk, vhid=199)
+    keeper._carp_master_now = lambda: False
+    keeper._arp_nudge(force=True)
+    assert keeper._last_nudge == 0.0   # never nudge from a CARP backup
+
+
+def test_carp_master_now_true_without_vhid(lk):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    assert keeper._carp_master_now() is True
+
+
+def test_carp_master_now_fails_closed(lk, monkeypatch):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, vhid=199)
+
+    def boom(*a, **k):
+        raise OSError("ifconfig unavailable")
+    monkeypatch.setattr(lk.subprocess, "check_output", boom)
+    assert keeper._carp_master_now() is False
+
+
+def test_ack_router_option_defaulted(lk):
+    # Existing 6-arg constructions (and old pickled replies) must keep working.
+    reply = lk.DhcpReply(5, "100.64.4.7", "100.64.4.1", 1800, None, None)
+    assert reply.router is None

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1,4 +1,5 @@
 """Unit tests for the lease-keeper daemon's pure helpers and follow decision."""
+import time
 
 
 def test_sane_ipv4(lk):
@@ -48,7 +49,7 @@ def _follow_keeper(lk, tmp_path):
 
 
 def _ack(lk, yiaddr, server="100.64.4.1"):
-    return lk.DhcpReply(5, yiaddr, server, 1800, None, None)
+    return lk.DhcpReply(5, yiaddr, server, 1800, None, None, None)
 
 
 def test_follow_accepts_same_class(lk, tmp_path):
@@ -99,12 +100,12 @@ def test_id_opts_built_from_args(lk):
     assert ("hostname", "vip") in keeper._id_opts
 
 
-def _nudge_keeper(lk, **kwargs):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None,
-                       arp_nudge=kwargs.pop("arp_nudge", 240), **kwargs)
+def _nudge_keeper(lk, arp_nudge=240, hbfile=None, **kwargs):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7",
+                       hbfile=hbfile, arp_nudge=arp_nudge, **kwargs)
     keeper.yiaddr = "100.64.4.7"
     keeper.server = "100.64.4.1"
-    keeper._carp_master_now = lambda: True   # not under test here (needs ifconfig)
+    keeper._probe_carp_master = lambda: True   # the real probe needs ifconfig
     return keeper
 
 
@@ -152,36 +153,35 @@ def test_nudge_works_from_router_option_alone(lk):
 
 def test_nudge_gated_to_carp_master(lk):
     keeper = _nudge_keeper(lk, vhid=199)
-    keeper._carp_master_now = lambda: False
+    keeper._probe_carp_master = lambda: False
     keeper._arp_nudge(force=True)
     assert keeper._last_nudge == 0.0   # never nudge from a CARP backup
 
 
-def test_carp_master_now_true_without_vhid(lk):
+def test_probe_carp_master_true_without_vhid(lk):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
-    assert keeper._carp_master_now() is True
+    assert keeper._probe_carp_master() is True
 
 
-def test_carp_master_now_fails_closed(lk, monkeypatch):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, vhid=199)
+def test_probe_failure_skips_nudge(lk, monkeypatch):
+    # A failed probe reports None, and the nudge fails closed on anything but
+    # a confirmed MASTER.
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None,
+                       vhid=199, arp_nudge=240)
+    keeper.yiaddr = "100.64.4.7"
+    keeper.server = "100.64.4.1"
 
     def boom(*a, **k):
         raise OSError("ifconfig unavailable")
     monkeypatch.setattr(lk.subprocess, "check_output", boom)
-    assert keeper._carp_master_now() is False
-
-
-def test_ack_router_option_defaulted(lk):
-    # Existing 6-arg constructions (and old pickled replies) must keep working.
-    reply = lk.DhcpReply(5, "100.64.4.7", "100.64.4.1", 1800, None, None)
-    assert reply.router is None
+    assert keeper._probe_carp_master() is None
+    keeper._arp_nudge(force=True)
+    assert keeper._last_nudge == 0.0
 
 
 def test_hb_includes_nudge_state(lk, tmp_path):
     hb = tmp_path / "hb"
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7",
-                       hbfile=str(hb), arp_nudge=240)
-    keeper.yiaddr = "100.64.4.7"
+    keeper = _nudge_keeper(lk, hbfile=str(hb))
     keeper.router = "100.64.4.1"
     keeper._last_nudge = 1783350000.0
     keeper._hb()
@@ -192,8 +192,8 @@ def test_hb_includes_nudge_state(lk, tmp_path):
 
 def test_hb_nudge_never_and_no_gateway(lk, tmp_path):
     hb = tmp_path / "hb"
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7",
-                       hbfile=str(hb), arp_nudge=240)
+    keeper = _nudge_keeper(lk, hbfile=str(hb))
+    keeper.server = None
     keeper._hb()
     content = hb.read_text()
     assert " nudge=0" in content     # enabled but never sent
@@ -202,32 +202,38 @@ def test_hb_nudge_never_and_no_gateway(lk, tmp_path):
 
 def test_hb_no_nudge_tokens_when_off(lk, tmp_path):
     hb = tmp_path / "hb"
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=str(hb))
+    keeper = _nudge_keeper(lk, arp_nudge=0, hbfile=str(hb))
     keeper._hb()
     assert "nudge=" not in hb.read_text()
 
 
-def test_nudge_fires_immediately_on_master_transition(lk):
-    keeper = _nudge_keeper(lk)
-    keeper._arp_nudge()                  # master from the start -> sends
+def test_master_transition_renews_early_and_nudges(lk):
+    keeper = _nudge_keeper(lk, vhid=199)
+    states = iter([True, False, True, True, True])
+    keeper._probe_carp_master = lambda: next(states)
+    keeper._poll_carp_role()             # master from the start -> no transition
+    assert keeper._renew_asap is False
+    assert keeper._last_nudge == 0.0
+    keeper._poll_carp_role()             # backup -> remembers the role
+    keeper._poll_carp_role()             # backup -> master (the forced nudge probes again)
+    assert keeper._renew_asap is True
     first = keeper._last_nudge
     assert first > 0
-    states = iter([False, True, True])
-    keeper._carp_master_now = lambda: next(states)
-    keeper._arp_nudge()                  # now backup -> no send, remembers the role
+    keeper._poll_carp_role()             # still master -> nothing new
     assert keeper._last_nudge == first
-    assert keeper._renew_asap is False
-    keeper._arp_nudge()                  # backup -> master: forced despite the interval
-    assert keeper._last_nudge > first
-    assert keeper._renew_asap is True    # and the lease renews early too
-    second = keeper._last_nudge
-    keeper._renew_asap = False
-    keeper._arp_nudge()                  # still master -> interval applies again
-    assert keeper._last_nudge == second
+
+
+def test_master_transition_renews_even_with_nudge_off(lk):
+    keeper = _nudge_keeper(lk, arp_nudge=0, vhid=199)
+    states = iter([False, True])
+    keeper._probe_carp_master = lambda: next(states)
+    keeper._poll_carp_role()
+    keeper._poll_carp_role()
+    assert keeper._renew_asap is True    # the early renew is not tied to the nudge
+    assert keeper._last_nudge == 0.0     # but no nudge was sent
 
 
 def test_hold_returns_early_for_asap_renew(lk):
-    import time
     keeper = _nudge_keeper(lk)
     keeper._renew_asap = True
     start = time.time()

--- a/net/os-carp-vip-dhcp/tests/test_status.py
+++ b/net/os-carp-vip-dhcp/tests/test_status.py
@@ -43,3 +43,42 @@ def test_parse_heartbeat_mismatch(tmp_path):
 
 def test_parse_heartbeat_missing(tmp_path):
     assert status.parse_heartbeat(str(tmp_path / "absent"))["bound"] is None
+
+
+def test_parse_heartbeat_nudge(tmp_path):
+    hb = tmp_path / "hb"
+    hb.write_text("1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived"
+                  " nudge=1783350700 gw=100.64.4.1\n")
+    result = status.parse_heartbeat(str(hb))
+    assert result["nudge_epoch"] == 1783350700
+    assert isinstance(result["nudge_age"], int) and result["nudge_age"] > 0
+    assert result["gw"] == "100.64.4.1"
+
+
+def test_parse_heartbeat_nudge_never(tmp_path):
+    hb = tmp_path / "hb"
+    hb.write_text("1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived nudge=0\n")
+    result = status.parse_heartbeat(str(hb))
+    assert result["nudge_epoch"] == 0
+    assert result["nudge_age"] is None
+    assert result["gw"] is None
+
+
+def test_parse_heartbeat_without_nudge_tokens(tmp_path):
+    hb = tmp_path / "hb"
+    hb.write_text("1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived\n")
+    result = status.parse_heartbeat(str(hb))
+    assert result["nudge_epoch"] is None
+    assert result["nudge_age"] is None
+
+
+def test_read_keepers_arp_nudge_field(tmp_path, monkeypatch):
+    conf = tmp_path / "keeper.conf"
+    conf.write_text(
+        "100.64.4.7|eth0|00:00:5e:00:01:fe|0|254|0|1||||240\n"
+        "100.64.4.8|eth0|00:00:5e:00:01:fd|0|253|0|1|||\n")   # old 10-field line
+    monkeypatch.setattr(status, "CONFFILE", str(conf))
+    monkeypatch.setattr(status, "RUN_DIR", str(tmp_path))
+    keepers = status.read_keepers({}, {})
+    assert keepers[0]["arp_nudge"] == 240
+    assert keepers[1]["arp_nudge"] == 0


### PR DESCRIPTION
## Problem

Some ISP gateways/BNGs **ignore gratuitous ARP** (spoofing protection) and **never send an ARP request** when their cache entry for the leased address expires. The result with outbound NAT to the CARP VIP is nasty to diagnose: everything works right after a CARP event or DHCP exchange, then traffic **silently blackholes ~20 minutes later** — outbound packets leave, nothing returns, and even the gateway stops answering pings sourced from the VIP.

Observed in the field (fiber access, OPNsense 26.1):

- `tcpdump` on WAN: a flood of client SYNs out from the VIP, **zero** inbound packets, and **zero** ARP who-has from the gateway.
- The keeper's hourly DHCP RENEW (broadcast, eth-src = CARP MAC) does **not** refresh the gateway's ARP cache.
- One broadcast **ARP request** from (VIP, CARP MAC) for the gateway restored traffic instantly (~4900 inbound frames in 8 s) — for another ~20 minutes, until the entry expired again.

## Fix: ARP nudge

Per-keeper **ARP nudge**, on by default: periodically broadcast an ARP request `who-has <gateway> tell <leased IP>` with the keeper's chaddr (the CARP MAC) as source, so the gateway's ARP entry never expires.

- Sent on the heartbeat cadence (default every 240 s, floor 30 s, 0 = off) plus immediately (forced) after **BOUND / RENEW ok / REBIND ok**.
- Gateway address from **DHCP option 3** (`router`, now parsed from ACKs), fallback: the DHCP `server_id`.
- **HA safety:** only sent while this node is **CARP MASTER for the VIP's vhid**. A single raw role probe (`_probe_carp_master()`, returning True/False/None) underlies both policies: the existing DHCP gating keeps its fail-open behaviour, while the nudge gate **fails closed** — a nudge from a backup would steal the VIP's traffic. `rc.d` now always passes `--vhid` so the check works even with DHCP gating off.
- **Becoming master** (failover, or a link flap re-electing CARP) is detected by a dedicated `_poll_carp_role()` on the heartbeat tick and triggers an immediate nudge **and an early lease RENEW** — upstream ARP and DHCP-snooping state may just have been disturbed, so neither waits for its timer. The early renew applies even with the nudge disabled.
- Passes **Dynamic ARP Inspection** by construction: the nudge's sender (leased IP, chaddr) is exactly the DHCP-snooped binding.

## Observability

- Status page gains an **ARP nudge** column: off / never (warning label on a bound master) / age, with target gateway and interval in the tooltip — plus a ⚡ **nudge now** button (running CARP master only).
- Manual nudge chain for troubleshooting: SIGUSR1 → flag serviced within a second (no network I/O in the signal handler) → configd action `carpvipdhcp nudge <ip>` → POST-only Diagnostics API endpoint → status page button. The heartbeat is rewritten right after, so the page reflects it immediately.
- Log page: warn once when the nudge is enabled but no gateway is known (otherwise a silent no-op), and log the nudge target whenever it changes.

## Docs

- README: new **"Playing nicely with ISP access-network security"** section mapping DHCP snooping, DAI, gratuitous-ARP filtering, no-re-ARP/"secured ARP", IPSG (IP-only vs strict IP+MAC — a documented limitation: FreeBSD egresses VIP data with the physical MAC), client-identity options and per-subscriber MAC/session limits to how the plugin cooperates.
- **"Design notes"**: mechanisms considered and deliberately not included (DHCP option 82, RFC 5227, DAI rate-limit pacing, unicast RENEW) with rationale.

## Config surface

New keeper setting **arpNudgeInterval** (advanced, default 240, 0 = off); keeper.conf line gains an 11th field; model bumped to 1.1.0, plugin version to 1.1. `DhcpReply` gained a `router` field, and ACK absorption is centralized in `_absorb_reply()`.

## Tests

- scapy stub made composable (`Ether(...) / ARP(...)`) and taught `ARP`.
- 20 new unit tests across daemon and status parsing (interval/force semantics, master gating and the fail-closed probe, master-transition renew+nudge — including with the nudge disabled, SIGUSR1 servicing, heartbeat tokens, status.py parsing, conf-line backward compatibility).
- `python -m pytest tests/` → **41 passed**; all CI checks green.
