### PR TITLE
os-carp-vip-dhcp: listen for the gateway's ARP reply (reachability + unanswered-nudge warning) (1.3.6)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.3.5
+PLUGIN_VERSION=         1.3.6
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -85,8 +85,9 @@ Then find it under **Interfaces → Virtual IPs DHCP**.
 After installing, the plugin lives under **Interfaces → Virtual IPs DHCP**, with three pages:
 
 - **Settings** — the keeper table (add / edit / enable keepers).
-- **Status** — effective configuration + runtime (bound lease, heartbeat age, ARP nudge age/target,
-  CARP demotion), per-keeper mode, and a ⚡ button to send a manual ARP nudge (on the CARP master).
+- **Status** — effective configuration + runtime (bound lease, heartbeat age, ARP nudge age/target and
+  whether the gateway has confirmed it, CARP demotion), per-keeper mode, and a ⚡ button to send a
+  manual ARP nudge (on the CARP master).
 - **Log** — the keeper log (searchable/filterable, with a clear button).
 
 There is also a **Dashboard widget** ("CARP-VIP DHCP") showing one row per keeper — VIP, CARP role,
@@ -177,6 +178,14 @@ OPNsense CARP answers ARP + egresses data as usual. The VIP becomes failover-cap
   role poll as a fallback if the signal is ever missed. A **manual nudge** is also available for
   troubleshooting: the ⚡ button on the status page (shown on the CARP master), or `kill -USR1` on the
   keeper daemon — it fires within a second and shows up in the log.
+  The keeper also **listens for the gateway's ARP reply** to each nudge as a reachability signal: the
+  Status page and dashboard widget show when the gateway last confirmed reachability (a green check),
+  and if several consecutive nudges go **unanswered** — the sign a carrier is dropping them (DAI / DHCP
+  snooping) — the keeper logs a warning and the Status page flags it. This capture needs no promiscuous
+  mode: the CARP master already accepts the VIP's virtual MAC, so the unicast reply reaches the socket.
+  If a particular NIC drops frames for a non-primary unicast MAC and the reply is never seen, an
+  advanced **“ARP listen in promiscuous mode”** toggle (default off) is the fallback — it makes the
+  daemon receive all traffic on the segment, so it warns when enabled and should stay off unless needed.
 - **Self-healing:** the daemon never exits on a transient DHCP/interface fault — it catches errors, keeps
   its heartbeat fresh (so CARP does not falsely demote the node) and retries.
 - **Health banner:** if an enabled keeper stops holding its lease — mismatch, a stalled daemon, or a

--- a/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
@@ -26,7 +26,7 @@ _id()
 }
 
 now=$(date +%s)
-while IFS='|' read -r request iface chaddr demote vhid runmaster follow vendorclass clientid hostname arpnudge || [ -n "${request}" ]; do
+while IFS='|' read -r request iface chaddr demote vhid runmaster follow vendorclass clientid hostname arpnudge arplistenpromisc || [ -n "${request}" ]; do
     [ -n "${request}" ] || continue
     case "${request}" in \#*) continue ;; esac
     [ "${demote}" = "1" ] || continue

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -7,7 +7,7 @@
 # rc(8) wrapper for the CARP-VIP DHCP lease keepers (lease-keeper.py).
 # Reads /usr/local/etc/carpvipdhcp/keeper.conf (rendered by the configd template):
 # one line per enabled keeper ->
-#   REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|RUN_ONLY_ON_MASTER|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE.
+#   REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|RUN_ONLY_ON_MASTER|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE|ARP_LISTEN_PROMISC.
 # Starts one supervised daemon per line, keyed by a filesystem-safe request-IP id.
 
 . /etc/rc.subr
