### PR TITLE
os-carp-vip-dhcp: log the gateway's ARP reply to a nudge (1.3.7)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.3.6
+PLUGIN_VERSION=         1.3.7
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -289,6 +289,9 @@ class Keeper:
                 return
             if arp.psrc == gw and arp.pdst == self.yiaddr:
                 self._last_arp_reply = time.time()
+                # Routine confirmation at DEBUG, mirroring "ARP nudge sent"; the
+                # main thread logs the first reply / recovery at INFO.
+                LOG.debug("ARP reply from %s (is-at) for %s", gw, self.yiaddr)
         except Exception as e:
             LOG.debug("ARP reply parse error: %s", e)
 
@@ -742,6 +745,15 @@ class Keeper:
             # is not the fix (the carrier is dropping it); if not, that NIC may simply
             # not surface the unicast reply.
             if self._last_arp_reply > self._reply_seen_at:
+                # A reply arrived since the last nudge -> reachable. Log the
+                # positive transitions at INFO (first confirmation, or recovery
+                # after an unanswered streak), mirroring the nudge-active INFO and
+                # the unanswered WARNING; every individual reply is at DEBUG.
+                if self._reply_seen_at == 0.0:
+                    LOG.info("ARP nudge confirmed: %s replied for %s", gw, self.yiaddr)
+                elif self._nudges_since_reply >= ARP_UNANSWERED_WARN:
+                    LOG.info("ARP nudge answered again by %s after %d unanswered",
+                             gw, self._nudges_since_reply)
                 self._reply_seen_at = self._last_arp_reply
                 self._nudges_since_reply = 0
             else:

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -339,6 +339,43 @@ def test_sniff_dispatch_routes_arp_reply(lk):
     assert keeper._last_arp_reply > 0
 
 
+def test_arp_reply_logged_at_debug(lk, caplog):
+    keeper = _nudge_keeper(lk)
+    keeper.router = "100.64.4.1"
+    with caplog.at_level("DEBUG", logger="lease-keeper"):
+        keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
+    assert any("ARP reply from 100.64.4.1" in r.getMessage() for r in caplog.records)
+
+
+def test_first_reply_logged_confirmed_at_info(lk, caplog):
+    keeper = _nudge_keeper(lk)
+    keeper.router = "100.64.4.1"
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        keeper._arp_nudge(force=True)                                  # sent, no reply yet
+        keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
+        keeper._arp_nudge(force=True)                                  # consumes -> first confirmation
+    assert any("ARP nudge confirmed" in r.getMessage() for r in caplog.records)
+
+
+def test_reply_after_unanswered_logs_recovery_at_info(lk, caplog):
+    keeper = _nudge_keeper(lk)
+    keeper.router = "100.64.4.1"
+
+    def reply():
+        keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
+
+    # Establish confirmed reachability first (so the next event is a recovery, not a first).
+    keeper._arp_nudge(force=True)
+    reply()
+    keeper._arp_nudge(force=True)
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        for _ in range(lk.ARP_UNANSWERED_WARN):          # unanswered streak
+            keeper._arp_nudge(force=True)
+        reply()
+        keeper._arp_nudge(force=True)                    # consume -> recovery
+    assert any("answered again" in r.getMessage() for r in caplog.records)
+
+
 def test_unanswered_nudges_warn_once(lk, caplog):
     keeper = _nudge_keeper(lk)                # target = server 100.64.4.1, probe -> master
     with caplog.at_level("WARNING", logger="lease-keeper"):


### PR DESCRIPTION
The log showed `ARP nudge sent` for each fire but nothing when the gateway's reply came back — `_on_arp_reply` recorded the timestamp silently. Mirror the send-side logging so the round trip is visible:

- **DEBUG** — each matching reply (`ARP reply from <gw> for <ip>`), symmetric with the per-fire `ARP nudge sent`.
- **INFO** — the positive *transitions*: the first confirmation (`ARP nudge confirmed`) and recovery after an unanswered streak (`answered again after N unanswered`). These are the counterparts to the existing nudge-active INFO and the unanswered WARNING, so the default log view shows reachability going bad *and* coming back.

Follows the plugin's logging philosophy (transitions at INFO, routine at DEBUG) and the single-owner threading split (sniffer logs the DEBUG per-reply; the main thread logs the INFO transitions at the consume point). Tests added for all three cases; 59 pass; flake8 clean.

`PLUGIN_VERSION` → **1.3.7**.