### PR TITLE
feat: wall-clock times + newest-first log; flag stale heartbeat on status

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.3.1
+PLUGIN_VERSION=         1.3.2
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/Api/DiagnosticsController.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/Api/DiagnosticsController.php
@@ -43,10 +43,14 @@ class DiagnosticsController extends ApiControllerBase
                 return isset($record['level']) && $record['level'] === $level;
             };
         }
+        // No default sort key: searchRecordsetBase only ever sorts ascending on
+        // its default, which would show the log oldest-first until the user
+        // clicks a header. Passing null keeps logparse.py's newest-first order on
+        // the first load; a header click still sorts either way.
         return $this->searchRecordsetBase(
             $records,
             ['timestamp', 'keeper', 'vhid', 'level', 'message'],
-            'timestamp',
+            null,
             $filter_funct
         );
     }

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
@@ -18,6 +18,18 @@
         return (value === null || value === undefined || value === '') ? '-' : value;
     }
 
+    // Matches the health banner's staleness ceiling: a keeper rewrites its
+    // heartbeat every ~30s, so an age past this means a stalled/dead daemon.
+    const STALE_MAX_AGE = 600;
+
+    function hbAgeCell(age) {
+        if (age === null || age === undefined) {
+            return '<span class="text-muted">-</span>';
+        }
+        let cls = age > STALE_MAX_AGE ? ' class="text-danger"' : '';
+        return '<span' + cls + '>' + fmtAge(age) + '</span>';
+    }
+
     function vhidBadge(k) {
         if (!k.vhid) {
             return '';
@@ -139,7 +151,7 @@
                     + '<td>' + carpStatus(k.carp_state) + '</td>'
                     + '<td>' + badge(k.running === true) + '</td>'
                     + '<td>' + leaseCell(k) + '</td>'
-                    + '<td>' + fmtAge(k.hb_age) + '</td>'
+                    + '<td>' + hbAgeCell(k.hb_age) + '</td>'
                     + '<td>' + leaseTimeCell(k) + '</td>'
                     + '<td>' + nudgeCell(k) + '</td>'
                     + '<td>' + dash(k.chaddr) + '</td>'

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -410,6 +410,12 @@ class Keeper:
         src = "server" if (self.t1_server or self.t2_server) else "derived"
         return t1, t2, src
 
+    def _clock(self, offset):
+        """Local wall-clock HH:MM of a moment `offset` seconds from now. Log
+        lines state future moments (renew/rebind/lease expiry) as relative
+        durations; the clock time saves the reader the mental arithmetic."""
+        return time.strftime("%H:%M", time.localtime(time.time() + offset))
+
     def _write_hb(self, content):
         # Write atomically (temp + rename) so a crash mid-write can't leave a partial file.
         if not self.hbfile:
@@ -749,7 +755,8 @@ class Keeper:
             self._ensure_sniffer()  # a dead sniffer would silently fail every DORA
             self._hb()  # active but not holding yet -> publish bound=- (not STANDBY)
             if self.dora():
-                LOG.info("DHCP BOUND %s (lease=%ss, server=%s)", self.yiaddr, self.lease, self.server)
+                LOG.info("DHCP BOUND %s (lease=%ss, expires ~%s, server=%s)",
+                         self.yiaddr, self.lease, self._clock(self.lease), self.server)
                 self._hb()
                 self._arp_nudge(force=True)
                 self.redora_wait = REDORA_MIN
@@ -760,12 +767,13 @@ class Keeper:
             return
         # Maintain: wait until T1, then RENEW; bail early on stop or master loss.
         t1, t2, src = self._timing()
-        LOG.info("DHCP lease %ds; renew at T1=%ds, rebind by T2=%ds (timing source: %s)",
-                 self.lease, t1, t2, src)
+        LOG.info("DHCP lease %ds; renew at T1=%ds (~%s), rebind by T2=%ds (~%s) (timing source: %s)",
+                 self.lease, t1, self._clock(t1), t2, self._clock(t2), src)
         if not self._hold(t1):
             return
         if self.renew():
-            LOG.info("DHCP RENEW ok %s (lease=%ss)", self.yiaddr, self.lease)
+            LOG.info("DHCP RENEW ok %s (lease=%ss, expires ~%s)",
+                     self.yiaddr, self.lease, self._clock(self.lease))
             self._hb()
             self._arp_nudge(force=True)
             return
@@ -782,7 +790,8 @@ class Keeper:
                 ok = True
                 break
         if ok:
-            LOG.info("DHCP REBIND ok %s", self.yiaddr)
+            LOG.info("DHCP REBIND ok %s (lease=%ss, expires ~%s)",
+                     self.yiaddr, self.lease, self._clock(self.lease))
             self._hb()
             self._arp_nudge(force=True)
             return


### PR DESCRIPTION
Log and status readability. Three small, related improvements.

## Log: wall-clock times
Every log line that states a future moment as a relative duration now also shows the local clock time, so you do not have to do the arithmetic when reading the log after the fact:
- `DHCP lease 7200s; renew at T1=3600s (~21:32), rebind by T2=6300s (~22:06) (timing source: derived)`
- `DHCP BOUND 1.2.3.4 (lease=7200s, expires ~14:30, server=1.2.3.1)` — same on RENEW / REBIND.

Via a small `_clock()` helper.

## Log page: newest-first by default
The log grid showed **oldest-first** until you clicked a header. Root cause: `searchRecordsetBase` only ever sorts *ascending* on its default key, and the controller passed `'timestamp'` as that default — overriding `logparse.py`'s newest-first pre-sort (whose own comment says it is meant to be the default order). Pass `null` so the newest-first order survives the first load; a header click still sorts either way. Aligns the controller with the documented intent.

## Status: flag a stale heartbeat
The *Heartbeat age* column was plain text — a stalled keeper sat there in grey with nothing on the page raising a flag. Colour it red once the age passes the **same 600s staleness ceiling the health banner uses**, and mute a missing heartbeat, so the status page shows health at a glance and agrees visually with the banner.

## Notes
- Python suite unaffected (42 passed); `_clock` is a one-line `strftime` helper.
- **Stacked on #9** (docs, 1.3.1) — merge #9 first and this shows only its own delta; no conflicts either way.
- Version → **1.3.2** (patch).