@@ -35,7 +35,7 @@ carpvipdhcp_start()
 {
     [ -f "${conf}" ] || { echo "no config"; return 0; }
     count=0
-    while IFS='|' read -r request iface chaddr demote vhid runmaster follow vendorclass clientid hostname arpnudge || [ -n "${request}" ]; do
+    while IFS='|' read -r request iface chaddr demote vhid runmaster follow vendorclass clientid hostname arpnudge arplistenpromisc || [ -n "${request}" ]; do
         [ -n "${request}" ] || continue
         case "${request}" in \#*) continue ;; esac
         if [ -z "${iface}" ] || [ -z "${chaddr}" ]; then
@@ -70,6 +70,8 @@ carpvipdhcp_start()
         [ -n "${clientid}" ] && set -- "$@" --client-id "${clientid}"
         [ -n "${hostname}" ] && set -- "$@" --hostname "${hostname}"
         [ -n "${arpnudge}" ] && set -- "$@" --arp-nudge "${arpnudge}"
+        # Promiscuous ARP capture is an opt-in fallback (default off).
+        [ "${arplistenpromisc}" = "1" ] && set -- "$@" --arp-listen-promisc
         # -f detach; -r supervise/restart on crash; -R 5 restart delay; -P supervisor pidfile.
         /usr/sbin/daemon -f -r -R 5 -P "${pidfile}" -t "${name}-${id}" "${keeper}" "$@"
         count=$((count + 1))

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
@@ -45,6 +45,13 @@
         <help><![CDATA[Periodically broadcast an ARP request from the VIP (with its CARP MAC) for the upstream gateway, so the gateway's ARP entry for the VIP never expires. Use when the upstream ignores gratuitous ARP and never re-ARPs an expired entry — the symptom is that traffic NATed to the VIP works right after a CARP event or DHCP exchange, then silently blackholes some minutes later (outbound packets leave, nothing returns). Only sent while this node is CARP master for the VIP. Default: 240 (on) — one broadcast ARP per interval, harmless on gateways that behave normally. Setting 0 disables the nudge entirely: the periodic nudge, the automatic nudge on CARP failover AND the manual nudge button on the status page (the early lease renew on failover is unaffected).]]></help>
     </field>
     <field>
+        <id>keeper.arpListenPromisc</id>
+        <label>ARP listen in promiscuous mode</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help><![CDATA[Fallback, default OFF. The keeper listens for the gateway's ARP reply to each nudge and shows on the Status page when the gateway last confirmed reachability; if nudges go unanswered it logs a warning. Normally the reply is captured without promiscuous mode (the CARP master already accepts the VIP's MAC). Enable this ONLY if the Status page shows the nudge is never confirmed on a bound master — some NICs drop frames addressed to a non-primary unicast MAC unless the interface is promiscuous. WARNING: promiscuous mode makes this root daemon receive ALL traffic on the segment, not just its own; leave it off unless you need it.]]></help>
+    </field>
+    <field>
         <id>keeper.chaddrOverride</id>
         <label>chaddr override</label>
         <type>text</type>

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
@@ -68,6 +68,19 @@
                 </arpNudgeInterval>
 
                 <!--
+                    Fallback: put the capture socket in promiscuous mode so the
+                    gateway's unicast ARP reply to a nudge is seen on NICs that
+                    drop frames for non-primary unicast MACs. Off by default (the
+                    CARP master already accepts the VIP MAC, so the reply normally
+                    arrives without it). Only enable if the status page shows the
+                    nudge is never confirmed; it makes the daemon see all segment
+                    traffic.
+                -->
+                <arpListenPromisc type="BooleanField">
+                    <Default>0</Default>
+                </arpListenPromisc>
+
+                <!--
                     Optional DHCP request options for ISPs that only lease when they
                     see a specific vendor-class / client-id / hostname. Empty = the
                     option is not sent. These identify the KEEPER's own DHCP client

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
@@ -121,16 +121,18 @@
             cell = '<span title="' + tip + '">' + fmtAge(k.nudge_age) + '</span>';
         }
         // Reachability: did the gateway answer the nudge? Only meaningful once we
-        // have actually nudged. A reply is the healthy signal; nudging on a bound
-        // master with no reply is the ISP-dropping symptom the daemon also warns on.
+        // have actually nudged. A reply counts as confirmation only while it is
+        // fresh (within a few nudge intervals, matching the daemon's unanswered
+        // threshold); a reply that then stops coming goes stale and flips to the
+        // warning, which is the ISP-dropping symptom the daemon also logs.
         if (k.nudge_age != null) {
-            if (k.arp_reply_age != null) {
+            if (k.arp_confirmed === true) {
                 cell += ' <span class="text-success" title="'
                     + "{{ lang._('Gateway confirmed reachable (replied to the ARP nudge)') }}"
                     + '"><i class="fa fa-check fa-fw"></i>' + fmtAge(k.arp_reply_age) + '</span>';
             } else if (k.carp_state === 'MASTER' && k.bound) {
                 cell += ' <span class="text-warning" title="'
-                    + "{{ lang._('No ARP reply from the gateway yet — it may be dropping the nudge') }}"
+                    + "{{ lang._('No recent ARP reply from the gateway — it may be dropping the nudge') }}"
                     + '"><i class="fa fa-exclamation-triangle fa-fw"></i>'
                     + "{{ lang._('no reply') }}" + '</span>';
             }

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
@@ -120,6 +120,21 @@
         } else {
             cell = '<span title="' + tip + '">' + fmtAge(k.nudge_age) + '</span>';
         }
+        // Reachability: did the gateway answer the nudge? Only meaningful once we
+        // have actually nudged. A reply is the healthy signal; nudging on a bound
+        // master with no reply is the ISP-dropping symptom the daemon also warns on.
+        if (k.nudge_age != null) {
+            if (k.arp_reply_age != null) {
+                cell += ' <span class="text-success" title="'
+                    + "{{ lang._('Gateway confirmed reachable (replied to the ARP nudge)') }}"
+                    + '"><i class="fa fa-check fa-fw"></i>' + fmtAge(k.arp_reply_age) + '</span>';
+            } else if (k.carp_state === 'MASTER' && k.bound) {
+                cell += ' <span class="text-warning" title="'
+                    + "{{ lang._('No ARP reply from the gateway yet — it may be dropping the nudge') }}"
+                    + '"><i class="fa fa-exclamation-triangle fa-fw"></i>'
+                    + "{{ lang._('no reply') }}" + '</span>';
+            }
+        }
         if (k.running === true && k.carp_state === 'MASTER') {
             cell += ' <button class="btn btn-xs btn-default nudge_now" data-id="' + k.request
                 + '" title="' + "{{ lang._('Send an ARP nudge now') }}" + '">'

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -182,8 +182,14 @@ class Keeper:
         self._last_nudge = 0.0
         self._nudge_gw = None          # last nudge target we logged (log again on change)
         self._nudge_warned = False     # warned once about a missing nudge target
-        self._last_arp_reply = 0.0     # epoch of the gateway's last ARP reply to our nudge (0 = none)
-        self._nudges_since_reply = 0   # nudges sent since the last reply (unanswered-nudge detector)
+        # ARP-reply reachability, split cleanly across threads: the sniffer thread
+        # only stamps _last_arp_reply (a lone atomic float write); everything that
+        # follows -- the "consumed up to here" bookmark, the unanswered counter and
+        # the warn latch -- is touched ONLY by the main thread (in _arp_nudge), so
+        # there is no cross-thread read-modify-write to race.
+        self._last_arp_reply = 0.0     # epoch of the gateway's last ARP reply (sniffer-written, 0 = none)
+        self._reply_seen_at = 0.0      # last _last_arp_reply the main thread has accounted for
+        self._nudges_since_reply = 0   # consecutive nudges with no new reply (unanswered detector)
         self._arp_unanswered_warned = False  # warned once about unanswered nudges (reset on a reply)
         self._was_master = None        # CARP role at the last nudge check (None = unknown yet)
         self._nudge_now = False        # operator asked for an immediate nudge (SIGUSR1)
@@ -269,8 +275,13 @@ class Keeper:
         """Record the gateway's ARP reply to our nudge as a reachability signal.
         Only the reply to OUR who-has counts: op=2 (is-at), sender = the nudge
         target gateway, target protocol address = our leased IP. Anything else on
-        the segment is ignored. Runs on the sniffer thread; sets simple fields the
-        main loop reads (int/float assignment is atomic enough for this heuristic)."""
+        the segment is ignored. Runs on the sniffer thread and does ONE thing --
+        stamp _last_arp_reply (a lone atomic write); the main thread consumes it
+        in _arp_nudge, so the counter/warn state is single-owner (no race).
+
+        The signal is advisory: an on-segment attacker could forge a reply (or
+        withhold one), so a green "reachable" is not proof. It only drives a
+        diagnostic; nothing here feeds lease/CARP/follow decisions."""
         try:
             arp = p[ARP]
             if arp.op != 2:                     # 2 = is-at (reply); requests are filtered out in BPF
@@ -280,8 +291,6 @@ class Keeper:
                 return
             if arp.psrc == gw and arp.pdst == self.yiaddr:
                 self._last_arp_reply = time.time()
-                self._nudges_since_reply = 0
-                self._arp_unanswered_warned = False
         except Exception as e:
             LOG.debug("ARP reply parse error: %s", e)
 
@@ -726,13 +735,19 @@ class Keeper:
                       hwdst="00:00:00:00:00:00", pdst=gw),
                   iface=self.iface, verbose=0)
             self._last_nudge = time.time()
-            # Reachability: _on_arp_reply zeroes this when the gateway answers. If
-            # it keeps climbing, no reply is coming back. The likely cause -- and
-            # so the hint -- depends on whether we are already listening
-            # promiscuously: if we are, promisc is not the fix (the carrier is
-            # dropping it); if we are not, that NIC may simply not surface the
-            # unicast reply. Warn once, reset on the next reply.
-            self._nudges_since_reply += 1
+            # Reachability accounting (main-thread-only; the sniffer just stamps
+            # _last_arp_reply). If a reply landed since we last looked, we are
+            # reachable -> clear the counter; otherwise this nudge went unanswered.
+            # When the count reaches the threshold, warn once. The hint depends on
+            # whether we are already promiscuous: if we are, promisc is not the fix
+            # (the carrier is dropping it); if not, that NIC may simply not surface
+            # the unicast reply.
+            if self._last_arp_reply > self._reply_seen_at:
+                self._reply_seen_at = self._last_arp_reply
+                self._nudges_since_reply = 0
+                self._arp_unanswered_warned = False
+            else:
+                self._nudges_since_reply += 1
             if (self._nudges_since_reply >= ARP_UNANSWERED_WARN
                     and not self._arp_unanswered_warned):
                 if self.arp_listen_promisc:

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -8,8 +8,10 @@ This does lease maintenance ONLY; ARP for the address and data traffic are
 handled by CARP. Optionally (--arp-nudge) it also refreshes the upstream
 gateway's ARP entry for the leased address, for gateways that ignore
 gratuitous ARP and never re-ARP an expired entry (traffic to the address
-silently blackholes until the gateway receives an ARP *request* from it).
-By default it is ungated and runs on both HA nodes for
+silently blackholes until the gateway receives an ARP *request* from it). It
+also watches for the gateway's ARP reply to that nudge as a reachability
+signal, and warns if repeated nudges go unanswered (a likely sign the carrier
+is dropping them). By default it is ungated and runs on both HA nodes for
 redundancy; opt-in run-only-on-master gating restricts it to the CARP master.
 
 Robustness:
@@ -23,13 +25,18 @@ Robustness:
     --once/--release-on-exit -- so the address is not given up needlessly.
 
 Security posture (this daemon parses untrusted WAN traffic as root):
-  * The sniffer is NOT promiscuous: requests carry the BOOTP broadcast flag so
-    the server broadcasts its replies, which reach a non-promiscuous socket --
-    the daemon never sees a neighbour's unicast traffic.
-  * The BPF filter is the next boundary: only DHCP traffic (udp port 67/68)
-    ever reaches Python; everything else is dropped in the kernel.
-  * A reply must carry our current xid and the BOOTREPLY op before any field
-    is read (see _on_dhcp_reply) -- unsolicited or replayed packets are discarded early.
+  * The sniffer is NOT promiscuous by default: DHCP requests carry the BOOTP
+    broadcast flag so the server broadcasts its replies to a non-promiscuous
+    socket, and the gateway's unicast ARP reply to a nudge reaches us because
+    the CARP master already accepts the VIP's virtual MAC (its own traffic).
+    --arp-listen-promisc is an opt-in fallback (default off) for NICs that drop
+    non-primary unicast; it widens capture to the whole segment, so it warns
+    when enabled.
+  * The BPF filter is the next boundary: only DHCP (udp port 67/68) and ARP
+    *replies* reach Python; everything else is dropped in the kernel.
+  * A DHCP reply must carry our current xid and the BOOTREPLY op before any
+    field is read (see _on_dhcp_reply); an ARP reply must come from the nudge
+    target for our leased IP (see _on_arp_reply) -- other packets are dropped early.
   * Only the handful of DHCP options the keeper needs is extracted; there is
     no full dissection of the reply's other option data (untrusted network
     input -- it came from whatever answered on the wire, e.g. a rogue or
@@ -97,6 +104,7 @@ MIN_T1 = 30                # floor for the renew timer (very short leases)
 REBIND_MARGIN = 15         # ensure T2 is at least this far past T1
 BROADCAST_FLAG = 0x8000    # BOOTP flags: ask the server to broadcast OFFER/ACK
 ARP_NUDGE_MIN = 30         # floor for --arp-nudge so a typo cannot flood the segment
+ARP_UNANSWERED_WARN = 3    # warn after this many consecutive nudges with no gateway reply
 LOG_MAX_BYTES = 512 * 1024
 LOG_BACKUPS = 3
 
@@ -151,7 +159,7 @@ class Keeper:
     def __init__(self, iface, chaddr, request_ip=None, eth_src=None,
                  hbfile=None, release_on_exit=False, only_when_master=False, vhid=None,
                  follow=False, vendor_class=None, client_id=None, hostname=None,
-                 arp_nudge=0):
+                 arp_nudge=0, arp_listen_promisc=False):
         self.iface = iface
         self.chaddr = chaddr.lower()
         self.chraw = mac2raw(chaddr)
@@ -166,10 +174,17 @@ class Keeper:
         # fresh, for gateways that ignore gratuitous ARP and never re-ARP an
         # expired entry (see the README's "ARP nudge" section for the full story).
         self.arp_nudge = max(ARP_NUDGE_MIN, arp_nudge) if arp_nudge else 0
+        # Promiscuous ARP capture: off by default (the CARP master already
+        # accepts the VIP MAC, so the unicast reply reaches a normal socket).
+        # Opt-in fallback for NICs that drop non-primary unicast MACs.
+        self.arp_listen_promisc = arp_listen_promisc
         self.router = None             # default gateway (DHCP opt 3, fallback: server_id)
         self._last_nudge = 0.0
         self._nudge_gw = None          # last nudge target we logged (log again on change)
         self._nudge_warned = False     # warned once about a missing nudge target
+        self._last_arp_reply = 0.0     # epoch of the gateway's last ARP reply to our nudge (0 = none)
+        self._nudges_since_reply = 0   # nudges sent since the last reply (unanswered-nudge detector)
+        self._arp_unanswered_warned = False  # warned once about unanswered nudges (reset on a reply)
         self._was_master = None        # CARP role at the last nudge check (None = unknown yet)
         self._nudge_now = False        # operator asked for an immediate nudge (SIGUSR1)
         self._poll_role_now = False    # a CARP transition fired -> re-check role now (SIGUSR2)
@@ -214,15 +229,17 @@ class Keeper:
                     self._sniffer.stop()
                 except Exception:
                     pass
-            # promisc=False: we set the BOOTP broadcast flag on every request, so
-            # an RFC 2131-compliant server broadcasts OFFER/ACK -- and broadcast
-            # frames reach a non-promiscuous socket. Not listening promiscuously on
-            # a WAN interface keeps this root daemon off every neighbour's traffic.
-            # The BPF filter is a second boundary, not an optimization: only DHCP
-            # reaches the Python parser at all.
+            # Non-promiscuous by default: the BOOTP broadcast flag makes the
+            # server broadcast OFFER/ACK, and the gateway's unicast ARP reply to a
+            # nudge reaches us because the CARP master already accepts the VIP's
+            # virtual MAC. arp_listen_promisc is the opt-in fallback for NICs that
+            # drop non-primary unicast (widens capture -- warned at startup).
+            # The BPF filter is a boundary, not an optimization: only DHCP and ARP
+            # *replies* (arp[6:2]=2) reach the Python parser at all.
             self._sniffer = AsyncSniffer(
-                iface=self.iface, filter="udp and (port 67 or port 68)",
-                prn=self._on_dhcp_reply, store=0, promisc=False)
+                iface=self.iface,
+                filter="(udp and (port 67 or port 68)) or (arp and arp[6:2] = 2)",
+                prn=self._on_sniff, store=0, promisc=self.arp_listen_promisc)
             self._sniffer.start()
             return True
         except Exception as e:
@@ -238,6 +255,35 @@ class Keeper:
             LOG.warning("DHCP-reply sniffer down -- (re)starting")
             self._start_sniffer()
             time.sleep(1)
+
+    def _on_sniff(self, p):
+        # One sniffer feeds two parsers; keep the DHCP and ARP concerns separate.
+        # The BPF filter already narrowed traffic to DHCP + ARP replies, so this
+        # only routes by layer -- each handler does its own validation/guarding.
+        if p.haslayer(BOOTP):
+            self._on_dhcp_reply(p)
+        elif p.haslayer(ARP):
+            self._on_arp_reply(p)
+
+    def _on_arp_reply(self, p):
+        """Record the gateway's ARP reply to our nudge as a reachability signal.
+        Only the reply to OUR who-has counts: op=2 (is-at), sender = the nudge
+        target gateway, target protocol address = our leased IP. Anything else on
+        the segment is ignored. Runs on the sniffer thread; sets simple fields the
+        main loop reads (int/float assignment is atomic enough for this heuristic)."""
+        try:
+            arp = p[ARP]
+            if arp.op != 2:                     # 2 = is-at (reply); requests are filtered out in BPF
+                return
+            gw = self._nudge_target()
+            if not gw or not self.yiaddr:
+                return
+            if arp.psrc == gw and arp.pdst == self.yiaddr:
+                self._last_arp_reply = time.time()
+                self._nudges_since_reply = 0
+                self._arp_unanswered_warned = False
+        except Exception as e:
+            LOG.debug("ARP reply parse error: %s", e)
 
     def _on_dhcp_reply(self, p):
         try:
@@ -457,10 +503,11 @@ class Keeper:
     def _hb(self):
         t1, t2, src = self._timing()
         # Publish nudge state so the status page can show it: nudge=<epoch of the
-        # last sent nudge, 0 = never> and the current target gateway (if known).
+        # last sent nudge, 0 = never>, arpok=<epoch of the gateway's last ARP reply,
+        # 0 = none seen> and the current target gateway (if known).
         extra = ""
         if self.arp_nudge:
-            extra = " nudge=%d" % int(self._last_nudge)
+            extra = " nudge=%d arpok=%d" % (int(self._last_nudge), int(self._last_arp_reply))
             gw = self._nudge_target()
             if gw:
                 extra += " gw=%s" % gw
@@ -679,6 +726,26 @@ class Keeper:
                       hwdst="00:00:00:00:00:00", pdst=gw),
                   iface=self.iface, verbose=0)
             self._last_nudge = time.time()
+            # Reachability: _on_arp_reply zeroes this when the gateway answers. If
+            # it keeps climbing, no reply is coming back. The likely cause -- and
+            # so the hint -- depends on whether we are already listening
+            # promiscuously: if we are, promisc is not the fix (the carrier is
+            # dropping it); if we are not, that NIC may simply not surface the
+            # unicast reply. Warn once, reset on the next reply.
+            self._nudges_since_reply += 1
+            if (self._nudges_since_reply >= ARP_UNANSWERED_WARN
+                    and not self._arp_unanswered_warned):
+                if self.arp_listen_promisc:
+                    hint = ("the gateway is not answering -- with promiscuous "
+                            "listening already on, the carrier is likely dropping "
+                            "the nudge (DAI/DHCP snooping)")
+                else:
+                    hint = ("the gateway may be dropping it (DAI/DHCP snooping), or "
+                            "this NIC may not surface the unicast reply without "
+                            "'ARP listen in promiscuous mode'")
+                LOG.warning("ARP nudge unanswered: %d sent to %s for %s with no reply "
+                            "-- %s", self._nudges_since_reply, gw, self.yiaddr, hint)
+                self._arp_unanswered_warned = True
             # Every fire is logged, but at the right level: the first one (and any
             # target change) at INFO so the default log shows the nudge is active;
             # the routine repeats at DEBUG, so they are there in "Debug (all)"
@@ -908,6 +975,10 @@ def main():
                     help="periodically broadcast an ARP request from the leased IP "
                          "for the gateway, so upstream gear that never re-ARPs keeps "
                          "a fresh entry (0 = off, suggested 240)")
+    ap.add_argument("--arp-listen-promisc", action="store_true",
+                    help="put the capture socket in promiscuous mode so the gateway's "
+                         "unicast ARP reply is seen on NICs that filter non-primary "
+                         "unicast MACs (default off; only needed if replies aren't seen)")
     ap.add_argument("--once", action="store_true")
     ap.add_argument("--release-on-exit", action="store_true")
     a = ap.parse_args()
@@ -934,7 +1005,12 @@ def main():
                hbfile=a.hbfile, release_on_exit=a.release_on_exit or a.once,
                only_when_master=a.only_when_master, vhid=a.vhid, follow=a.follow,
                vendor_class=a.vendor_class, client_id=a.client_id, hostname=a.hostname,
-               arp_nudge=a.arp_nudge)
+               arp_nudge=a.arp_nudge, arp_listen_promisc=a.arp_listen_promisc)
+
+    if a.arp_listen_promisc:
+        LOG.warning("ARP listen: PROMISCUOUS capture enabled on %s -- the daemon now "
+                    "sees all traffic on the segment (opt-in fallback for NICs that "
+                    "drop the gateway's unicast ARP reply otherwise)", a.iface)
 
     def _sig(*_):
         LOG.info("signal received -- stopping")

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -183,14 +183,12 @@ class Keeper:
         self._nudge_gw = None          # last nudge target we logged (log again on change)
         self._nudge_warned = False     # warned once about a missing nudge target
         # ARP-reply reachability, split cleanly across threads: the sniffer thread
-        # only stamps _last_arp_reply (a lone atomic float write); everything that
-        # follows -- the "consumed up to here" bookmark, the unanswered counter and
-        # the warn latch -- is touched ONLY by the main thread (in _arp_nudge), so
-        # there is no cross-thread read-modify-write to race.
+        # only stamps _last_arp_reply (a lone atomic float write); the "consumed up
+        # to here" bookmark and the unanswered counter are touched ONLY by the main
+        # thread (in _arp_nudge), so there is no cross-thread read-modify-write.
         self._last_arp_reply = 0.0     # epoch of the gateway's last ARP reply (sniffer-written, 0 = none)
         self._reply_seen_at = 0.0      # last _last_arp_reply the main thread has accounted for
         self._nudges_since_reply = 0   # consecutive nudges with no new reply (unanswered detector)
-        self._arp_unanswered_warned = False  # warned once about unanswered nudges (reset on a reply)
         self._was_master = None        # CARP role at the last nudge check (None = unknown yet)
         self._nudge_now = False        # operator asked for an immediate nudge (SIGUSR1)
         self._poll_role_now = False    # a CARP transition fired -> re-check role now (SIGUSR2)
@@ -738,18 +736,17 @@ class Keeper:
             # Reachability accounting (main-thread-only; the sniffer just stamps
             # _last_arp_reply). If a reply landed since we last looked, we are
             # reachable -> clear the counter; otherwise this nudge went unanswered.
-            # When the count reaches the threshold, warn once. The hint depends on
-            # whether we are already promiscuous: if we are, promisc is not the fix
-            # (the carrier is dropping it); if not, that NIC may simply not surface
-            # the unicast reply.
+            # The counter only steps +1 or resets to 0, so it lands on the threshold
+            # exactly once per streak -> warn there (no separate "warned" latch). The
+            # hint depends on whether we are already promiscuous: if we are, promisc
+            # is not the fix (the carrier is dropping it); if not, that NIC may simply
+            # not surface the unicast reply.
             if self._last_arp_reply > self._reply_seen_at:
                 self._reply_seen_at = self._last_arp_reply
                 self._nudges_since_reply = 0
-                self._arp_unanswered_warned = False
             else:
                 self._nudges_since_reply += 1
-            if (self._nudges_since_reply >= ARP_UNANSWERED_WARN
-                    and not self._arp_unanswered_warned):
+            if self._nudges_since_reply == ARP_UNANSWERED_WARN:
                 if self.arp_listen_promisc:
                     hint = ("the gateway is not answering -- with promiscuous "
                             "listening already on, the carrier is likely dropping "
@@ -760,7 +757,6 @@ class Keeper:
                             "'ARP listen in promiscuous mode'")
                 LOG.warning("ARP nudge unanswered: %d sent to %s for %s with no reply "
                             "-- %s", self._nudges_since_reply, gw, self.yiaddr, hint)
-                self._arp_unanswered_warned = True
             # Every fire is logged, but at the right level: the first one (and any
             # target change) at INFO so the default log shows the nudge is active;
             # the routine repeats at DEBUG, so they are there in "Debug (all)"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
@@ -43,6 +43,13 @@ def pid_alive(path):
         return None
 
 
+def _epoch_and_age(value):
+    """Parse a heartbeat epoch token into (epoch, age): age = now - epoch, or None
+    when the epoch is 0 ('never'). Raises ValueError on a non-integer value."""
+    epoch = int(value)
+    return epoch, (int(time.time()) - epoch if epoch else None)
+
+
 def parse_heartbeat(path):
     result = {"bound": None, "lease": None, "t1": None, "t2": None, "timing_source": None,
               "standby": False, "mismatch": False, "mismatch_got": None, "mismatch_want": None,
@@ -84,17 +91,13 @@ def parse_heartbeat(path):
         elif part.startswith("nudge="):
             # nudge=0 means "enabled but never sent yet" -> age stays None.
             try:
-                result["nudge_epoch"] = int(part.split("=", 1)[1])
-                if result["nudge_epoch"]:
-                    result["nudge_age"] = int(time.time()) - result["nudge_epoch"]
+                result["nudge_epoch"], result["nudge_age"] = _epoch_and_age(part.split("=", 1)[1])
             except ValueError:
                 pass
         elif part.startswith("arpok="):
             # arpok=0 means "no gateway ARP reply seen yet" -> age stays None.
             try:
-                result["arp_reply_epoch"] = int(part.split("=", 1)[1])
-                if result["arp_reply_epoch"]:
-                    result["arp_reply_age"] = int(time.time()) - result["arp_reply_epoch"]
+                result["arp_reply_epoch"], result["arp_reply_age"] = _epoch_and_age(part.split("=", 1)[1])
             except ValueError:
                 pass
         elif part.startswith("gw="):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
@@ -22,6 +22,13 @@ CONFFILE = "/usr/local/etc/carpvipdhcp/keeper.conf"
 CONFIG_XML = "/conf/config.xml"
 RUN_DIR = "/var/run"
 
+# A gateway ARP reply counts as reachability confirmation only while fresh: within
+# this many nudge intervals (matching the daemon's unanswered-nudge threshold), but
+# never less than the floor (guards very short intervals). Older = stale -> the GUI
+# flags it, mirroring the daemon's "ARP nudge unanswered" warning.
+ARP_CONFIRM_INTERVALS = 3
+ARP_CONFIRM_FLOOR = 90
+
 
 def keeper_id(request_ip):
     return re.sub(r"[^A-Za-z0-9]", "_", request_ip)
@@ -173,6 +180,9 @@ def read_keepers(states, names):
             "pid": pid,
         }
         entry.update(parse_heartbeat("%s/carpvipdhcp-%s.hb" % (RUN_DIR, kid)))
+        age = entry.get("arp_reply_age")
+        entry["arp_confirmed"] = (
+            age is not None and age <= max(ARP_CONFIRM_FLOOR, arp_nudge * ARP_CONFIRM_INTERVALS))
         keepers.append(entry)
     return keepers
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
@@ -8,7 +8,7 @@ pidfile and heartbeat file. Output:
 
 The heartbeat file is written by lease-keeper.py in one of two forms:
     <epoch> bound=<ip> lease=<seconds> t1=<seconds> t2=<seconds> src=<server|derived>
-            [nudge=<epoch|0> [gw=<ip>]]
+            [nudge=<epoch|0> arpok=<epoch|0> [gw=<ip>]]
     <epoch> MISMATCH got=<ip> want=<ip>
 """
 import json
@@ -39,7 +39,8 @@ def pid_alive(path):
 def parse_heartbeat(path):
     result = {"bound": None, "lease": None, "t1": None, "t2": None, "timing_source": None,
               "standby": False, "mismatch": False, "mismatch_got": None, "mismatch_want": None,
-              "hb_epoch": None, "hb_age": None, "nudge_epoch": None, "nudge_age": None, "gw": None}
+              "hb_epoch": None, "hb_age": None, "nudge_epoch": None, "nudge_age": None, "gw": None,
+              "arp_reply_epoch": None, "arp_reply_age": None}
     try:
         raw = open(path).read().strip()
     except OSError:
@@ -79,6 +80,14 @@ def parse_heartbeat(path):
                 result["nudge_epoch"] = int(part.split("=", 1)[1])
                 if result["nudge_epoch"]:
                     result["nudge_age"] = int(time.time()) - result["nudge_epoch"]
+            except ValueError:
+                pass
+        elif part.startswith("arpok="):
+            # arpok=0 means "no gateway ARP reply seen yet" -> age stays None.
+            try:
+                result["arp_reply_epoch"] = int(part.split("=", 1)[1])
+                if result["arp_reply_epoch"]:
+                    result["arp_reply_age"] = int(time.time()) - result["arp_reply_epoch"]
             except ValueError:
                 pass
         elif part.startswith("gw="):

--- a/net/os-carp-vip-dhcp/src/opnsense/service/templates/OPNsense/CarpVipDhcp/keeper.conf
+++ b/net/os-carp-vip-dhcp/src/opnsense/service/templates/OPNsense/CarpVipDhcp/keeper.conf
@@ -1,7 +1,7 @@
 {#
     Rendered keeper table for lease-keeper.py (one line per enabled keeper).
 
-    Format per line:  REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|RUN_ONLY_ON_MASTER|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE
+    Format per line:  REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|RUN_ONLY_ON_MASTER|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE|ARP_LISTEN_PROMISC
     Everything is derived from each keeper's referenced CARP VirtualIP: we look
     the VIP up in the legacy virtualip list to get its interface (-> physical
     device) and VHID (-> chaddr 00:00:5e:00:01:VHID). chaddrOverride wins when set.
@@ -26,7 +26,7 @@
 {%       set chaddr = '' %}
 {%     endif %}
 {%     if vip.iface and chaddr %}
-{{ k.carpVip }}|{{ vip.iface }}|{{ chaddr }}|{{ k.demoteOnLeaseLoss|default('0') }}|{{ vip.vhid }}|{{ k.runOnlyOnMaster|default('0') }}|{{ k.followIp|default('0') }}|{{ k.vendorClass|default('') }}|{{ k.clientId|default('') }}|{{ k.hostname|default('') }}|{{ k.arpNudgeInterval|default('0') }}
+{{ k.carpVip }}|{{ vip.iface }}|{{ chaddr }}|{{ k.demoteOnLeaseLoss|default('0') }}|{{ vip.vhid }}|{{ k.runOnlyOnMaster|default('0') }}|{{ k.followIp|default('0') }}|{{ k.vendorClass|default('') }}|{{ k.clientId|default('') }}|{{ k.hostname|default('') }}|{{ k.arpNudgeInterval|default('0') }}|{{ k.arpListenPromisc|default('0') }}
 {%     endif %}
 {%   endif %}
 {% endfor %}

--- a/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/CarpVipDhcp.js
+++ b/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/CarpVipDhcp.js
@@ -130,9 +130,28 @@ export default class CarpVipDhcp extends BaseTableWidget {
         return this._cell(this.translations.nudge + ' ' + val, 'text-muted');
     }
 
+    // Compact reachability glyph next to the nudge age: a check once the gateway
+    // has replied to a nudge, a warning when a bound master's nudges go
+    // unanswered. Mirrors the Status page; icon-only to keep the widget row narrow.
+    _arpReplyGlyph(k) {
+        if (!k.arp_nudge || k.nudge_age === null || k.nudge_age === undefined) {
+            return '';
+        }
+        if (k.arp_reply_age !== null && k.arp_reply_age !== undefined) {
+            return ' <i class="fa fa-check text-success" title="'
+                + this.translations.arpok + '"></i>';
+        }
+        if (k.carp_state === 'MASTER' && k.bound) {
+            return ' <i class="fa fa-exclamation-triangle text-warning" title="'
+                + this.translations.arpnoreply + '"></i>';
+        }
+        return '';
+    }
+
     _statusValue(k) {
         const sep = ' <span class="text-muted">·</span> ';
-        return this._carpBadge(k) + ' ' + this._leaseText(k) + sep + this._nudgeText(k);
+        return this._carpBadge(k) + ' ' + this._leaseText(k) + sep
+            + this._nudgeText(k) + this._arpReplyGlyph(k);
     }
 
     _fmtAge(sec) {

--- a/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/CarpVipDhcp.js
+++ b/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/CarpVipDhcp.js
@@ -130,14 +130,15 @@ export default class CarpVipDhcp extends BaseTableWidget {
         return this._cell(this.translations.nudge + ' ' + val, 'text-muted');
     }
 
-    // Compact reachability glyph next to the nudge age: a check once the gateway
-    // has replied to a nudge, a warning when a bound master's nudges go
-    // unanswered. Mirrors the Status page; icon-only to keep the widget row narrow.
+    // Compact reachability glyph next to the nudge age: a check while the gateway
+    // is confirming nudges (a fresh reply), a warning when a bound master's nudges
+    // go unanswered (a reply that stops coming goes stale). Mirrors the Status
+    // page; icon-only to keep the widget row narrow.
     _arpReplyGlyph(k) {
         if (!k.arp_nudge || k.nudge_age === null || k.nudge_age === undefined) {
             return '';
         }
-        if (k.arp_reply_age !== null && k.arp_reply_age !== undefined) {
+        if (k.arp_confirmed === true) {
             return ' <i class="fa fa-check text-success" title="'
                 + this.translations.arpok + '"></i>';
         }

--- a/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/Metadata/CarpVipDhcp.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/www/js/widgets/Metadata/CarpVipDhcp.xml
@@ -14,6 +14,8 @@
             <stopped>stopped</stopped>
             <off>off</off>
             <never>never</never>
+            <arpok>gateway confirmed reachable (replied to the ARP nudge)</arpok>
+            <arpnoreply>no ARP reply from the gateway yet — it may be dropping the nudge</arpnoreply>
             <none>No keepers configured</none>
             <error>Unable to load keeper status</error>
         </translations>

--- a/net/os-carp-vip-dhcp/tests/conftest.py
+++ b/net/os-carp-vip-dhcp/tests/conftest.py
@@ -42,8 +42,10 @@ def _stub_scapy():
         def __truediv__(self, other):
             return self
 
+    # Distinct subclasses (not one shared class) so haslayer()/p[Layer] identity
+    # checks can tell ARP from BOOTP, as they do with the real scapy layers.
     for _name in ("ARP", "Ether", "IP", "UDP", "BOOTP", "DHCP"):
-        setattr(allmod, _name, _Layer)
+        setattr(allmod, _name, type(_name, (_Layer,), {}))
     allmod.sendp = lambda *a, **k: None
     allmod.AsyncSniffer = _Sniffer
     scapy.all = allmod

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -308,14 +308,21 @@ class _ArpPkt:
         return self._arp
 
 
-def test_arp_reply_records_reachability(lk):
+def test_arp_reply_stamped_by_sniffer_consumed_on_next_nudge(lk):
     keeper = _nudge_keeper(lk)
     keeper.router = "100.64.4.254"           # nudge target = router (opt 3)
+    # Simulate a prior unanswered streak.
     keeper._nudges_since_reply = 5
     keeper._arp_unanswered_warned = True
     assert keeper._last_arp_reply == 0.0
+    # The sniffer thread only stamps the reply time -- it must NOT touch the
+    # main-thread-owned counter/warn flag (that is what keeps them race-free).
     keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.254", "100.64.4.7"))
     assert keeper._last_arp_reply > 0
+    assert keeper._nudges_since_reply == 5
+    assert keeper._arp_unanswered_warned is True
+    # The next nudge (main thread) consumes the reply and clears the streak.
+    keeper._arp_nudge(force=True)
     assert keeper._nudges_since_reply == 0
     assert keeper._arp_unanswered_warned is False
 
@@ -365,7 +372,9 @@ def test_reply_resets_unanswered_warning(lk):
     for _ in range(lk.ARP_UNANSWERED_WARN):
         keeper._arp_nudge(force=True)
     assert keeper._arp_unanswered_warned is True
+    # A reply lands (stamped by the sniffer); the next nudge consumes it and clears.
     keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
+    keeper._arp_nudge(force=True)
     assert keeper._nudges_since_reply == 0
     assert keeper._arp_unanswered_warned is False
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1,5 +1,6 @@
 """Unit tests for the lease-keeper daemon's pure helpers and follow decision."""
 import time
+import types
 
 
 def test_sane_ipv4(lk):
@@ -289,3 +290,128 @@ def test_nudge_missing_gateway_warns_once(lk, caplog):
         keeper._arp_nudge(force=True)
     warnings = [r for r in caplog.records if "no gateway known" in r.getMessage()]
     assert len(warnings) == 1        # warned, but only once
+
+
+# ---- ARP-reply listening (reachability confirmation) ----
+
+class _ArpPkt:
+    """Minimal stand-in for a scapy ARP packet: p[ARP] -> op/psrc/pdst, and
+    haslayer(ARP) so the sniffer dispatcher routes it."""
+    def __init__(self, lk, op, psrc, pdst):
+        self._lk = lk
+        self._arp = types.SimpleNamespace(op=op, psrc=psrc, pdst=pdst)
+
+    def haslayer(self, layer):
+        return layer is self._lk.ARP
+
+    def __getitem__(self, layer):
+        return self._arp
+
+
+def test_arp_reply_records_reachability(lk):
+    keeper = _nudge_keeper(lk)
+    keeper.router = "100.64.4.254"           # nudge target = router (opt 3)
+    keeper._nudges_since_reply = 5
+    keeper._arp_unanswered_warned = True
+    assert keeper._last_arp_reply == 0.0
+    keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.254", "100.64.4.7"))
+    assert keeper._last_arp_reply > 0
+    assert keeper._nudges_since_reply == 0
+    assert keeper._arp_unanswered_warned is False
+
+
+def test_arp_reply_ignores_unrelated(lk):
+    keeper = _nudge_keeper(lk)
+    keeper.router = "100.64.4.254"
+    keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.9", "100.64.4.7"))    # wrong sender
+    keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.254", "100.64.4.99"))  # wrong target IP
+    keeper._on_arp_reply(_ArpPkt(lk, 1, "100.64.4.254", "100.64.4.7"))   # a request, not a reply
+    assert keeper._last_arp_reply == 0.0
+
+
+def test_sniff_dispatch_routes_arp_reply(lk):
+    keeper = _nudge_keeper(lk)
+    keeper.router = "100.64.4.254"
+    keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.254", "100.64.4.7"))
+    assert keeper._last_arp_reply > 0
+
+
+def test_unanswered_nudges_warn_once(lk, caplog):
+    keeper = _nudge_keeper(lk)                # target = server 100.64.4.1, probe -> master
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        for _ in range(lk.ARP_UNANSWERED_WARN + 2):
+            keeper._arp_nudge(force=True)
+    warnings = [r for r in caplog.records if "unanswered" in r.getMessage()]
+    assert len(warnings) == 1
+    assert keeper._nudges_since_reply >= lk.ARP_UNANSWERED_WARN
+    # Not in promiscuous mode -> the hint should point at enabling it.
+    assert "promiscuous" in warnings[0].getMessage()
+
+
+def test_unanswered_warning_omits_promisc_hint_when_already_promisc(lk, caplog):
+    keeper = _nudge_keeper(lk, arp_listen_promisc=True)
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        for _ in range(lk.ARP_UNANSWERED_WARN):
+            keeper._arp_nudge(force=True)
+    warnings = [r for r in caplog.records if "unanswered" in r.getMessage()]
+    assert len(warnings) == 1
+    # Promisc already on -> blame the carrier, do not suggest turning promisc on.
+    assert "carrier is likely dropping" in warnings[0].getMessage()
+
+
+def test_reply_resets_unanswered_warning(lk):
+    keeper = _nudge_keeper(lk)
+    keeper.router = "100.64.4.1"
+    for _ in range(lk.ARP_UNANSWERED_WARN):
+        keeper._arp_nudge(force=True)
+    assert keeper._arp_unanswered_warned is True
+    keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
+    assert keeper._nudges_since_reply == 0
+    assert keeper._arp_unanswered_warned is False
+
+
+def test_hb_includes_arp_reply_state(lk, tmp_path):
+    hb = tmp_path / "hb"
+    keeper = _nudge_keeper(lk, hbfile=str(hb))
+    keeper.router = "100.64.4.1"
+    keeper._last_nudge = 1783350000.0
+    keeper._last_arp_reply = 1783350050.0
+    keeper._hb()
+    content = hb.read_text()
+    assert " nudge=1783350000" in content
+    assert " arpok=1783350050" in content
+
+
+def test_hb_arpok_zero_when_no_reply(lk, tmp_path):
+    hb = tmp_path / "hb"
+    keeper = _nudge_keeper(lk, hbfile=str(hb))
+    keeper._hb()
+    assert " arpok=0" in hb.read_text()
+
+
+def test_arp_listen_promisc_defaults_off(lk):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    assert keeper.arp_listen_promisc is False
+
+
+def test_sniffer_filter_captures_arp_and_honours_promisc(lk, monkeypatch):
+    captured = {}
+
+    class _Cap:
+        def __init__(self, *a, **k):
+            captured.update(k)
+            self.thread = types.SimpleNamespace(is_alive=lambda: True)
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    monkeypatch.setattr(lk, "AsyncSniffer", _Cap)
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None,
+                       arp_listen_promisc=True)
+    assert keeper._start_sniffer() is True
+    assert "arp" in captured["filter"]        # ARP replies now reach the parser
+    assert "port 67" in captured["filter"]     # ...alongside DHCP, unchanged
+    assert captured["promisc"] is True         # opt-in flag reaches the socket

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -311,20 +311,16 @@ class _ArpPkt:
 def test_arp_reply_stamped_by_sniffer_consumed_on_next_nudge(lk):
     keeper = _nudge_keeper(lk)
     keeper.router = "100.64.4.254"           # nudge target = router (opt 3)
-    # Simulate a prior unanswered streak.
-    keeper._nudges_since_reply = 5
-    keeper._arp_unanswered_warned = True
+    keeper._nudges_since_reply = 5           # simulate a prior unanswered streak
     assert keeper._last_arp_reply == 0.0
     # The sniffer thread only stamps the reply time -- it must NOT touch the
-    # main-thread-owned counter/warn flag (that is what keeps them race-free).
+    # main-thread-owned counter (that is what keeps them race-free).
     keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.254", "100.64.4.7"))
     assert keeper._last_arp_reply > 0
     assert keeper._nudges_since_reply == 5
-    assert keeper._arp_unanswered_warned is True
     # The next nudge (main thread) consumes the reply and clears the streak.
     keeper._arp_nudge(force=True)
     assert keeper._nudges_since_reply == 0
-    assert keeper._arp_unanswered_warned is False
 
 
 def test_arp_reply_ignores_unrelated(lk):
@@ -366,17 +362,21 @@ def test_unanswered_warning_omits_promisc_hint_when_already_promisc(lk, caplog):
     assert "carrier is likely dropping" in warnings[0].getMessage()
 
 
-def test_reply_resets_unanswered_warning(lk):
+def test_reply_resets_and_rearms_unanswered_warning(lk, caplog):
     keeper = _nudge_keeper(lk)
     keeper.router = "100.64.4.1"
-    for _ in range(lk.ARP_UNANSWERED_WARN):
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        for _ in range(lk.ARP_UNANSWERED_WARN):
+            keeper._arp_nudge(force=True)          # warns once, at the threshold
+        # A reply lands (stamped by the sniffer); the next nudge consumes it and clears.
+        keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
         keeper._arp_nudge(force=True)
-    assert keeper._arp_unanswered_warned is True
-    # A reply lands (stamped by the sniffer); the next nudge consumes it and clears.
-    keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
-    keeper._arp_nudge(force=True)
-    assert keeper._nudges_since_reply == 0
-    assert keeper._arp_unanswered_warned is False
+        assert keeper._nudges_since_reply == 0
+        # A fresh unanswered streak warns again -- the reset re-arms it (no latch).
+        for _ in range(lk.ARP_UNANSWERED_WARN):
+            keeper._arp_nudge(force=True)
+    warnings = [r for r in caplog.records if "unanswered" in r.getMessage()]
+    assert len(warnings) == 2
 
 
 def test_hb_includes_arp_reply_state(lk, tmp_path):

--- a/net/os-carp-vip-dhcp/tests/test_status.py
+++ b/net/os-carp-vip-dhcp/tests/test_status.py
@@ -64,6 +64,24 @@ def test_parse_heartbeat_nudge_never(tmp_path):
     assert result["gw"] is None
 
 
+def test_parse_heartbeat_arpok(tmp_path):
+    hb = tmp_path / "hb"
+    hb.write_text("1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived"
+                  " nudge=1783350700 arpok=1783350710 gw=100.64.4.1\n")
+    result = status.parse_heartbeat(str(hb))
+    assert result["arp_reply_epoch"] == 1783350710
+    assert isinstance(result["arp_reply_age"], int) and result["arp_reply_age"] > 0
+
+
+def test_parse_heartbeat_arpok_never(tmp_path):
+    hb = tmp_path / "hb"
+    hb.write_text("1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived"
+                  " nudge=1783350700 arpok=0 gw=100.64.4.1\n")
+    result = status.parse_heartbeat(str(hb))
+    assert result["arp_reply_epoch"] == 0
+    assert result["arp_reply_age"] is None
+
+
 def test_parse_heartbeat_without_nudge_tokens(tmp_path):
     hb = tmp_path / "hb"
     hb.write_text("1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived\n")

--- a/net/os-carp-vip-dhcp/tests/test_status.py
+++ b/net/os-carp-vip-dhcp/tests/test_status.py
@@ -1,4 +1,6 @@
 """Unit tests for status.py heartbeat / keeper-id parsing."""
+import time
+
 import status
 
 
@@ -93,10 +95,36 @@ def test_parse_heartbeat_without_nudge_tokens(tmp_path):
 def test_read_keepers_arp_nudge_field(tmp_path, monkeypatch):
     conf = tmp_path / "keeper.conf"
     conf.write_text(
-        "100.64.4.7|eth0|00:00:5e:00:01:fe|0|254|0|1||||240\n"
+        "100.64.4.7|eth0|00:00:5e:00:01:fe|0|254|0|1||||240|0\n"
         "100.64.4.8|eth0|00:00:5e:00:01:fd|0|253|0|1|||\n")   # old 10-field line
     monkeypatch.setattr(status, "CONFFILE", str(conf))
     monkeypatch.setattr(status, "RUN_DIR", str(tmp_path))
     keepers = status.read_keepers({}, {})
     assert keepers[0]["arp_nudge"] == 240
     assert keepers[1]["arp_nudge"] == 0
+
+
+def _write_hb(path, arpok_age, now, arp_nudge=240):
+    path.write_text(
+        "%d bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived nudge=%d arpok=%d gw=100.64.4.1\n"
+        % (now, now - 5, now - arpok_age))
+
+
+def test_read_keepers_arp_confirmed_fresh_and_stale(tmp_path, monkeypatch):
+    now = int(time.time())
+    conf = tmp_path / "keeper.conf"
+    conf.write_text(
+        "100.64.4.7|eth0|00:00:5e:00:01:fe|0|254|0|1||||240|0\n"    # fresh reply
+        "100.64.4.8|eth0|00:00:5e:00:01:fd|0|253|0|1||||240|0\n"    # stale reply
+        "100.64.4.9|eth0|00:00:5e:00:01:fc|0|252|0|1||||240|0\n")   # no reply seen
+    monkeypatch.setattr(status, "CONFFILE", str(conf))
+    monkeypatch.setattr(status, "RUN_DIR", str(tmp_path))
+    _write_hb(tmp_path / "carpvipdhcp-100_64_4_7.hb", 5, now)       # 5s ago -> fresh
+    _write_hb(tmp_path / "carpvipdhcp-100_64_4_8.hb", 5000, now)    # 5000s ago -> stale
+    (tmp_path / "carpvipdhcp-100_64_4_9.hb").write_text(
+        "%d bound=100.64.4.9 lease=1800 t1=900 t2=1575 src=derived nudge=%d arpok=0 gw=100.64.4.1\n"
+        % (now, now - 5))                                          # arpok=0 -> never
+    by_ip = {k["request"]: k for k in status.read_keepers({}, {})}
+    assert by_ip["100.64.4.7"]["arp_confirmed"] is True
+    assert by_ip["100.64.4.8"]["arp_confirmed"] is False
+    assert by_ip["100.64.4.9"]["arp_confirmed"] is False


### PR DESCRIPTION
Turns the fire-and-forget ARP nudge into a verified one. "Nudge age" only ever meant *we last sent*; now the keeper watches for the gateway's reply, so it can confirm reachability and — the real point — **detect when a carrier is silently dropping the nudge** (DAI / DHCP snooping), which fire-and-forget can never tell you.

### No promiscuous mode needed (with an opt-in fallback)
The reply is a **unicast** ARP reply to the CARP virtual MAC. On the CARP master the NIC already accepts that MAC (that is how the VIP receives any traffic at all), so a `promisc=False` BPF sniffer sees it — we only ever nudge from the master. An advanced **`--arp-listen-promisc`** toggle (default **off**, logs a warning when on) is the documented fallback for NICs that drop non-primary unicast MACs; it does not change the default "never promiscuous on WAN" posture.

### Refactor: DHCP vs ARP
One sniffer thread (shared resilient-restart; DHCP/ARP/CARP are one lease state machine), but the callback is split into a dispatcher `_on_sniff` → focused `_on_dhcp_reply` / `_on_arp_reply`. Separates the parsing concerns without duplicating the transport or re-coupling the state.

### Changes
- **Daemon:** BPF widened to DHCP + ARP replies (`arp[6:2]=2`); `_on_arp_reply` records the gateway's reply to our who-has as `_last_arp_reply` (published `arpok=` in the heartbeat); warn once after `ARP_UNANSWERED_WARN` unanswered nudges, with a promisc-aware hint (already promiscuous → blame the carrier; otherwise → suggest the fallback).
- **Wiring:** 12th `keeper.conf` field `ARP_LISTEN_PROMISC` (template, rc.d, CARP-status-hook read); model `BooleanField` + advanced form toggle (default off, with a promiscuous-mode warning in the help).
- **GUI:** Status page shows a green check + confirmed age, or a warning when a bound master's nudges go unanswered; dashboard widget shows a compact glyph.
- **Tests:** reply match/ignore, dispatcher routing, unanswered-warn-once (both hint variants), reply resets the warning, `arpok` heartbeat + `status.py` parsing, promisc plumbing. conftest scapy stub now uses distinct layer subclasses so `haslayer()`/`p[Layer]` identity works. **55 pass** (was 43); flake8 clean; shell/XML validated locally.

`PLUGIN_VERSION` → **1.3.6**.