### PR TITLE
feat(os-carp-vip-dhcp): converge follow from the peer's DHCP ACK (avoid dual-master)

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -37,9 +37,12 @@ Security posture (this daemon parses untrusted WAN traffic as root):
     *replies*, and (once bound) ARP claiming our leased IP reach Python;
     everything else -- including the segment's broadcast who-has flood -- is
     dropped in the kernel.
-  * A DHCP reply must carry our current xid and the BOOTREPLY op before any
-    field is read (see _on_dhcp_reply); an ARP reply must come from the nudge
-    target for our leased IP (see _on_arp_reply) -- other packets are dropped early.
+  * A DHCP reply must carry the BOOTREPLY op; our own xid gates the first-party
+    path, and in follow mode a reply on our shared chaddr (the peer node's ACK)
+    is read too, but only to RECORD an observed address change for the main
+    thread's hardened follow path (see _on_dhcp_reply). An ARP reply must come
+    from the nudge target for our leased IP (see _on_arp_reply) -- other packets
+    are dropped early.
   * Only the handful of DHCP options the keeper needs is extracted; there is
     no full dissection of the reply's other option data (untrusted network
     input -- it came from whatever answered on the wire, e.g. a rogue or
@@ -234,6 +237,11 @@ class Keeper:
         self.t2_server = None          # server-provided rebinding time (DHCP opt 59)
         self.stop = False
         self._rx = None                # latest DhcpReply snapshot (set by the sniffer thread)
+        # Follow mode: a changed ISP address first seen in the PEER's ACK (both
+        # HA nodes run an identical keeper on the same shared chaddr). The sniffer
+        # writes it (a lone atomic ref-assign); the main thread consumes it and
+        # drives the hardened follow -- see _on_dhcp_reply / _check_observed_follow.
+        self._observed_change = None
         self._ev = threading.Event()
         self._sniffer = None
 
@@ -354,38 +362,70 @@ class Keeper:
         except Exception as e:
             LOG.debug("ARP conflict parse error: %s", e)
 
+    def _parse_reply(self, p, yiaddr):
+        """Snapshot only the handful of DHCP options the keeper acts on into a
+        DhcpReply; the rest of the reply's option data -- untrusted, from
+        whatever answered on the wire -- is left untouched."""
+        mt = sid = lt = rt = bt = ro = msg = None
+        for o in p[DHCP].options:
+            if isinstance(o, tuple):
+                if o[0] == "message-type":
+                    mt = o[1]
+                elif o[0] == "server_id":
+                    sid = o[1]
+                elif o[0] == "lease_time":
+                    lt = o[1]
+                elif o[0] == "renewal_time":
+                    rt = o[1]
+                elif o[0] == "rebinding_time":
+                    bt = o[1]
+                elif o[0] == "router":
+                    ro = o[1]
+                elif o[0] == "message":     # option 56: server's text (e.g. a NAK reason)
+                    msg = o[1]
+        return DhcpReply(mt, yiaddr, sid, lt, rt, bt, ro, msg)
+
+    def _chaddr_matches(self, b):
+        """True if the reply's BOOTP client hardware address is our chaddr (the
+        CARP virtual MAC). Used to accept the PEER's ACK on the shared chaddr:
+        the peer node runs an identical keeper on the very same chaddr."""
+        try:
+            raw = bytes(getattr(b, "chaddr", b"") or b"")
+        except (TypeError, ValueError):
+            return False
+        return raw[:6] == self.chraw
+
     def _on_dhcp_reply(self, p):
         try:
             if not (p.haslayer(BOOTP) and p.haslayer(DHCP)):
                 return
             b = p[BOOTP]
-            # Trust gate: only a reply to OUR in-flight exchange (random xid,
-            # regenerated per DORA) is parsed further; anything else on the
-            # segment -- other clients' traffic, replays, junk -- stops here.
-            if b.xid != self.xid or b.op != BOOTREPLY:
+            if b.op != BOOTREPLY:
                 return
-            # Extract only the fields the keeper acts on; the rest of the reply's
-            # option data -- untrusted, from whatever answered on the wire -- is
-            # left untouched.
-            mt = sid = lt = rt = bt = ro = msg = None
-            for o in p[DHCP].options:
-                if isinstance(o, tuple):
-                    if o[0] == "message-type":
-                        mt = o[1]
-                    elif o[0] == "server_id":
-                        sid = o[1]
-                    elif o[0] == "lease_time":
-                        lt = o[1]
-                    elif o[0] == "renewal_time":
-                        rt = o[1]
-                    elif o[0] == "rebinding_time":
-                        bt = o[1]
-                    elif o[0] == "router":
-                        ro = o[1]
-                    elif o[0] == "message":     # option 56: server's text (e.g. a NAK reason)
-                        msg = o[1]
-            self._rx = DhcpReply(mt, b.yiaddr, sid, lt, rt, bt, ro, msg)
-            self._ev.set()
+            # First-party path: a reply to OUR in-flight exchange (random xid,
+            # regenerated per DORA). Parsed and handed to the waiting main thread.
+            if b.xid == self.xid:
+                self._rx = self._parse_reply(p, b.yiaddr)
+                self._ev.set()
+                return
+            # Not our xid. In follow mode, still watch for the PEER's ACK: both HA
+            # nodes run an identical keeper on the SAME chaddr (the CARP virtual
+            # MAC), so the peer's ACK reveals a changed ISP address one exchange
+            # sooner than our own renewal timer -- closing the window where the
+            # two nodes hold different VIP prefixes long enough for CARP to
+            # dual-master (see docs/single-ip-wan-carp.md, section 3). This is a
+            # deliberately narrow relaxation of the xid trust gate: it requires
+            # our chaddr and an ACK for a plausible, different address, and it
+            # only RECORDS the observation (one atomic ref write) for the main
+            # thread -- which routes it through the same follow hardening
+            # (sane / same-class / expected-server / throttle) as a first-party
+            # ACK and never acts on the sniffer thread.
+            if not self.follow or not self.yiaddr or not self._chaddr_matches(b):
+                return
+            rx = self._parse_reply(p, b.yiaddr)
+            if (rx.mtype == ACK and rx.yiaddr and rx.yiaddr != self.yiaddr
+                    and _sane_ipv4(rx.yiaddr)):
+                self._observed_change = rx
         except Exception as e:
             LOG.debug("DHCP reply parse error: %s", e)
 
@@ -705,6 +745,24 @@ class Keeper:
         except Exception as e:
             LOG.error("follow_update retry failed: %s", e)
 
+    def _check_observed_follow(self):
+        """Adopt an address change first seen in the PEER's DHCP ACK (same shared
+        chaddr) without waiting for our own renewal timer. The sniffer only
+        records the observation; the follow itself runs here on the main thread,
+        through the same hardening/throttle as a first-party ACK. This collapses
+        the follow window that would otherwise leave the two nodes on different
+        VIP prefixes long enough for the backup to promote (transient
+        dual-master; see docs/single-ip-wan-carp.md section 3)."""
+        rx = self._observed_change
+        if rx is None:
+            return
+        self._observed_change = None
+        if not self.follow or not rx.yiaddr or rx.yiaddr == self.yiaddr:
+            return
+        LOG.info("observed peer DHCP ACK for %s (we hold %s) -- following early to converge",
+                 rx.yiaddr, self.yiaddr)
+        self._handle_changed_address(rx.yiaddr, rx, "OBSERVED", release_on_enforce=False)
+
     # ---- CARP role, gating & standby ----
 
     def _hb_standby(self):
@@ -883,6 +941,11 @@ class Keeper:
                 LOG.info("manual ARP nudge requested (SIGUSR1)")
                 self._arp_nudge(force=True)
                 self._hb()   # publish the new nudge age right away for the status page
+            if self._observed_change is not None:
+                # The peer's ACK revealed a changed ISP address -> follow now
+                # (within ~1s) instead of at our own renewal timer, so the two
+                # nodes converge before CARP's ~3s timeout can dual-master us.
+                self._check_observed_follow()
             if self.only_when_master and slept % GATE_POLL == 0 and not self._is_master():
                 return False
             time.sleep(1)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -243,10 +243,12 @@ class Keeper:
         # drives the hardened follow -- see _on_dhcp_reply / _check_observed_follow.
         self._observed_change = None
         self._ev = threading.Event()
-        # Wakes the main thread's maintain-loop sleep the instant the sniffer
-        # records an observed address change, so the follow fires in
-        # milliseconds instead of waiting out the 1s tick. Set only by the
-        # sniffer thread; waited/cleared only by the main thread.
+        # General early-wake for the maintain-loop sleep (_sleep_gated): lets it
+        # return before the 1s tick when there is pending work. Currently the
+        # sniffer sets it on an observed address change so the follow fires in
+        # milliseconds; a future fast-wake need should reuse this rather than mint
+        # a second event. Set only by the sniffer thread; waited/cleared only by
+        # the main thread.
         self._wake = threading.Event()
         self._sniffer = None
 
@@ -948,12 +950,8 @@ class Keeper:
                 self._arp_nudge(force=True)
                 self._hb()   # publish the new nudge age right away for the status page
             if self._observed_change is not None:
-                # The peer's ACK revealed a changed ISP address -> follow now
-                # instead of at our own renewal timer, so the two nodes converge
-                # before CARP's ~3s timeout can dual-master us. The sniffer wakes
-                # us the instant it records one (self._wake, below), so this fires
-                # within milliseconds; the 1s timeout still drives the periodic
-                # checks when nothing signals.
+                # A peer-ACK observation is pending -> follow now (rationale +
+                # the dual-master window it closes are in _check_observed_follow).
                 self._check_observed_follow()
             if self.only_when_master and slept % GATE_POLL == 0 and not self._is_master():
                 return False

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -243,6 +243,11 @@ class Keeper:
         # drives the hardened follow -- see _on_dhcp_reply / _check_observed_follow.
         self._observed_change = None
         self._ev = threading.Event()
+        # Wakes the main thread's maintain-loop sleep the instant the sniffer
+        # records an observed address change, so the follow fires in
+        # milliseconds instead of waiting out the 1s tick. Set only by the
+        # sniffer thread; waited/cleared only by the main thread.
+        self._wake = threading.Event()
         self._sniffer = None
 
     # ---- sniffer (resilient) ----
@@ -426,6 +431,7 @@ class Keeper:
             if (rx.mtype == ACK and rx.yiaddr and rx.yiaddr != self.yiaddr
                     and _sane_ipv4(rx.yiaddr)):
                 self._observed_change = rx
+                self._wake.set()   # wake the maintain-loop sleep now, don't wait for the tick
         except Exception as e:
             LOG.debug("DHCP reply parse error: %s", e)
 
@@ -943,12 +949,18 @@ class Keeper:
                 self._hb()   # publish the new nudge age right away for the status page
             if self._observed_change is not None:
                 # The peer's ACK revealed a changed ISP address -> follow now
-                # (within ~1s) instead of at our own renewal timer, so the two
-                # nodes converge before CARP's ~3s timeout can dual-master us.
+                # instead of at our own renewal timer, so the two nodes converge
+                # before CARP's ~3s timeout can dual-master us. The sniffer wakes
+                # us the instant it records one (self._wake, below), so this fires
+                # within milliseconds; the 1s timeout still drives the periodic
+                # checks when nothing signals.
                 self._check_observed_follow()
             if self.only_when_master and slept % GATE_POLL == 0 and not self._is_master():
                 return False
-            time.sleep(1)
+            # Event-driven sleep: return at once when the sniffer signals a fresh
+            # observation, otherwise time out after ~1s to run the periodic checks.
+            if self._wake.wait(1.0):
+                self._wake.clear()
             slept += 1
         return not self.stop
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -164,6 +164,20 @@ def test_observed_peer_ack_records_change(lk, tmp_path):
     assert keeper._rx is None          # the first-party slot is untouched
 
 
+def test_observed_wakes_main_loop(lk, tmp_path):
+    keeper = _observe_keeper(lk, tmp_path)
+    assert not keeper._wake.is_set()
+    keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60"))
+    assert keeper._wake.is_set()       # sniffer wakes the maintain-loop sleep at once
+
+
+def test_ignored_observation_does_not_wake(lk, tmp_path):
+    keeper = _observe_keeper(lk, tmp_path)
+    keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.7"))     # same address -> no change
+    assert keeper._observed_change is None
+    assert not keeper._wake.is_set()
+
+
 def test_observed_ignores_same_address(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
     keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.7"))     # no change from what we hold
@@ -222,12 +236,13 @@ def test_check_observed_follow_rejects_wrong_server(lk, tmp_path):
     assert keeper.fired == []          # same hardening as a first-party ACK
 
 
-def test_observed_serviced_within_a_second(lk, tmp_path):
+def test_observed_serviced_by_maintain_loop(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
     keeper.fired = []
     keeper._follow_update = keeper.fired.append
     keeper._observed_change = _ack(lk, "100.64.4.60")
-    keeper._sleep_gated(1)             # the 1s maintain-loop tick services it
+    keeper._wake.set()                 # as the sniffer would -> loop returns at once
+    keeper._sleep_gated(1)
     assert keeper.fired == ["100.64.4.60"]
 
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -56,9 +56,11 @@ def _ack(lk, yiaddr, server="100.64.4.1"):
 class _DhcpPkt:
     """Minimal stand-in for a scapy DHCP reply: p[BOOTP].xid/op/yiaddr and
     p[DHCP].options, with haslayer() so _on_dhcp_reply parses it."""
-    def __init__(self, lk, xid, options, yiaddr="100.64.4.7"):
+    def __init__(self, lk, xid, options, yiaddr="100.64.4.7",
+                 chaddr=b"\x00\x00\x5e\x00\x01\xfe"):
         self._lk = lk
-        self._bootp = types.SimpleNamespace(xid=xid, op=lk.BOOTREPLY, yiaddr=yiaddr)
+        self._bootp = types.SimpleNamespace(xid=xid, op=lk.BOOTREPLY, yiaddr=yiaddr,
+                                            chaddr=chaddr)
         self._dhcp = types.SimpleNamespace(options=options)
 
     def haslayer(self, layer):
@@ -134,6 +136,99 @@ def test_enforce_mismatch_refused(lk, tmp_path):
     keeper.yiaddr = "100.64.4.7"
     keeper.release = lambda: None
     assert keeper._handle_changed_address("100.64.4.60", _ack(lk, "100.64.4.60"), "DORA", True) is False
+
+
+# ---- observed peer ACK: converge follow from the peer's exchange (single-ip s.3) ----
+
+def _observe_keeper(lk, tmp_path):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, follow=True)
+    keeper._follow_state = str(tmp_path / "follow_state")
+    keeper.server = "100.64.4.1"
+    keeper.yiaddr = "100.64.4.7"
+    keeper.xid = 0x11111111          # OUR in-flight xid
+    return keeper
+
+
+def _peer_ack(lk, yiaddr, xid=0x22222222, server="100.64.4.1",
+              chaddr=b"\x00\x00\x5e\x00\x01\xfe"):
+    """A DHCP ACK on our shared chaddr but a DIFFERENT xid -- i.e. the peer's."""
+    return _DhcpPkt(lk, xid, [("message-type", lk.ACK), ("server_id", server),
+                              ("lease_time", 1800), "end"], yiaddr=yiaddr, chaddr=chaddr)
+
+
+def test_observed_peer_ack_records_change(lk, tmp_path):
+    keeper = _observe_keeper(lk, tmp_path)
+    keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60"))
+    assert keeper._observed_change is not None
+    assert keeper._observed_change.yiaddr == "100.64.4.60"
+    assert keeper._rx is None          # the first-party slot is untouched
+
+
+def test_observed_ignores_same_address(lk, tmp_path):
+    keeper = _observe_keeper(lk, tmp_path)
+    keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.7"))     # no change from what we hold
+    assert keeper._observed_change is None
+
+
+def test_observed_ignores_wrong_chaddr(lk, tmp_path):
+    keeper = _observe_keeper(lk, tmp_path)
+    keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60", chaddr=b"\xaa\xbb\xcc\xdd\xee\xff"))
+    assert keeper._observed_change is None
+
+
+def test_observed_ignores_non_ack(lk, tmp_path):
+    keeper = _observe_keeper(lk, tmp_path)
+    keeper._on_dhcp_reply(_DhcpPkt(lk, 0x22222222,
+                                   [("message-type", lk.OFFER), ("server_id", "100.64.4.1"), "end"],
+                                   yiaddr="100.64.4.60"))
+    assert keeper._observed_change is None
+
+
+def test_observed_ignored_when_not_follow(lk, tmp_path):
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, follow=False)
+    keeper.server = "100.64.4.1"
+    keeper.yiaddr = "100.64.4.7"
+    keeper.xid = 0x11111111
+    keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60"))
+    assert keeper._observed_change is None
+
+
+def test_own_xid_reply_uses_first_party_path(lk, tmp_path):
+    keeper = _observe_keeper(lk, tmp_path)
+    keeper._on_dhcp_reply(_DhcpPkt(lk, keeper.xid,
+                                   [("message-type", lk.ACK), ("server_id", "100.64.4.1"), "end"],
+                                   yiaddr="100.64.4.60"))
+    assert keeper._observed_change is None            # not the observed path
+    assert keeper._rx is not None and keeper._rx.yiaddr == "100.64.4.60"
+
+
+def test_check_observed_follow_drives_hardened_follow(lk, tmp_path):
+    keeper = _observe_keeper(lk, tmp_path)
+    keeper.fired = []
+    keeper._follow_update = keeper.fired.append
+    keeper._observed_change = _ack(lk, "100.64.4.60")
+    keeper._check_observed_follow()
+    assert keeper.fired == ["100.64.4.60"]
+    assert keeper.request_ip == "100.64.4.60"
+    assert keeper._observed_change is None
+
+
+def test_check_observed_follow_rejects_wrong_server(lk, tmp_path):
+    keeper = _observe_keeper(lk, tmp_path)
+    keeper.fired = []
+    keeper._follow_update = keeper.fired.append
+    keeper._observed_change = _ack(lk, "100.64.4.60", server="100.64.4.9")  # not our server
+    keeper._check_observed_follow()
+    assert keeper.fired == []          # same hardening as a first-party ACK
+
+
+def test_observed_serviced_within_a_second(lk, tmp_path):
+    keeper = _observe_keeper(lk, tmp_path)
+    keeper.fired = []
+    keeper._follow_update = keeper.fired.append
+    keeper._observed_change = _ack(lk, "100.64.4.60")
+    keeper._sleep_gated(1)             # the 1s maintain-loop tick services it
+    assert keeper.fired == ["100.64.4.60"]
 
 
 def test_id_opts_empty_by_default(lk):

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -216,6 +216,34 @@ def test_own_xid_reply_uses_first_party_path(lk, tmp_path):
     assert keeper._rx is not None and keeper._rx.yiaddr == "100.64.4.60"
 
 
+def test_observed_latest_wins(lk, tmp_path):
+    # Two peer ACKs in quick succession (the sniffer overwrites _observed_change):
+    # the handler acts on the LATEST address -- the older one is superseded (the
+    # shared lease is now the newer address), so dropping it is correct.
+    keeper = _observe_keeper(lk, tmp_path)
+    keeper.fired = []
+    keeper._follow_update = keeper.fired.append
+    keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60"))
+    keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.61"))
+    assert keeper._observed_change.yiaddr == "100.64.4.61"
+    keeper._check_observed_follow()
+    assert keeper.fired == ["100.64.4.61"]
+    assert keeper._observed_change is None
+
+
+def test_observed_same_address_after_follow_is_dropped(lk, tmp_path):
+    # After we've followed to the new address, a lingering observation for that
+    # same address is a no-op (the == self.yiaddr guard), never a double-follow.
+    keeper = _observe_keeper(lk, tmp_path)
+    keeper.fired = []
+    keeper._follow_update = keeper.fired.append
+    keeper.yiaddr = "100.64.4.61"                 # we already hold the new address
+    keeper._observed_change = _ack(lk, "100.64.4.61")
+    keeper._check_observed_follow()
+    assert keeper.fired == []                     # no redundant follow
+    assert keeper._observed_change is None
+
+
 def test_check_observed_follow_drives_hardened_follow(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
     keeper.fired = []

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -141,11 +141,11 @@ def test_enforce_mismatch_refused(lk, tmp_path):
 # ---- observed peer ACK: converge follow from the peer's exchange (single-ip s.3) ----
 
 def _observe_keeper(lk, tmp_path):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, follow=True)
-    keeper._follow_state = str(tmp_path / "follow_state")
-    keeper.server = "100.64.4.1"
-    keeper.yiaddr = "100.64.4.7"
-    keeper.xid = 0x11111111          # OUR in-flight xid
+    # Same fixture as _follow_keeper (server / yiaddr / _follow_state / fired +
+    # _follow_update stubs), plus a known in-flight xid so a peer ACK (different
+    # xid) takes the observed path.
+    keeper = _follow_keeper(lk, tmp_path)
+    keeper.xid = 0x11111111
     return keeper
 
 
@@ -221,8 +221,6 @@ def test_observed_latest_wins(lk, tmp_path):
     # the handler acts on the LATEST address -- the older one is superseded (the
     # shared lease is now the newer address), so dropping it is correct.
     keeper = _observe_keeper(lk, tmp_path)
-    keeper.fired = []
-    keeper._follow_update = keeper.fired.append
     keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60"))
     keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.61"))
     assert keeper._observed_change.yiaddr == "100.64.4.61"
@@ -235,8 +233,6 @@ def test_observed_same_address_after_follow_is_dropped(lk, tmp_path):
     # After we've followed to the new address, a lingering observation for that
     # same address is a no-op (the == self.yiaddr guard), never a double-follow.
     keeper = _observe_keeper(lk, tmp_path)
-    keeper.fired = []
-    keeper._follow_update = keeper.fired.append
     keeper.yiaddr = "100.64.4.61"                 # we already hold the new address
     keeper._observed_change = _ack(lk, "100.64.4.61")
     keeper._check_observed_follow()
@@ -246,8 +242,6 @@ def test_observed_same_address_after_follow_is_dropped(lk, tmp_path):
 
 def test_check_observed_follow_drives_hardened_follow(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
-    keeper.fired = []
-    keeper._follow_update = keeper.fired.append
     keeper._observed_change = _ack(lk, "100.64.4.60")
     keeper._check_observed_follow()
     assert keeper.fired == ["100.64.4.60"]
@@ -257,8 +251,6 @@ def test_check_observed_follow_drives_hardened_follow(lk, tmp_path):
 
 def test_check_observed_follow_rejects_wrong_server(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
-    keeper.fired = []
-    keeper._follow_update = keeper.fired.append
     keeper._observed_change = _ack(lk, "100.64.4.60", server="100.64.4.9")  # not our server
     keeper._check_observed_follow()
     assert keeper.fired == []          # same hardening as a first-party ACK
@@ -266,8 +258,6 @@ def test_check_observed_follow_rejects_wrong_server(lk, tmp_path):
 
 def test_observed_serviced_by_maintain_loop(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
-    keeper.fired = []
-    keeper._follow_update = keeper.fired.append
     keeper._observed_change = _ack(lk, "100.64.4.60")
     keeper._wake.set()                 # as the sniffer would -> loop returns at once
     keeper._sleep_gated(1)


### PR DESCRIPTION
Implements the passive-observation mitigation for the follow dual-master window (docs/single-ip-wan-carp.md §3), which was lab-confirmed on a two-node bench.

## Problem
In follow mode both HA nodes keep the lease on the **same shared chaddr** (the CARP virtual MAC). On an ISP address change, each keeper adopted the new address only at its **own** renewal timer. If the two nodes' renewals were more than ~3 s apart, they briefly advertised **different CARP VIP prefixes**; a CARP advertisement's integrity check covers the VIP prefixes, so the backup stopped validating the master's adverts and **promoted → transient dual-master** until they converged. Confirmed in the lab: the backup promoted ~3.3 s after the master's prefix changed.

## Fix
The keeper now also observes the **peer's** DHCP ACK on the shared chaddr:
- **Sniffer thread (instant):** a reply that isn't ours (different xid) but is an **ACK for our chaddr** carrying a plausible, **different** address is recorded in `_observed_change` — a single atomic ref write. It never acts here.
- **Main thread (≤1 s):** the 1 s maintain-loop tick (the same mechanism that services the SIGUSR1/SIGUSR2 flags) picks it up and runs the **existing hardened follow** (`_handle_changed_address`: sane / same-class / expected-server / throttle) — so a peer-observed ACK is validated exactly like a first-party one.

Result: the backup converges within the same exchange, well under the ~3 s CARP timeout → no dual-master. If the peer's ACK isn't visible (server doesn't broadcast and promisc is off) it falls back to today's independent convergence, so this is a pure improvement.

## Safety
A deliberately **narrow** relaxation of the xid trust gate the daemon documents: the observed path requires our chaddr **and** an ACK **and** a sane, different address, and only *records* for the main thread. All follow hardening and the flap/spoof throttle still apply; nothing state-mutating runs on the sniffer thread.

## Tests
10 new unit tests (records/ignores by chaddr, message-type, same-vs-changed address, follow mode; first-party path unaffected; main-thread follow drives and rejects a wrong server; serviced within the 1 s tick). `pytest`: **77 passed**. `flake8 --max-line-length=120`: **clean**.

Unit-tested; not yet integration-tested with the running daemon on the two-node lab.

Note on sequencing: once this and #27 land, the §3 caveat can be softened to note the keeper now converges via peer-ACK observation.