### PR TITLE
os-carp-vip-dhcp: detect an ARP conflict on the leased IP (1.3.8)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.3.7
+PLUGIN_VERSION=         1.3.8
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -187,9 +187,9 @@ OPNsense CARP answers ARP + egresses data as usual. The VIP becomes failover-cap
   advanced **“ARP listen in promiscuous mode”** toggle (default off) is the fallback — it makes the
   daemon receive all traffic on the segment, so it warns when enabled and should stay off unless needed.
   While listening it also **flags an ARP conflict**: if another MAC is seen using the leased IP (a
-  duplicate address, or the ISP having reassigned it), the keeper logs a warning (throttled per
-  offending MAC). This is a passive, advisory check — it only warns, never acts; the peer HA node shares
-  the CARP MAC and so is never mistaken for a conflict.
+  duplicate address, or the ISP having reassigned it), the keeper logs a warning (throttled — it
+  re-warns when the offending MAC changes or at most hourly). This is a passive, advisory check — it
+  only warns, never acts; the peer HA node shares the CARP MAC and so is never mistaken for a conflict.
 - **Self-healing:** the daemon never exits on a transient DHCP/interface fault — it catches errors, keeps
   its heartbeat fresh (so CARP does not falsely demote the node) and retries.
 - **Health banner:** if an enabled keeper stops holding its lease — mismatch, a stalled daemon, or a

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -186,6 +186,10 @@ OPNsense CARP answers ARP + egresses data as usual. The VIP becomes failover-cap
   If a particular NIC drops frames for a non-primary unicast MAC and the reply is never seen, an
   advanced **“ARP listen in promiscuous mode”** toggle (default off) is the fallback — it makes the
   daemon receive all traffic on the segment, so it warns when enabled and should stay off unless needed.
+  While listening it also **flags an ARP conflict**: if another MAC is seen using the leased IP (a
+  duplicate address, or the ISP having reassigned it), the keeper logs a warning (throttled per
+  offending MAC). This is a passive, advisory check — it only warns, never acts; the peer HA node shares
+  the CARP MAC and so is never mistaken for a conflict.
 - **Self-healing:** the daemon never exits on a transient DHCP/interface fault — it catches errors, keeps
   its heartbeat fresh (so CARP does not falsely demote the node) and retries.
 - **Health banner:** if an enabled keeper stops holding its lease — mismatch, a stalled daemon, or a

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -10,9 +10,10 @@ gateway's ARP entry for the leased address, for gateways that ignore
 gratuitous ARP and never re-ARP an expired entry (traffic to the address
 silently blackholes until the gateway receives an ARP *request* from it). It
 also watches for the gateway's ARP reply to that nudge as a reachability
