### PR TITLE
os-carp-vip-dhcp: tidy the Status ARP-reply display (1.3.10)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.3.9
+PLUGIN_VERSION=         1.3.10
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
@@ -121,15 +121,16 @@
             cell = '<span title="' + tip + '">' + fmtAge(k.nudge_age) + '</span>';
         }
         // Reachability: did the gateway answer the nudge? Only meaningful once we
-        // have actually nudged. A reply counts as confirmation only while it is
-        // fresh (within a few nudge intervals, matching the daemon's unanswered
-        // threshold); a reply that then stops coming goes stale and flips to the
-        // warning, which is the ISP-dropping symptom the daemon also logs.
+        // have actually nudged. When confirmed, show just a check (the reply age
+        // tracks the nudge age, so a second duration here would be redundant) with
+        // the age in the tooltip. A reply that stops coming goes stale and flips to
+        // the warning -- the ISP-dropping symptom the daemon also logs.
         if (k.nudge_age != null) {
             if (k.arp_confirmed === true) {
                 cell += ' <span class="text-success" title="'
-                    + "{{ lang._('Gateway confirmed reachable (replied to the ARP nudge)') }}"
-                    + '"><i class="fa fa-check fa-fw"></i>' + fmtAge(k.arp_reply_age) + '</span>';
+                    + "{{ lang._('Gateway confirmed reachable — last ARP reply') }}"
+                    + ' ' + fmtAge(k.arp_reply_age)
+                    + '"><i class="fa fa-check fa-fw"></i></span>';
             } else if (k.carp_state === 'MASTER' && k.bound) {
                 cell += ' <span class="text-warning" title="'
                     + "{{ lang._('No recent ARP reply from the gateway — it may be dropping the nudge') }}"


### PR DESCRIPTION
The confirmed reachability state on the Status page rendered `<nudge age> ✓ <reply age>` — two durations that track each other when healthy (the gateway replies within ms of each nudge), so the second read as a confusing duplicate of the first.

Now: when confirmed, show just the green check (reply age moved to its tooltip); the reply age carries no standalone meaning while healthy — what matters is *whether* the gateway answers, which the check/warning already conveys. The **no reply** warning keeps its inline text, since there the divergence (replies stopped) is exactly the point. The dashboard widget was already icon-only, so the two views stay consistent.

GUI-only; `PLUGIN_VERSION` → **1.3.10**.