### PR TITLE
chore: add FUNDING.yml (Buy Me a Coffee sponsor button)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Shows a "Sponsor" button on the repository.
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+buy_me_a_coffee: toreamun


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so GitHub shows a **Sponsor** button linking to Buy Me a Coffee (`toreamun`) — the same link already in the README, now surfaced as the official repo button.

If the button doesn't appear, tick **Sponsorships** under Settings → General → Features.