### PR TITLE
chore: non-promiscuous sniffer, security-posture docs, PLUGIN_PYTHON dep

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -2,8 +2,8 @@ PLUGIN_NAME=		carp-vip-dhcp
 PLUGIN_VERSION=         1.1.1
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
-# NOTE: the py<XY>-scapy version MUST match the OPNsense base Python of your target release.
-# OPNsense 26.1 ships Python 3.13 -> py313-scapy. Bump this to match older/newer releases.
-PLUGIN_DEPENDS=		py313-scapy
+# PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,
+# so the scapy dependency follows OPNsense upgrades without manual bumps.
+PLUGIN_DEPENDS=		py${PLUGIN_PYTHON}-scapy
 
 .include "../../Mk/plugins.mk"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -22,6 +22,19 @@ Robustness:
   * RELEASE is NOT sent on a normal stop (SIGTERM) -- only with
     --once/--release-on-exit -- so the address is not given up needlessly.
 
+Security posture (this daemon parses untrusted WAN traffic as root):
+  * The BPF filter is the outer boundary: only DHCP traffic (udp port 67/68)
+    ever reaches Python; everything else is dropped in the kernel.
+  * A reply must carry our current xid and the BOOTREPLY op before any field
+    is read (see _on) -- unsolicited or replayed packets are discarded early.
+  * Only the handful of DHCP options the keeper needs is extracted; there is
+    no full dissection of attacker-controlled option data.
+  * Follow mode never rewrites the CARP VIP from a single ACK: the new address
+    is validated for plausibility, routability class and expected server, and
+    rate-throttled against flap/spoof storms (see _handle_changed_address).
+  * A parse error in the sniffer callback is dropped (debug-logged); malformed
+    input can never take the main loop down.
+
 Usage:
   lease-keeper.py --iface <if> --chaddr <mac> --request <ip>
   lease-keeper.py ... --once            # one-shot claim+verify+release (test)
@@ -184,6 +197,9 @@ class Keeper:
                     self._sniffer.stop()
                 except Exception:
                     pass
+            # The BPF filter is a security boundary, not an optimization: the
+            # callback runs as root on a promiscuous WAN socket, so nothing but
+            # DHCP is allowed to reach the Python parser at all.
             self._sniffer = AsyncSniffer(
                 iface=self.iface, filter="udp and (port 67 or port 68)",
                 prn=self._on, store=0)
@@ -208,8 +224,13 @@ class Keeper:
             if not (p.haslayer(BOOTP) and p.haslayer(DHCP)):
                 return
             b = p[BOOTP]
+            # Trust gate: only a reply to OUR in-flight exchange (random xid,
+            # regenerated per DORA) is parsed further; anything else on the
+            # segment -- other clients' traffic, replays, junk -- stops here.
             if b.xid != self.xid or b.op != BOOTREPLY:
                 return
+            # Extract only the fields the keeper acts on; attacker-controlled
+            # option data is otherwise left untouched.
             mt = sid = lt = rt = bt = ro = None
             for o in p[DHCP].options:
                 if isinstance(o, tuple):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -23,7 +23,10 @@ Robustness:
     --once/--release-on-exit -- so the address is not given up needlessly.
 
 Security posture (this daemon parses untrusted WAN traffic as root):
-  * The BPF filter is the outer boundary: only DHCP traffic (udp port 67/68)
+  * The sniffer is NOT promiscuous: requests carry the BOOTP broadcast flag so
+    the server broadcasts its replies, which reach a non-promiscuous socket --
+    the daemon never sees a neighbour's unicast traffic.
+  * The BPF filter is the next boundary: only DHCP traffic (udp port 67/68)
     ever reaches Python; everything else is dropped in the kernel.
   * A reply must carry our current xid and the BOOTREPLY op before any field
     is read (see _on) -- unsolicited or replayed packets are discarded early.
@@ -197,12 +200,15 @@ class Keeper:
                     self._sniffer.stop()
                 except Exception:
                     pass
-            # The BPF filter is a security boundary, not an optimization: the
-            # callback runs as root on a promiscuous WAN socket, so nothing but
-            # DHCP is allowed to reach the Python parser at all.
+            # promisc=False: we set the BOOTP broadcast flag on every request, so
+            # an RFC 2131-compliant server broadcasts OFFER/ACK -- and broadcast
+            # frames reach a non-promiscuous socket. Not listening promiscuously on
+            # a WAN interface keeps this root daemon off every neighbour's traffic.
+            # The BPF filter is a second boundary, not an optimization: only DHCP
+            # reaches the Python parser at all.
             self._sniffer = AsyncSniffer(
                 iface=self.iface, filter="udp and (port 67 or port 68)",
-                prn=self._on, store=0)
+                prn=self._on, store=0, promisc=False)
             self._sniffer.start()
             return True
         except Exception as e:


### PR DESCRIPTION
Follow-up to #5, which merged before these three commits were pushed. They belong to the same 1.1.1 maintenance round.

- **Drop promiscuous mode** on the DHCP sniffer (`promisc=False`). The keeper sets the BOOTP broadcast flag, so an RFC 2131-compliant server broadcasts its replies, which reach a non-promiscuous socket — verified against a live ISP (a throwaway-MAC DISCOVER drew a broadcast OFFER, ether dst `ff:ff:ff:ff:ff:ff`, flags `0x8000`). A root daemon no longer listens to every neighbour's WAN traffic; non-promiscuous listening is now the outermost boundary, ahead of the BPF filter.
- **Document the security posture in the code** — module-docstring section (non-promiscuous listening, BPF boundary, xid trust gate, minimal option extraction, follow-mode validation, parse-error containment) plus intent comments at the sniffer and the reply callback's gates, so a reviewer finds the threat model where the guards live.
- **Resolve the scapy dependency via `py${PLUGIN_PYTHON}-scapy`** instead of a hardcoded `py313-scapy`, so it follows the OPNsense base Python on upgrades — the same pattern upstream's `devel/debug` uses.

`python -m pytest tests/` → 42 passed; all CI checks green on the branch.