### PR TITLE
feat: dashboard health banner when a keeper stops holding its lease

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.1.1
+PLUGIN_VERSION=         1.2.0
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -142,6 +142,11 @@ OPNsense CARP answers ARP + egresses data as usual. The VIP becomes failover-cap
   master), or `kill -USR1` on the keeper daemon — it fires within a second and shows up in the log.
 - **Self-healing:** the daemon never exits on a transient DHCP/interface fault — it catches errors, keeps
   its heartbeat fresh (so CARP does not falsely demote the node) and retries.
+- **Health banner:** if an enabled keeper stops holding its lease — mismatch, a stalled daemon, or a
+  spare that cannot acquire its redundant lease — a warning banner appears across the GUI (auto-clearing
+  once healthy). A short grace period rides out reboots and restarts. This closes the silent-failure gap:
+  the redundant spare's keeper can fail without any outage, so without the banner you would not know HA
+  is degraded until a failover actually needed it. (It is a logged-in GUI banner, not an email push.)
 
 ## Prerequisites
 

--- a/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
@@ -11,10 +11,11 @@
 
 CONF="/usr/local/etc/carpvipdhcp/keeper.conf"
 RUN_DIR="/var/run"
-# A fresh heartbeat is written on every (re)bind/renew. The daemon renews at
-# T1 = 0.5 x lease, so a heartbeat can legitimately age up to ~T1 between writes.
-# Use a full typical lease (3600s) as the ceiling to avoid demoting a healthy
-# keeper mid-cycle; only a truly stalled keeper exceeds this.
+# The daemon refreshes the heartbeat every ~30s while holding a lease; the
+# largest legitimate gap is a failed-acquire backoff (~300s). 3600s is therefore
+# a deliberately generous ceiling: demotion is drastic, so we only act on a
+# truly stalled keeper, never a mid-cycle one. (The health *banner* uses a
+# tighter 600s ceiling -- a notice is cheap, so it can be more responsive.)
 MAX_AGE=3600
 
 [ -f "${CONF}" ] || exit 0

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/library/OPNsense/System/Status/CarpVipDhcpStatus.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/library/OPNsense/System/Status/CarpVipDhcpStatus.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Tore Amundsen
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+ * CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\System\Status;
+
+use OPNsense\System\AbstractStatus;
+use OPNsense\System\SystemStatusCode;
+
+/**
+ * Raise a dashboard banner when a CARP-VIP DHCP lease keeper stops holding its
+ * lease. Pull-based: core polls collectStatus(); the banner clears by itself
+ * once every keeper is healthy again. The keeper daemon needs no changes -- we
+ * read the heartbeat files it already writes (the same signals the CARP
+ * service-status hook uses), plus a grace period so a reboot or a keeper
+ * restart does not flash a false alarm.
+ */
+class CarpVipDhcpStatus extends AbstractStatus
+{
+    private const CONF = '/usr/local/etc/carpvipdhcp/keeper.conf';
+    private const RUN_DIR = '/var/run';
+    private const STATE_FILE = '/var/run/carpvipdhcp-notice.state';
+    // A healthy keeper rewrites its heartbeat every ~30s; the largest legitimate
+    // gap is a re-acquire backoff (~300s). 600s reliably means a stalled daemon.
+    private const STALE = 600;
+    // Only alert once a problem has persisted this long, to ride out restarts.
+    private const GRACE = 300;
+
+    public function __construct()
+    {
+        $this->internalPriority = 2;
+        $this->internalPersistent = false;
+        $this->internalIsBanner = true;
+        $this->internalScope = ['*'];
+        $this->internalTitle = gettext('CARP-VIP DHCP');
+        $this->internalLocation = '/ui/carpvipdhcp/';
+    }
+
+    public function collectStatus()
+    {
+        $problems = [];
+        foreach ($this->keeperAddresses() as $request) {
+            $reason = $this->unhealthyReason($request);
+            if ($reason !== null) {
+                $problems[] = sprintf('%s (%s)', $request, $reason);
+            }
+        }
+
+        if (empty($problems)) {
+            @unlink(self::STATE_FILE);
+            return;
+        }
+
+        // Debounce against the wall clock (survives irregular polling): record
+        // when the problem was first seen, alert only once it outlasts GRACE.
+        $now = time();
+        $since = is_readable(self::STATE_FILE) ? (int)trim((string)@file_get_contents(self::STATE_FILE)) : 0;
+        if ($since <= 0) {
+            @file_put_contents(self::STATE_FILE, (string)$now);
+            return;
+        }
+        if ($now - $since < self::GRACE) {
+            return;
+        }
+
+        $this->internalMessage = sprintf(
+            gettext('CARP-VIP DHCP lease keeper problem: %s. HA failover may not work until resolved.'),
+            implode(', ', $problems)
+        );
+        $this->internalStatus = SystemStatusCode::WARNING;
+    }
+
+    /**
+     * The request address (keeper id) of every enabled keeper. keeper.conf only
+     * lists enabled, resolvable keepers, so each line is one that should be up.
+     */
+    private function keeperAddresses(): array
+    {
+        $out = [];
+        if (!is_readable(self::CONF)) {
+            return $out;
+        }
+        foreach (file(self::CONF, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+            $line = trim($line);
+            if ($line === '' || $line[0] === '#' || strpos($line, '|') === false) {
+                continue;
+            }
+            $out[] = explode('|', $line)[0];
+        }
+        return $out;
+    }
+
+    /**
+     * null if the keeper is healthy, otherwise a short reason. Mirrors the CARP
+     * service-status hook's heartbeat semantics (STANDBY / MISMATCH / bound==)
+     * and adds staleness detection for a dead or stuck daemon.
+     */
+    private function unhealthyReason(string $request): ?string
+    {
+        $hb = self::RUN_DIR . '/carpvipdhcp-' . preg_replace('/[^A-Za-z0-9]/', '_', $request) . '.hb';
+        $content = is_readable($hb) ? trim((string)@file_get_contents($hb)) : '';
+        if ($content === '') {
+            return gettext('no heartbeat');
+        }
+        $epoch = (int)explode(' ', $content)[0];
+        if ($epoch <= 0 || (time() - $epoch) > self::STALE) {
+            return gettext('daemon stalled (no fresh heartbeat)');
+        }
+        if (strpos($content, 'MISMATCH') !== false) {
+            return gettext('ISP handed a different address than the VIP');
+        }
+        if (strpos($content, 'STANDBY') !== false) {
+            return null;   // intentionally idle CARP backup, heartbeat fresh
+        }
+        if (strpos($content, 'bound=' . $request . ' ') !== false) {
+            return null;
+        }
+        return gettext('not holding the lease');
+    }
+}

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/library/OPNsense/System/Status/CarpVipDhcpStatus.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/library/OPNsense/System/Status/CarpVipDhcpStatus.php
@@ -73,8 +73,10 @@ class CarpVipDhcpStatus extends AbstractStatus
 
         // Debounce against the wall clock (survives irregular polling): record
         // when the problem was first seen, alert only once it outlasts GRACE.
+        // This also rides out the normal acquire/re-acquire window, where the
+        // keeper legitimately publishes bound=- (which reads as "not holding").
         $now = time();
-        $since = is_readable(self::STATE_FILE) ? (int)trim((string)@file_get_contents(self::STATE_FILE)) : 0;
+        $since = (int)@file_get_contents(self::STATE_FILE);   // missing file -> 0
         if ($since <= 0) {
             @file_put_contents(self::STATE_FILE, (string)$now);
             return;
@@ -97,10 +99,11 @@ class CarpVipDhcpStatus extends AbstractStatus
     private function keeperAddresses(): array
     {
         $out = [];
-        if (!is_readable(self::CONF)) {
+        $lines = @file(self::CONF, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if ($lines === false) {
             return $out;
         }
-        foreach (file(self::CONF, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+        foreach ($lines as $line) {
             $line = trim($line);
             if ($line === '' || $line[0] === '#' || strpos($line, '|') === false) {
                 continue;
@@ -118,7 +121,7 @@ class CarpVipDhcpStatus extends AbstractStatus
     private function unhealthyReason(string $request): ?string
     {
         $hb = self::RUN_DIR . '/carpvipdhcp-' . preg_replace('/[^A-Za-z0-9]/', '_', $request) . '.hb';
-        $content = is_readable($hb) ? trim((string)@file_get_contents($hb)) : '';
+        $content = trim((string)@file_get_contents($hb));   // missing file -> ''
         if ($content === '') {
             return gettext('no heartbeat');
         }


### PR DESCRIPTION
Closes the plugin's one real observability gap.

## Why
A keeper that fails to hold its lease is currently only visible on its own Status/Log page — unless `demoteOnLeaseLoss` is set, in which case CARP hands the VIP to the peer (visible). The silent case is the **redundant spare**: in the default ungated mode both nodes hold the lease, so the spare's keeper can fail with **no outage at all** — and nobody learns HA is degraded until a failover actually needs it.

## What
An OPNsense `System\Status` collector (`CarpVipDhcpStatus`) — the current pull-based notices mechanism (`file_notice()` is gone in modern core; modelled on `www/caddy` and core's `CrashReporterStatus`). It:

- reads the **heartbeat files the keeper already writes** — no daemon change, no config change, no new dependency;
- raises a **warning banner across the GUI** (`scope: ['*']`) when an enabled keeper is unhealthy — mismatch, stalled daemon (stale heartbeat), or not holding the lease;
- **auto-clears** when every keeper is healthy again (non-persistent);
- **debounces** past a grace period (300 s) so a reboot or a keeper restart does not flash a false alarm;
- health semantics mirror the CARP service-status hook (`STANDBY`/`MISMATCH`/`bound==request`) plus a staleness ceiling (600 s, safely above the largest legitimate heartbeat gap).

No config toggle: a health banner is passive/informational, and consistent with keeping toggles for environment-conflicting behaviour rather than internal robustness.

## Scope note
This is a **logged-in GUI banner**, not an email/push — that is the mechanism modern OPNsense offers plugins for this. Still a real improvement over 'only on the plugin's own tab'.

## Notes
- No Python changed, so the pytest suite is unaffected (42 passed). The collector is PHP; there is no PHP unit-test harness in this plugin (consistent with the existing controllers/models), so it relies on CI (`php -l` + PSR-12) and the verified upstream pattern.
- **Stacked on #6** — until #6 merges, this PR's diff also shows #6's commits. Merge order does not matter (no conflicting changes); merging #6 first makes this PR show only the banner delta.
- Version → **1.2.0** (new functionality); model schema unchanged (1.1.0).