### PR TITLE
os-carp-vip-dhcp: log the server's NAK reason (DHCP option 56) (1.3.9)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.3.8
+PLUGIN_VERSION=         1.3.9
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -113,7 +113,10 @@ LOG_MAX_BYTES = 512 * 1024
 LOG_BACKUPS = 3
 
 # A parsed DHCP reply, snapshotted from the sniffer thread.
-DhcpReply = namedtuple("DhcpReply", "mtype yiaddr server_id lease t1 t2 router")
+# `message` (DHCP option 56) is the server's optional human-readable text, mainly
+# a NAK reason. Defaulted so existing 7-field constructions stay valid.
+DhcpReply = namedtuple("DhcpReply", "mtype yiaddr server_id lease t1 t2 router message",
+                       defaults=(None,))
 MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
 
 
@@ -230,7 +233,7 @@ class Keeper:
         self.t1_server = None          # server-provided renewal time (DHCP opt 58)
         self.t2_server = None          # server-provided rebinding time (DHCP opt 59)
         self.stop = False
-        self._rx = None                # (mtype, yiaddr, server_id, lease, t1, t2)
+        self._rx = None                # latest DhcpReply snapshot (set by the sniffer thread)
         self._ev = threading.Event()
         self._sniffer = None
 
@@ -364,7 +367,7 @@ class Keeper:
             # Extract only the fields the keeper acts on; the rest of the reply's
             # option data -- untrusted, from whatever answered on the wire -- is
             # left untouched.
-            mt = sid = lt = rt = bt = ro = None
+            mt = sid = lt = rt = bt = ro = msg = None
             for o in p[DHCP].options:
                 if isinstance(o, tuple):
                     if o[0] == "message-type":
@@ -379,7 +382,9 @@ class Keeper:
                         bt = o[1]
                     elif o[0] == "router":
                         ro = o[1]
-            self._rx = DhcpReply(mt, b.yiaddr, sid, lt, rt, bt, ro)
+                    elif o[0] == "message":     # option 56: server's text (e.g. a NAK reason)
+                        msg = o[1]
+            self._rx = DhcpReply(mt, b.yiaddr, sid, lt, rt, bt, ro, msg)
             self._ev.set()
         except Exception as e:
             LOG.debug("DHCP reply parse error: %s", e)
@@ -409,8 +414,16 @@ class Keeper:
             if rx and rx.mtype == want:
                 return rx
             if rx and rx.mtype == NAK:
-                LOG.warning("DHCPNAK received (server %s, xid 0x%08x)",
-                            rx.server_id or "unknown", self.xid)
+                # Surface the server's option-56 text (why it refused) if present;
+                # it is the operator's main clue for a rejected renew.
+                reason = ""
+                if rx.message:
+                    m = rx.message
+                    if isinstance(m, bytes):
+                        m = m.decode(errors="replace")
+                    reason = " -- %s" % str(m).strip()
+                LOG.warning("DHCPNAK received (server %s, xid 0x%08x)%s",
+                            rx.server_id or "unknown", self.xid, reason)
                 return "NAK"
         return None
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -53,6 +53,54 @@ def _ack(lk, yiaddr, server="100.64.4.1"):
     return lk.DhcpReply(5, yiaddr, server, 1800, None, None, None)
 
 
+class _DhcpPkt:
+    """Minimal stand-in for a scapy DHCP reply: p[BOOTP].xid/op/yiaddr and
+    p[DHCP].options, with haslayer() so _on_dhcp_reply parses it."""
+    def __init__(self, lk, xid, options, yiaddr="100.64.4.7"):
+        self._lk = lk
+        self._bootp = types.SimpleNamespace(xid=xid, op=lk.BOOTREPLY, yiaddr=yiaddr)
+        self._dhcp = types.SimpleNamespace(options=options)
+
+    def haslayer(self, layer):
+        return layer in (self._lk.BOOTP, self._lk.DHCP)
+
+    def __getitem__(self, layer):
+        return self._bootp if layer is self._lk.BOOTP else self._dhcp
+
+
+def test_on_dhcp_reply_captures_option56_message(lk):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    pkt = _DhcpPkt(lk, keeper.xid, [("message-type", lk.NAK), ("server_id", "100.64.4.1"),
+                                    ("message", "pool exhausted"), "end"])
+    keeper._on_dhcp_reply(pkt)
+    assert keeper._rx.message == "pool exhausted"
+
+
+def test_dhcpnak_logs_option56_reason(lk, caplog):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    keeper._rx = lk.DhcpReply(lk.NAK, None, "100.64.4.1", None, None, None, None, "lease not available")
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        assert keeper._wait_for_dhcp_reply(lk.ACK, 0.2) == "NAK"
+    nak = [r for r in caplog.records if "DHCPNAK" in r.getMessage()]
+    assert nak and "lease not available" in nak[0].getMessage()
+
+
+def test_dhcpnak_reason_bytes_decoded(lk, caplog):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    keeper._rx = lk.DhcpReply(lk.NAK, None, "100.64.4.1", None, None, None, None, b"bad chaddr")
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        keeper._wait_for_dhcp_reply(lk.ACK, 0.2)
+    assert any("bad chaddr" in r.getMessage() for r in caplog.records)
+
+
+def test_dhcpnak_without_message_still_logs(lk, caplog):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    keeper._rx = lk.DhcpReply(lk.NAK, None, "100.64.4.1", None, None, None, None)   # message defaults to None
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        keeper._wait_for_dhcp_reply(lk.ACK, 0.2)
+    assert any("DHCPNAK received" in r.getMessage() for r in caplog.records)
+
+
 def test_follow_accepts_same_class(lk, tmp_path):
     keeper = _follow_keeper(lk, tmp_path)
     assert keeper._handle_changed_address("100.64.4.60", _ack(lk, "100.64.4.60"), "DORA", True) is True


### PR DESCRIPTION
The one concrete item from the "what DHCP content do we ignore?" discussion. A **DHCPNAK** often carries **option 56 (message)** — the server's human-readable reason for refusing (`lease not available`, `bad chaddr`, `no free leases`…). We parsed the reply but discarded that option, so the existing NAK warning gave only the server id and xid — no *why*.

- Capture option 56 into a new `DhcpReply.message` field (via `namedtuple(..., defaults=(None,))`, so the existing 7-field constructions stay valid — no churn).
- Append the decoded, stripped reason to the existing `DHCPNAK received …` warning when present; the line is unchanged when the server sends no message. Bytes values are decoded defensively (`errors="replace"`).

Scope: log-only diagnostic, no toggle/GUI. The other items from that discussion (FORCERENEW, IPv6/DHCPv6+NDP, ICMP probe, subnet-mask follow) are deliberately left out — IPv6 remains the notable "if you ever want to extend" area.

Tests: option 56 parsed into the reply; NAK warning includes a `str` reason, a `bytes` reason decoded, and still logs cleanly when there is no message. **68 pass**; flake8 clean.

`PLUGIN_VERSION` → **1.3.9**.