-signal, and warns if repeated nudges go unanswered (a likely sign the carrier
-is dropping them). By default it is ungated and runs on both HA nodes for
-redundancy; opt-in run-only-on-master gating restricts it to the CARP master.
+signal, warns if repeated nudges go unanswered (a likely sign the carrier is
+dropping them), and flags an ARP conflict if another MAC claims the leased
+address. By default it is ungated and runs on both HA nodes for redundancy;
+opt-in run-only-on-master gating restricts it to the CARP master.
 
 Robustness:
   * Full DHCP lifecycle: DORA (Discover / Offer / Request / Ack, the lease
@@ -32,8 +33,10 @@ Security posture (this daemon parses untrusted WAN traffic as root):
     --arp-listen-promisc is an opt-in fallback (default off) for NICs that drop
     non-primary unicast; it widens capture to the whole segment, so it warns
     when enabled.
-  * The BPF filter is the next boundary: only DHCP (udp port 67/68) and ARP
-    *replies* reach Python; everything else is dropped in the kernel.
+  * The BPF filter is the next boundary: only DHCP (udp port 67/68), ARP
+    *replies*, and (once bound) ARP claiming our leased IP reach Python;
+    everything else -- including the segment's broadcast who-has flood -- is
+    dropped in the kernel.
   * A DHCP reply must carry our current xid and the BOOTREPLY op before any
     field is read (see _on_dhcp_reply); an ARP reply must come from the nudge
     target for our leased IP (see _on_arp_reply) -- other packets are dropped early.
@@ -105,6 +108,7 @@ REBIND_MARGIN = 15         # ensure T2 is at least this far past T1
 BROADCAST_FLAG = 0x8000    # BOOTP flags: ask the server to broadcast OFFER/ACK
 ARP_NUDGE_MIN = 30         # floor for --arp-nudge so a typo cannot flood the segment
 ARP_UNANSWERED_WARN = 3    # warn after this many consecutive nudges with no gateway reply
+ARP_CONFLICT_REWARN = 3600  # re-warn about a persistent ARP conflict at most this often
 LOG_MAX_BYTES = 512 * 1024
 LOG_BACKUPS = 3
 
@@ -189,6 +193,11 @@ class Keeper:
         self._last_arp_reply = 0.0     # epoch of the gateway's last ARP reply (sniffer-written, 0 = none)
         self._reply_seen_at = 0.0      # last _last_arp_reply the main thread has accounted for
         self._nudges_since_reply = 0   # consecutive nudges with no new reply (unanswered detector)
+        # ARP conflict (another MAC claiming our leased IP). Detected + throttled
+        # entirely on the sniffer thread, so these are single-owner too.
+        self._sniffer_yiaddr = None    # leased IP the current sniffer filter was built for
+        self._last_conflict_warn = 0.0  # throttle for the conflict warning
+        self._conflict_mac = None       # last foreign MAC seen using our IP
         self._was_master = None        # CARP role at the last nudge check (None = unknown yet)
         self._nudge_now = False        # operator asked for an immediate nudge (SIGUSR1)
         self._poll_role_now = False    # a CARP transition fired -> re-check role now (SIGUSR2)
@@ -226,6 +235,20 @@ class Keeper:
         self._sniffer = None
 
     # ---- sniffer (resilient) ----
+    def _sniffer_filter(self):
+        # DHCP (broadcast OFFER/ACK) + ARP replies to our nudge (arp[6:2]=2). Once
+        # we hold a lease, also capture ARP whose SENDER protocol address is our
+        # leased IP (arp[14:4]) -- to spot another MAC claiming our address. The
+        # BPF filter is a boundary, not an optimization: it keeps everything else
+        # (incl. the segment's broadcast who-has flood) out of the Python parser.
+        f = "(udp and (port 67 or port 68)) or (arp and arp[6:2] = 2)"
+        try:
+            if self.yiaddr:
+                f += " or (arp and arp[14:4] = %d)" % int(ipaddress.IPv4Address(self.yiaddr))
+        except ValueError:
+            pass
+        return f
+
     def _start_sniffer(self):
         try:
             if self._sniffer:
@@ -238,11 +261,9 @@ class Keeper:
             # nudge reaches us because the CARP master already accepts the VIP's
             # virtual MAC. arp_listen_promisc is the opt-in fallback for NICs that
             # drop non-primary unicast (widens capture -- warned at startup).
-            # The BPF filter is a boundary, not an optimization: only DHCP and ARP
-            # *replies* (arp[6:2]=2) reach the Python parser at all.
+            self._sniffer_yiaddr = self.yiaddr   # what the filter below is built for
             self._sniffer = AsyncSniffer(
-                iface=self.iface,
-                filter="(udp and (port 67 or port 68)) or (arp and arp[6:2] = 2)",
+                iface=self.iface, filter=self._sniffer_filter(),
                 prn=self._on_sniff, store=0, promisc=self.arp_listen_promisc)
             self._sniffer.start()
             return True
@@ -259,6 +280,11 @@ class Keeper:
             LOG.warning("DHCP-reply sniffer down -- (re)starting")
             self._start_sniffer()
             time.sleep(1)
+        elif self.yiaddr != self._sniffer_yiaddr:
+            # Our leased IP became known (or changed) -> rebuild the filter so the
+            # conflict clause (ARP sender == our IP) tracks the current address.
+            LOG.debug("rebuilding sniffer filter for leased IP %s", self.yiaddr)
+            self._start_sniffer()
 
     def _on_sniff(self, p):
         # One sniffer feeds two parsers; keep the DHCP and ARP concerns separate.
@@ -267,7 +293,8 @@ class Keeper:
         if p.haslayer(BOOTP):
             self._on_dhcp_reply(p)
         elif p.haslayer(ARP):
-            self._on_arp_reply(p)
+            self._on_arp_reply(p)      # gateway answering our nudge (reachability)
+            self._on_arp_conflict(p)   # someone else claiming our leased IP
 
     def _on_arp_reply(self, p):
         """Record the gateway's ARP reply to our nudge as a reachability signal.
@@ -294,6 +321,33 @@ class Keeper:
                 LOG.debug("ARP reply from %s (is-at) for %s", gw, self.yiaddr)
         except Exception as e:
             LOG.debug("ARP reply parse error: %s", e)
+
+    def _on_arp_conflict(self, p):
+        """Warn if another MAC claims our leased IP -- an ARP whose sender IP is
+        ours but whose sender MAC is not our CARP MAC (the peer node shares that
+        MAC, so it is excluded). Signals a duplicate address / ISP reassignment.
+        Passive and advisory (spoofable); it only logs, never acts. Throttled per
+        offending MAC so a persistent conflict does not flood the log. Detection
+        and throttle state are touched only here (sniffer thread) -> single-owner."""
+        try:
+            if not self.yiaddr:
+                return
+            arp = p[ARP]
+            if arp.psrc != self.yiaddr:
+                return
+            mac = (arp.hwsrc or "").lower()
+            if not mac or mac == self.chaddr:   # our own / peer's CARP MAC -> not a conflict
+                return
+            now = time.time()
+            if mac == self._conflict_mac and now - self._last_conflict_warn < ARP_CONFLICT_REWARN:
+                return
+            self._conflict_mac = mac
+            self._last_conflict_warn = now
+            LOG.warning("ARP conflict: %s is using our leased IP %s (our MAC is %s) "
+                        "-- possible duplicate address or ISP reassignment",
+                        mac, self.yiaddr, self.chaddr)
+        except Exception as e:
+            LOG.debug("ARP conflict parse error: %s", e)
 
     def _on_dhcp_reply(self, p):
         try:

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -326,9 +326,11 @@ class Keeper:
         """Warn if another MAC claims our leased IP -- an ARP whose sender IP is
         ours but whose sender MAC is not our CARP MAC (the peer node shares that
         MAC, so it is excluded). Signals a duplicate address / ISP reassignment.
-        Passive and advisory (spoofable); it only logs, never acts. Throttled per
-        offending MAC so a persistent conflict does not flood the log. Detection
-        and throttle state are touched only here (sniffer thread) -> single-owner."""
+        Passive and advisory (spoofable); it only logs, never acts. Throttled so a
+        persistent conflict does not flood the log: re-warns only when the
+        offending MAC changes or after ARP_CONFLICT_REWARN (a new impostor thus
+        surfaces at once). Detection and throttle state are touched only here
+        (sniffer thread) -> single-owner."""
         try:
             if not self.yiaddr:
                 return

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -295,11 +295,11 @@ def test_nudge_missing_gateway_warns_once(lk, caplog):
 # ---- ARP-reply listening (reachability confirmation) ----
 
 class _ArpPkt:
-    """Minimal stand-in for a scapy ARP packet: p[ARP] -> op/psrc/pdst, and
+    """Minimal stand-in for a scapy ARP packet: p[ARP] -> op/psrc/pdst/hwsrc, and
     haslayer(ARP) so the sniffer dispatcher routes it."""
-    def __init__(self, lk, op, psrc, pdst):
+    def __init__(self, lk, op, psrc, pdst, hwsrc=""):
         self._lk = lk
-        self._arp = types.SimpleNamespace(op=op, psrc=psrc, pdst=pdst)
+        self._arp = types.SimpleNamespace(op=op, psrc=psrc, pdst=pdst, hwsrc=hwsrc)
 
     def haslayer(self, layer):
         return layer is self._lk.ARP
@@ -374,6 +374,49 @@ def test_reply_after_unanswered_logs_recovery_at_info(lk, caplog):
         reply()
         keeper._arp_nudge(force=True)                    # consume -> recovery
     assert any("answered again" in r.getMessage() for r in caplog.records)
+
+
+# ---- ARP conflict detection (another MAC claiming our leased IP) ----
+
+def test_arp_conflict_warns(lk, caplog):
+    keeper = _nudge_keeper(lk)                    # yiaddr=100.64.4.7, chaddr=00:00:5e:00:01:fe
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        keeper._on_arp_conflict(_ArpPkt(lk, 2, "100.64.4.7", "100.64.4.1", hwsrc="aa:bb:cc:dd:ee:ff"))
+    assert any("ARP conflict" in r.getMessage() for r in caplog.records)
+
+
+def test_arp_conflict_ignores_our_own_mac(lk, caplog):
+    keeper = _nudge_keeper(lk)
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        # Same as our CARP MAC (the peer node shares it) -> not a conflict.
+        keeper._on_arp_conflict(_ArpPkt(lk, 1, "100.64.4.7", "100.64.4.1", hwsrc="00:00:5e:00:01:fe"))
+    assert not any("ARP conflict" in r.getMessage() for r in caplog.records)
+
+
+def test_arp_conflict_ignores_other_ip(lk, caplog):
+    keeper = _nudge_keeper(lk)
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        keeper._on_arp_conflict(_ArpPkt(lk, 1, "100.64.4.99", "100.64.4.1", hwsrc="aa:bb:cc:dd:ee:ff"))
+    assert not any("ARP conflict" in r.getMessage() for r in caplog.records)
+
+
+def test_arp_conflict_throttled_per_mac(lk, caplog):
+    keeper = _nudge_keeper(lk)
+    pkt = _ArpPkt(lk, 2, "100.64.4.7", "100.64.4.1", hwsrc="aa:bb:cc:dd:ee:ff")
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        keeper._on_arp_conflict(pkt)
+        keeper._on_arp_conflict(pkt)              # same MAC within the re-warn window
+    warnings = [r for r in caplog.records if "ARP conflict" in r.getMessage()]
+    assert len(warnings) == 1
+
+
+def test_sniffer_filter_tracks_leased_ip(lk):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    assert "arp[14:4]" not in keeper._sniffer_filter()   # no lease yet -> no conflict clause
+    keeper.yiaddr = "100.64.4.7"
+    f = keeper._sniffer_filter()
+    assert "arp[6:2] = 2" in f                            # reachability clause kept
+    assert "arp[14:4]" in f                               # conflict clause added for the leased IP
 
 
 def test_unanswered_nudges_warn_once(lk, caplog):


### PR DESCRIPTION
Passive duplicate-address detection (the one additional ARP message worth handling — see the discussion on the previous PR). While the keeper listens for nudge replies, it now also flags an **ARP conflict**: another MAC using our leased IP (a duplicate address, or the ISP having reassigned the lease). That is a classic silent failure — intermittent blackholing that is otherwise very hard to pin down.

### How
- **BPF (tight):** once bound, add `arp and arp[14:4] = <leased IP>` so only ARP whose *sender* is our exact address reaches Python; the segment's broadcast who-has flood stays in the kernel. The filter is rebuilt (via `_ensure_sniffer`, tracked by `_sniffer_yiaddr`) when the leased IP becomes known or changes.
- **Detection:** `_on_arp_conflict` runs on the sniffer thread (single-owner, like the reachability path). A conflict = ARP with `psrc == our IP` and `hwsrc != our CARP MAC`. It **excludes our own CARP MAC**, so the peer HA node (which shares that MAC) is never mistaken for a conflict. Warn once per offending MAC, throttled by `ARP_CONFLICT_REWARN` (1 h).
- **Advisory only:** it logs a WARNING, never acts. Spoofable like any passive ARP signal.

### Deliberately NOT done
Answering incoming ARP for the VIP stays the kernel/CARP's job — a daemon-side responder would risk answering from a backup and stealing the VIP's traffic. This change is detection only.

Tests: warns on a foreign MAC; ignores our own MAC and other IPs; throttled per MAC; the filter tracks the leased IP. **64 pass**; flake8 clean.

`PLUGIN_VERSION` → **1.3.8**.