### PR TITLE
docs(readme): fix three stale/incorrect claims

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.3.2
+PLUGIN_VERSION=         1.3.3
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -207,7 +207,7 @@ of them:
 | **Gratuitous-ARP filtering** | ignores unsolicited ARP announcements (ARP-spoofing defence) — CARP's own gratuitous ARP on failover is silently dropped | the nudge is a normal ARP **request**, which the gateway must process in order to answer; that is the one ARP path such gear reliably learns from |
 | **No re-ARP on expiry** ("secured ARP") | the gateway never broadcasts who-has for a subscriber address; an expired entry silently blackholes all downstream traffic | the periodic nudge (default 240 s, well under typical 15–20 min ARP timeouts) keeps the entry permanently fresh; becoming CARP master triggers an immediate nudge so a failover or link flap never waits out the interval |
 | **IP Source Guard (IP-only)** | drops upstream packets whose source IP is not in the binding table | the leased VIP *is* in the table — fine |
-| **IP Source Guard (strict IP+MAC)** | additionally requires the source *MAC* to match the binding | ⚠ **known limitation**: FreeBSD egresses data from a CARP VIP with the interface's *physical* MAC, not the CARP MAC. Under strict IPSG, outbound VIP traffic is dropped even though the lease and ARP are healthy. Symptom: the gateway answers ARP/pings *to* the VIP, but anything *sourced from* it never gets a reply, fresh nudge or not. There is no clean per-packet fix; the workaround is spoofing the interface MAC to equal the lease MAC (see the single-IP scenario doc) |
+| **IP Source Guard (strict IP+MAC)** | additionally requires the source *MAC* to match the binding | ⚠ **known limitation**: FreeBSD egresses data from a CARP VIP with the interface's *physical* MAC, not the CARP MAC. Under strict IPSG, outbound VIP traffic is dropped even though the lease and ARP are healthy. Symptom: the gateway answers ARP/pings *to* the VIP, but anything *sourced from* it never gets a reply, fresh nudge or not. There is no clean per-packet fix; the workaround is to spoof the WAN interface's MAC to the CARP virtual MAC (OPNsense: *Interfaces → [WAN] → Spoof MAC*) so egress uses it — messy and topology-dependent |
 | **Client identity checks** | the server only leases to a known vendor-class (opt 60), client-id (61) or hostname (12) | per-keeper DHCP request options (advanced fields) |
 | **Per-subscriber MAC / session limits** | the port accepts a limited number of source MACs or DHCP sessions | mind the budget: each node's own MAC plus the CARP MAC all appear on the ISP-facing segment. With a strict one-IP/one-MAC ISP, see [docs/single-ip-wan-carp.md](docs/single-ip-wan-carp.md) |
 
@@ -221,7 +221,6 @@ ARP nudge). This is the core reason the lease lives on the CARP MAC rather than 
 - **IPv4 DHCP only** (DHCPv6/ND out of scope for now — the ARP nudge has no IPv6 equivalent here
   either; IPv6 neighbor discovery is a separate mechanism).
 - WAN is the typical — but not required — placement.
-- You must own the MAC/reservation you keep a lease for; holding a foreign lease is an ISP violation.
 - Requires **root** (raw L2/BPF socket) and depends on **Scapy**.
 
 ### Design notes — considered and deliberately not included
@@ -232,9 +231,10 @@ ARP nudge). This is the core reason the lease lives on the CARP MAC rather than 
   rogue host on the ISP segment claiming the address is beyond what a subscriber device can police.
 - **DAI/ARP rate-limit accommodation:** access gear typically rate-limits ARP at ≥15 pps; one nudge
   per 240 s is four orders of magnitude below — no pacing logic needed.
-- **Unicast DHCP RENEW:** the keeper renews by broadcast with the broadcast flag set, and the
-  promiscuous sniffer also captures unicast replies — both server behaviours are covered without a
-  unicast sending mode.
+- **Unicast DHCP RENEW:** the keeper always sets the broadcast flag, so an RFC 2131-compliant server
+  broadcasts OFFER/ACK — which a non-promiscuous socket receives (verified on a fiber ISP). A server
+  that instead unicasts to the CARP MAC is still received on the master, whose interface accepts the
+  virtual MAC natively. Either way, no unicast sending mode is needed.
 
 ## License
 


### PR DESCRIPTION
Full accuracy pass over the plugin README. Three genuine fixes; the rest of the document holds.

1. **Drop the "you must own the MAC/reservation ... ISP violation" caveat.** Nobody "owns" a CARP virtual MAC — it is derived from the vhid, not a burned-in address you have rights to — so the line is conceptually off. It is also disproportionate: OPNsense ships MAC spoofing as a first-class GUI feature, so keeping a lease on your own CARP MAC on your own line is standard HA, not a violation. The README's opening already frames the tool that way.

2. **Rewrite the "Unicast DHCP RENEW" design note.** It still described a *promiscuous* sniffer capturing unicast replies — but the sniffer has been **non-promiscuous** since the `promisc=False` change (1.1.1). The note now states the correct reasoning: the broadcast flag makes a non-promiscuous socket sufficient (verified on a fiber ISP), and a server that unicasts to the CARP MAC is still received on the master because its interface accepts the virtual MAC natively. (Conclusion — no unicast sending mode needed — was always right; only the justification was stale.)

3. **Fix the strict-IPSG workaround cross-reference.** It pointed at `docs/single-ip-wan-carp.md` for "spoofing the interface MAC", but that doc does not mention MAC spoofing at all (verified). Point at the actual mechanism instead — OPNsense *Interfaces → [WAN] → Spoof MAC*.

Docs only, no code. Version → **1.3.3**.