### PR TITLE
os-carp-vip-dhcp: match CARP Status badge in widget; log level filter on action-bar row (1.3.5)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.3.4
+PLUGIN_VERSION=         1.3.5
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/log.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/log.volt
@@ -36,10 +36,14 @@
             }
         });
 
-        // Move the clear-log button into the grid's action bar so it sits on the
-        // same row as the refresh / rowcount / columns / export icons instead of
-        // on a line of its own (core Diagnostics/log.volt pattern).
-        $("#command-wrapper").detach().appendTo("#grid-log-header .actionBar");
+        // Move the level filter and clear-log button into the grid's action bar
+        // so they share the row with the search / refresh / rowcount / columns /
+        // export icons instead of sitting on a line of their own (core
+        // Diagnostics/log.volt pattern). The level filter goes to the left of the
+        // bar, the clear button to the right with the other command icons.
+        let actionBar = $("#grid-log-header .actionBar");
+        $("#level-wrapper").detach().prependTo(actionBar);
+        $("#command-wrapper").detach().appendTo(actionBar);
 
         $("#level_filter").change(function () {
             $("#grid-log").bootgrid('reload');
@@ -62,8 +66,10 @@
 </script>
 
 <div class="content-box">
-    <div class="col-sm-12" style="padding: 1em 1em 0 1em;">
-        <label for="level_filter">
+    <!-- Action-bar controls. Hidden here to avoid a flash on their own line; the
+         script relocates them into the bootgrid action bar once it is built. -->
+    <div id="log-controls" style="display: none;">
+        <label id="level-wrapper" for="level_filter" style="margin: 0 1em 0 0;">
             <strong>{{ lang._('Level') }}:</strong>
             <select id="level_filter" class="form-control" style="display: inline-block; width: auto;">
                 <option value="DEBUG">{{ lang._('Debug (all)') }}</option>

--- a/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/CarpVipDhcp.js
+++ b/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/CarpVipDhcp.js
@@ -90,11 +90,16 @@ export default class CarpVipDhcp extends BaseTableWidget {
         return html;
     }
 
-    // A coloured MASTER/BACKUP pill, matching the built-in CARP Status widget.
+    // MASTER/BACKUP pill using the exact same markup as the built-in CARP Status
+    // widget (badge badge-pill carp-status-icon, green when master) so the same
+    // state reads identically across both dashboard widgets.
     _carpBadge(k) {
-        const cls = {MASTER: 'label-success', INIT: 'label-warning'}[k.carp_state] || 'label-default';
-        return $('<span></span>').addClass('label').addClass(cls)
-            .text(k.carp_state || '-').prop('outerHTML');
+        const state = k.carp_state || '-';
+        const $b = $('<span></span>').addClass('badge badge-pill carp-status-icon').text(state);
+        if (state === 'MASTER') {
+            $b.css('background-color', 'green');
+        }
+        return $b.prop('outerHTML');
     }
 
     _leaseText(k) {


### PR DESCRIPTION
Two small GUI-consistency fixes reported from the dashboard/log screenshots.

### Widget badge matches the CARP Status widget
The keeper's CARP state badge was rendered as a rectangular Bootstrap label (`label label-success`) — a different **shape and green shade** than the built-in **CARP Status** widget, which uses a pill for the very same MASTER/BACKUP state. Now uses the identical markup the core widget uses:

```html
<span class="badge badge-pill carp-status-icon" style="background-color: green">MASTER</span>
```

green for MASTER, the shared `carp-status-icon` default otherwise — so the same state reads identically across both widgets.

### Log level filter shares the action-bar row
The **Level** filter sat alone on its own line above the grid while the search box and the refresh / rowcount / columns / export / clear icons were on the action-bar row below it. The filter is now relocated into the bootgrid action bar (left of the search), on the same row as those icons — matching where the clear button already moved. It is defined hidden and moved in after the grid builds, to avoid a flash on its own line.

`PLUGIN_VERSION` → **1.3.5**.