### PR TITLE
feat: build.sh --install — build-from-source install path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,13 +8,21 @@
 # resulting .pkg is installable with `pkg add` / uploadable to a GitHub release.
 #
 # Usage:
-#   ./build.sh [category/plugin]      # default: net/os-carp-vip-dhcp
+#   ./build.sh [-i|--install] [category/plugin]   # default plugin: net/os-carp-vip-dhcp
 #
-# Output: ./dist/<pkg>.pkg
+# Output: ./dist/<pkg>.pkg  (with --install, also pkg-add'd into the running system)
 #
 set -e
 
-PLUGIN="${1:-net/os-carp-vip-dhcp}"
+INSTALL=0
+PLUGIN="net/os-carp-vip-dhcp"
+for arg in "$@"; do
+    case "$arg" in
+        -i|--install) INSTALL=1 ;;
+        -*) echo "error: unknown option '$arg' (use -i/--install)" >&2; exit 1 ;;
+        *) PLUGIN="$arg" ;;
+    esac
+done
 REPO_DIR=$(cd "$(dirname "$0")" && pwd)
 PLUGINS_TREE="/usr/plugins"
 DIST="${REPO_DIR}/dist"
@@ -66,9 +74,25 @@ if [ -z "${found}" ]; then
     echo "error: no .pkg produced — check the build output above" >&2
     exit 1
 fi
+# The plugin depends on Scapy (py3<minor>-scapy); `pkg add` does not resolve deps,
+# so ensure it once up front (as install.sh does) before adding the .pkg.
+if [ "${INSTALL}" = "1" ]; then
+    pyver="py3$(python3 -c 'import sys; print(sys.version_info.minor)')"
+    echo ">>> Ensuring dependency ${pyver}-scapy"
+    pkg install -y "${pyver}-scapy"
+fi
+
 echo "${found}" | while read -r pkg; do
     cp -v "${pkg}" "${DIST}/"
+    if [ "${INSTALL}" = "1" ]; then
+        # force = reinstall in place when iterating on the same version from main
+        echo ">>> Installing $(basename "${pkg}")"
+        pkg add -f "${DIST}/$(basename "${pkg}")"
+    fi
 done
 
 echo ">>> Done. Packages in ${DIST}:"
 ls -1 "${DIST}"/*.pkg
+if [ "${INSTALL}" = "1" ]; then
+    echo ">>> Installed from source. Reload the GUI if it was open."
+fi

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -177,6 +177,24 @@ pkg add ./os-carp-vip-dhcp-*.pkg
 
 </details>
 
+<details>
+<summary><b>Build from source (run the latest, or don't rely on a release)</b></summary>
+
+For testers who want the latest `main` (e.g. an unreleased fix) or anyone who would rather build inspected source than trust the signed release. The plugin has no compiled code — "build" just packages the files — but it uses the OPNsense plugin build tooling, so run it on an OPNsense box (or an OPNsense build VM).
+
+```sh
+# 1. Clone (this is the "download" — main for latest, or check out a tag).
+git clone https://github.com/toreamun/opnsense-plugins
+cd opnsense-plugins            # inspect the source you're about to run
+
+# 2. Build + install, as root. Fetches the official plugins tree for the build
+#    tooling, packages net/os-carp-vip-dhcp, ensures Scapy, and pkg-adds it.
+./build.sh --install
+```
+
+`./build.sh` on its own only builds `./dist/<pkg>.pkg` (no install) — use that to build on a separate box and copy just the `.pkg` to a hardened firewall (keeping the build toolchain off it). Settings survive a reinstall; re-run the one-line `install.sh` any time to return to signed releases.
+</details>
+
 ## License
 
 BSD-2-Clause. See [LICENSE](../../LICENSE).


### PR DESCRIPTION
Follow-up to the release-question discussion: give users who don't want to rely on the signed release (or who want to run the latest `main`, e.g. an unreleased fix) a build-from-source path.

`build.sh` already builds a `.pkg` from source (stages the plugin into the official plugins tree, `make package`, collects into `./dist/`). This adds:
- **`-i|--install`** — after building, ensure the Scapy dependency (`pkg add` doesn't resolve deps, so mirror install.sh) then force-add the built `.pkg` (force = reinstall in place when iterating on the same version).
- **README "Build from source" section** — the `git clone` → inspect → `./build.sh --install` flow. Clone-first (not pipe-to-sh), which fits the trust-conscious audience. `./build.sh` alone still only builds `./dist/<pkg>.pkg` (build on a separate box, copy the `.pkg` to a hardened firewall to keep the toolchain off it).

The plugin has no compiled code, so "build" just packages the interpreted files. `sh -n` clean.