### PR TITLE
feat: dashboard widget showing per-keeper status

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.2.0
+PLUGIN_VERSION=         1.3.0
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -58,6 +58,9 @@ After installing, the plugin lives under **Interfaces → Virtual IPs DHCP**, wi
   CARP demotion), per-keeper mode, and a ⚡ button to send a manual ARP nudge (on the CARP master).
 - **Log** — the keeper log (searchable/filterable, with a clear button).
 
+There is also a **Dashboard widget** ("CARP-VIP DHCP") showing one row per keeper — VIP, CARP role,
+lease state and ARP-nudge age — for an at-a-glance view without opening the Status page.
+
 The privilege that grants access is **“Interfaces: Virtual IPs DHCP”**.
 
 ## When is this relevant?

--- a/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/CarpVipDhcp.js
+++ b/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/CarpVipDhcp.js
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 Tore Amundsen
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+ * CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Dashboard widget: one row per CARP-VIP DHCP keeper (VIP, CARP role, lease
+// state, ARP-nudge age). Reuses the diagnostics status API the plugin's Status
+// page already polls; no widget-specific backend.
+export default class CarpVipDhcp extends BaseTableWidget {
+    constructor() {
+        super();
+        this.tickTimeout = 10;
+    }
+
+    getMarkup() {
+        const $container = $('<div></div>');
+        $container.append(this.createTable('carpvipdhcp-widget-table', {
+            headers: [
+                this.translations.vip || 'VIP',
+                this.translations.carp || 'CARP',
+                this.translations.lease || 'Lease',
+                this.translations.nudge || 'ARP nudge',
+            ],
+        }));
+        return $container;
+    }
+
+    async onWidgetTick() {
+        const data = await this.ajaxCall('/api/carpvipdhcp/diagnostics/status');
+        if (!data || !Array.isArray(data.keepers)) {
+            this.displayError(this.translations.error || 'Unable to load keeper status');
+            return;
+        }
+        if (data.keepers.length === 0) {
+            super.updateTable('carpvipdhcp-widget-table', [
+                [this._cell(this.translations.none || 'No keepers configured', 'text-muted'), '', '', ''],
+            ]);
+            return;
+        }
+        const rows = data.keepers.map((k) => [
+            this._vipCell(k),
+            this._carpCell(k),
+            this._leaseCell(k),
+            this._nudgeCell(k),
+        ]);
+        super.updateTable('carpvipdhcp-widget-table', rows);
+    }
+
+    // ---- cell builders (return outerHTML strings, as updateTable expects) ----
+
+    _cell(text, cls) {
+        const $s = $('<span></span>').text(text);
+        if (cls) {
+            $s.addClass(cls);
+        }
+        return $s.prop('outerHTML');
+    }
+
+    _vipCell(k) {
+        let html = this._cell(k.request);
+        if (k.vhid) {
+            html += ' ' + this._cell('vhid ' + k.vhid, 'text-muted');
+        }
+        return html;
+    }
+
+    _carpCell(k) {
+        if (!k.carp_state) {
+            return this._cell('-', 'text-muted');
+        }
+        const cls = {MASTER: 'text-success', INIT: 'text-warning'}[k.carp_state] || '';
+        return this._cell(k.carp_state, cls);
+    }
+
+    _leaseCell(k) {
+        if (!k.running) {
+            return this._cell(this.translations.stopped || 'stopped', 'text-danger');
+        }
+        if (k.mismatch) {
+            return this._cell(this.translations.mismatch || 'mismatch', 'text-danger');
+        }
+        if (k.standby) {
+            return this._cell(this.translations.standby || 'standby', 'text-muted');
+        }
+        if (k.bound && k.bound === k.request) {
+            return this._cell(this.translations.held || 'held', 'text-success');
+        }
+        return this._cell(this.translations.notheld || 'not held', 'text-warning');
+    }
+
+    _nudgeCell(k) {
+        if (!k.arp_nudge) {
+            return this._cell(this.translations.off || 'off', 'text-muted');
+        }
+        if (k.nudge_age === null || k.nudge_age === undefined) {
+            return this._cell(this.translations.never || 'never', 'text-warning');
+        }
+        return this._cell(this._fmtAge(k.nudge_age));
+    }
+
+    _fmtAge(sec) {
+        if (sec < 60) {
+            return sec + ' s';
+        }
+        if (sec < 3600) {
+            return Math.floor(sec / 60) + ' min';
+        }
+        return Math.floor(sec / 3600) + ' h';
+    }
+}

--- a/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/CarpVipDhcp.js
+++ b/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/CarpVipDhcp.js
@@ -22,21 +22,34 @@
 
 // Dashboard widget: one row per CARP-VIP DHCP keeper (VIP, CARP role, lease
 // state, ARP-nudge age). Reuses the diagnostics status API the plugin's Status
-// page already polls; no widget-specific backend.
+// page already polls; no widget-specific backend. The cell classification below
+// mirrors the Status page (status.volt leaseCell/carpStatus/nudgeCell) in a
+// simpler form -- keep the two in sync when the health rules change.
 export default class CarpVipDhcp extends BaseTableWidget {
     constructor() {
         super();
-        this.tickTimeout = 10;
+        // Keeper state moves at CARP/DHCP-lease timescales; a slower tick keeps
+        // the backend (status.py forks ifconfig/sysctl + parses config.xml) off
+        // a tight loop. The health banner, not this widget, is the alert path.
+        this.tickTimeout = 30;
+    }
+
+    getGridOptions() {
+        // Scroll inside the widget once many keepers push it past this height,
+        // instead of growing the dashboard cell unbounded.
+        return {
+            sizeToContent: 650,
+        };
     }
 
     getMarkup() {
         const $container = $('<div></div>');
         $container.append(this.createTable('carpvipdhcp-widget-table', {
             headers: [
-                this.translations.vip || 'VIP',
-                this.translations.carp || 'CARP',
-                this.translations.lease || 'Lease',
-                this.translations.nudge || 'ARP nudge',
+                this.translations.vip,
+                this.translations.carp,
+                this.translations.lease,
+                this.translations.nudge,
             ],
         }));
         return $container;
@@ -45,12 +58,12 @@ export default class CarpVipDhcp extends BaseTableWidget {
     async onWidgetTick() {
         const data = await this.ajaxCall('/api/carpvipdhcp/diagnostics/status');
         if (!data || !Array.isArray(data.keepers)) {
-            this.displayError(this.translations.error || 'Unable to load keeper status');
+            this.displayError(this.translations.error);
             return;
         }
         if (data.keepers.length === 0) {
             super.updateTable('carpvipdhcp-widget-table', [
-                [this._cell(this.translations.none || 'No keepers configured', 'text-muted'), '', '', ''],
+                [this._cell(this.translations.none, 'text-muted'), '', '', ''],
             ]);
             return;
         }
@@ -61,6 +74,10 @@ export default class CarpVipDhcp extends BaseTableWidget {
             this._nudgeCell(k),
         ]);
         super.updateTable('carpvipdhcp-widget-table', rows);
+    }
+
+    displayError(message) {
+        $('#carpvipdhcp-widget-table').empty().append($('<div></div>').text(message));
     }
 
     // ---- cell builders (return outerHTML strings, as updateTable expects) ----
@@ -91,26 +108,26 @@ export default class CarpVipDhcp extends BaseTableWidget {
 
     _leaseCell(k) {
         if (!k.running) {
-            return this._cell(this.translations.stopped || 'stopped', 'text-danger');
+            return this._cell(this.translations.stopped, 'text-danger');
         }
         if (k.mismatch) {
-            return this._cell(this.translations.mismatch || 'mismatch', 'text-danger');
+            return this._cell(this.translations.mismatch, 'text-danger');
         }
         if (k.standby) {
-            return this._cell(this.translations.standby || 'standby', 'text-muted');
+            return this._cell(this.translations.standby, 'text-muted');
         }
         if (k.bound && k.bound === k.request) {
-            return this._cell(this.translations.held || 'held', 'text-success');
+            return this._cell(this.translations.held, 'text-success');
         }
-        return this._cell(this.translations.notheld || 'not held', 'text-warning');
+        return this._cell(this.translations.notheld, 'text-warning');
     }
 
     _nudgeCell(k) {
         if (!k.arp_nudge) {
-            return this._cell(this.translations.off || 'off', 'text-muted');
+            return this._cell(this.translations.off, 'text-muted');
         }
         if (k.nudge_age === null || k.nudge_age === undefined) {
-            return this._cell(this.translations.never || 'never', 'text-warning');
+            return this._cell(this.translations.never, 'text-warning');
         }
         return this._cell(this._fmtAge(k.nudge_age));
     }

--- a/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/Metadata/CarpVipDhcp.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/Metadata/CarpVipDhcp.xml
@@ -1,0 +1,24 @@
+<metadata>
+    <carpvipdhcp>
+        <filename>CarpVipDhcp.js</filename>
+        <endpoints>
+            <endpoint>/api/carpvipdhcp/diagnostics/status</endpoint>
+        </endpoints>
+        <translations>
+            <title>CARP-VIP DHCP</title>
+            <vip>VIP</vip>
+            <carp>CARP</carp>
+            <lease>Lease</lease>
+            <nudge>ARP nudge</nudge>
+            <held>held</held>
+            <notheld>not held</notheld>
+            <standby>standby</standby>
+            <mismatch>mismatch</mismatch>
+            <stopped>stopped</stopped>
+            <off>off</off>
+            <never>never</never>
+            <none>No keepers configured</none>
+            <error>Unable to load keeper status</error>
+        </translations>
+    </carpvipdhcp>
+</metadata>


### PR DESCRIPTION
Adds a **Dashboard widget** ("CARP-VIP DHCP") — an at-a-glance view of keeper health without opening the Status page.

## What
One row per keeper: **VIP + vhid, CARP role, lease state, ARP-nudge age**, refreshed on the widget tick (10 s).

## How (new BaseWidget dashboard system)
- `src/opnsense/www/js/widgets/CarpVipDhcp.js` — `class CarpVipDhcp extends BaseTableWidget`, fetches via the inherited `ajaxCall` on `onWidgetTick`.
- `src/opnsense/www/js/widgets/Metadata/CarpVipDhcp.xml` — registration (auto-discovered by the dashboard's `Metadata/*.xml` glob; no Makefile/registry edit).
- **Reuses the existing `api/carpvipdhcp/diagnostics/status` endpoint** the Status page already polls — no backend, no new endpoint, no ACL change (the `<endpoint>` in the metadata is the ACL-visibility gate, already covered by `api/carpvipdhcp/*`).
- Cell colours use the same Bootstrap status classes (`text-success`/`text-warning`/`text-danger`/`text-muted`) the Status page uses.

Modelled on the verified upstream pattern (`sysutils/dmidecode`, core `Carp.js`, `BaseTableWidget`).

## Notes / honest limits
- This is the plugin's **first JS file**; the repo's CI has no JS linter, so the widget is not lint-tested. Syntax was validated locally (`node --check`) and the code follows the verified `BaseTableWidget` contract, but final validation is visual on a live dashboard.
- Python suite unaffected (42 passed); XML metadata is well-formed.
- Version → **1.3.0** (new functionality); model schema unchanged.