### PR TITLE
os-carp-vip-dhcp: document update/uninstall, install.sh reports install vs update, small cleanups

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
 #
-# One-line installer for a toreamun/opnsense-plugins plugin on OPNsense.
+# One-line installer / updater for a toreamun/opnsense-plugins plugin on OPNsense.
 #
 # Resolves the LATEST signed release (no version to hard-code), verifies its
 # maintainer signature, installs the Scapy runtime dependency for this box's
 # Python, and installs the plugin. Run as root on the OPNsense box:
 #
 #   fetch -o - https://raw.githubusercontent.com/toreamun/opnsense-plugins/main/install.sh | sh
+#
+# Re-run the exact same command to UPDATE: it always fetches the current latest
+# release and reinstalls over whatever is present (see `pkg add -f` below), so a
+# fresh install and an in-place upgrade are the same one-liner. Settings live in
+# config.xml and are preserved; the plugin's post-install restarts the keepers
+# onto the new code.
 #
 # Pick a specific plugin (default: os-carp-vip-dhcp):
 #   fetch -o - .../install.sh | sh -s -- <plugin-name>
@@ -63,11 +69,23 @@ echo ">>> Installing the Scapy dependency for this box's Python..."
 pyver="$(python3 -c 'import sys; print("py3%d" % sys.version_info.minor)' 2>/dev/null || echo py313)"
 pkg install -y "${pyver}-scapy"
 
-echo ">>> Installing ${PLUGIN}..."
+# Note the currently-installed version (if any) so the final line can say
+# "installed" vs "updated". `|| true` keeps set -e happy when it is absent.
+prev="$(pkg query '%v' "${PLUGIN}" 2>/dev/null || true)"
+
+if [ -n "${prev}" ]; then verb="Updating"; else verb="Installing"; fi
+echo ">>> ${verb} ${PLUGIN}..."
 # -f so the verified release is (re)installed even when an older/other build is
 # already present -- i.e. the one-liner also upgrades. The Scapy dependency was
 # installed just above (set -e aborts otherwise), so it is present.
 pkg add -f "${WORK}/${pkgfile}"
+new="$(pkg query '%v' "${PLUGIN}" 2>/dev/null || true)"
 
-echo ">>> Done. ${PLUGIN} installed and signature-verified."
+if [ -z "${prev}" ]; then
+    echo ">>> Done. ${PLUGIN} ${new:+${new} }installed and signature-verified."
+elif [ "${prev}" = "${new}" ]; then
+    echo ">>> Done. ${PLUGIN} reinstalled at ${new} (signature-verified)."
+else
+    echo ">>> Done. ${PLUGIN} updated ${prev} -> ${new} (signature-verified)."
+fi
 echo "    (os-carp-vip-dhcp: find it in the GUI under Interfaces > Virtual IPs DHCP.)"

--- a/install.sh
+++ b/install.sh
@@ -82,10 +82,11 @@ pkg add -f "${WORK}/${pkgfile}"
 new="$(pkg query '%v' "${PLUGIN}" 2>/dev/null || true)"
 
 if [ -z "${prev}" ]; then
-    echo ">>> Done. ${PLUGIN} ${new:+${new} }installed and signature-verified."
+    detail="installed"
 elif [ "${prev}" = "${new}" ]; then
-    echo ">>> Done. ${PLUGIN} reinstalled at ${new} (signature-verified)."
+    detail="reinstalled at ${new}"
 else
-    echo ">>> Done. ${PLUGIN} updated ${prev} -> ${new} (signature-verified)."
+    detail="updated ${prev} -> ${new}"
 fi
+echo ">>> Done. ${PLUGIN} ${detail} and signature-verified."
 echo "    (os-carp-vip-dhcp: find it in the GUI under Interfaces > Virtual IPs DHCP.)"

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -6,7 +6,7 @@
 [![License: BSD-2-Clause](https://img.shields.io/badge/license-BSD--2--Clause-blue)](../../LICENSE)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-donate-ffdd00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/toreamun)
 
-## Installing
+## Installing &amp; updating
 
 On the OPNsense box, as **root**, run the installer. It resolves the latest signed
 release, **verifies its maintainer signature**, installs the Scapy dependency for
@@ -16,8 +16,28 @@ your box's Python, and installs the plugin:
 fetch -o - https://raw.githubusercontent.com/toreamun/opnsense-plugins/main/install.sh | sh
 ```
 
-The plugin then appears under **Interfaces → Virtual IPs DHCP**. Remove it with
-`pkg delete os-carp-vip-dhcp` (the Scapy dependency is left in place).
+**Re-run the exact same command to update.** It never hard-codes a version — it
+always fetches the current latest signed release and reinstalls over whatever is
+present, so install and in-place upgrade are the same one-liner. Your settings
+live in `config.xml` and are preserved, and the keeper daemons are restarted onto
+the new code automatically. The command prints whether it installed or updated
+(e.g. `updated 1.3.3 -> 1.3.4`).
+
+The plugin then appears under **Interfaces → Virtual IPs DHCP**.
+
+### Uninstalling
+
+Remove it with `pkg delete`:
+
+```sh
+pkg delete os-carp-vip-dhcp
+```
+
+That is all you need — the package's deinstall hooks stop the keeper daemons
+(so none is left orphaned renewing a lease or holding the node CARP-demoted) and
+remove the files it generated. The Scapy dependency is left in place, since other
+things may use it; remove it by hand with `pkg delete py313-scapy` if you want.
+Per-keeper log files are kept for post-mortem.
 
 <details>
 <summary>Manual install (step by step, no script)</summary>

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -124,11 +124,9 @@ carpvipdhcp_stop()
 
 carpvipdhcp_restart()
 {
-    if [ -n "${svc_id}" ]; then
-        carpvipdhcp_stop_id "${svc_id}"
-    else
-        carpvipdhcp_stop
-    fi
+    # Both stop and start already honour svc_id (one keeper vs. all), so there is
+    # no need to re-branch here.
+    carpvipdhcp_stop
     carpvipdhcp_start
 }
 


### PR DESCRIPTION
Follow-up to #12 (these two commits were pushed after #12 had already merged, so they never reached `main`).

### Docs: update + uninstall, and honest installer output
- `install.sh` now records the installed version before/after `pkg add -f` and reports `installed`, `reinstalled at X`, or `updated X -> Y` instead of always claiming "installed"; the progress line says `Installing` vs `Updating`. Header comment states the one-liner also upgrades in place.
- `README.md`: retitled **Installing & updating**; documents that re-running the same command updates in place (version never hard-coded, settings in `config.xml` preserved, keepers restarted onto new code), and adds an **Uninstalling** section for `pkg delete` (the deinstall hooks stop the daemons and remove generated files; Scapy is left in place; logs kept for post-mortem).

No separate uninstall script: `pkg delete` is already a one-liner and the real cleanup lives in the package's deinstall hooks, so a remote `fetch|sh` uninstaller would only wrap one command while adding a destructive pipe-to-root habit.

### Cleanups (no behaviour change)
- `rc.d/carpvipdhcp`: `carpvipdhcp_restart` re-branched on `svc_id`, but `stop` and `start` already honour it (one keeper vs. all), so restart just calls stop then start.
- `install.sh`: fold the three-way done-message into one `detail` string + a single `echo`, dropping the cryptic `${new:+${new} }` expansion.