### PR TITLE
docs(os-carp-vip-dhcp): security notes (#9/#10) + prominent Single-IP WAN section

### DIFF
--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -75,6 +75,16 @@ A small root daemon keeps a DHCP lease alive for a chosen `chaddr` — the CARP 
 
 Once the ISP routes the VIP address to that MAC, native OPNsense CARP answers ARP and egresses data as usual — so the VIP becomes failover-capable on a DHCP interface. The daemon references an existing CARP VirtualIP (deriving interface, vhid→chaddr and IP), follows the lease (RENEW at T1, REBIND at T2, re-DORA — a full Discover-Offer-Request-Ack — at expiry), and by default runs on **both** nodes redundantly — same lease, seamless failover, no split-brain. Because the lease lives on the CARP **virtual** MAC, a failover invalidates nothing upstream: the same MAC simply starts answering from the new master.
 
+## Single-IP WAN (only one public IP)
+
+Only *one* public IP on the WAN? You still get CARP failover. The shape:
+
+- each node takes a small **private** static WAN IP (used only for CARP advertisements + node identity);
+- **one floating CARP VIP** holds the single public lease — this plugin keeps it alive on the virtual MAC;
+- a **gateway group** routes the backup's own traffic out through the master over the SYNC link.
+
+That's the gist — the full recipe (IP plan, failover flow, GUI steps, lab-validation status) is in **➜ [Single-IP WAN failover](docs/single-ip-wan-carp.md)**.
+
 ---
 
 <details>

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -42,6 +42,7 @@ On the OPNsense box, as **root**:
    ```sh
    fetch -o - https://raw.githubusercontent.com/toreamun/opnsense-plugins/main/install.sh | sh
    ```
+   *(Trust note: this bootstrap runs as **root before it can verify itself** — trust-on-first-use over GitHub TLS, since the signature check it performs lives inside the as-yet-unverified script. To establish trust yourself instead, use the verified **Manual install** or **Build from source** paths below.)*
 3. Open **Interfaces → Virtual IPs DHCP**, add a **keeper** (a per-VIP lease-holder) pointing at that CARP VIP, and **enable** it.
 
 That's it — the VIP now holds a live lease. The defaults are sensible: it follows a dynamic address, keeps the gateway's ARP fresh, and runs on both nodes for seamless failover.

--- a/net/os-carp-vip-dhcp/docs/single-ip-wan-carp.md
+++ b/net/os-carp-vip-dhcp/docs/single-ip-wan-carp.md
@@ -313,7 +313,9 @@ sequenceDiagram
 - **The CARP `pass` secures the *election*, not the *segment*.** The `pass` (a SHA-1
   HMAC) stops a stranger from injecting CARP advertisements to hijack the VIP — but it
   does nothing about a hostile on-segment neighbour **ARP-spoofing** the VIP or the
-  gateway directly (a plain L2 attack, independent of CARP). On a genuinely shared L2 you
+  gateway directly — a **general untrusted-shared-L2 exposure** that a plain, non-CARP
+  firewall on the same segment shares equally. CARP does not *create* that risk; it only
+  *adds* the election as one more thing to authenticate. On a genuinely shared L2 you
   can additionally set CARP to **unicast** (`ifconfig <if> vhid <n> … peer <peer-node-IP>`;
   FreeBSD 14 `carp(4)`) so advertisements go only to the peer instead of flooding the
   segment — hardening the election against on-segment observation/injection. Caveats: it

--- a/net/os-carp-vip-dhcp/docs/single-ip-wan-carp.md
+++ b/net/os-carp-vip-dhcp/docs/single-ip-wan-carp.md
@@ -310,6 +310,18 @@ sequenceDiagram
   VRRP/CARP. **Most fiber ISPs isolate customers per VLAN/port** (you only see gw
   `.1`) → safe. **Verify** with `tcpdump -T carp` + `arp -an` on the WAN before
   trusting it. Use an unusual `vhid` + a `pass` regardless.
+- **The CARP `pass` secures the *election*, not the *segment*.** The `pass` (a SHA-1
+  HMAC) stops a stranger from injecting CARP advertisements to hijack the VIP — but it
+  does nothing about a hostile on-segment neighbour **ARP-spoofing** the VIP or the
+  gateway directly (a plain L2 attack, independent of CARP). On a genuinely shared L2 you
+  can additionally set CARP to **unicast** (`ifconfig <if> vhid <n> … peer <peer-node-IP>`;
+  FreeBSD 14 `carp(4)`) so advertisements go only to the peer instead of flooding the
+  segment — hardening the election against on-segment observation/injection. Caveats: it
+  is a manual ifconfig-level setting (not exposed in the OPNsense VIP GUI, so not
+  persistent without a hook), it disables CARP's TTL verification, and it still does
+  **not** stop ARP-spoofing. So unicast hardens CARP; it does not make an untrusted shared
+  L2 safe — and most fiber ISPs isolate per VLAN/port anyway (previous bullet), where it
+  is moot.
 - **`blockpriv`/`blockbogons` vs. CARP advertisements — should be fine:** a peer's
   advertisements arrive on the WAN with a **private/link-local source IP**
   (`10.1.1.x` → `blockpriv`). OPNsense installs a global `quick` rule (roughly the


### PR DESCRIPTION
Doc polish, three parts:

**#9 — install.sh | sh is trust-on-first-use.** Trust note by the install one-liner (runs as root before it can verify itself; the signature check lives inside the unverified script) pointing to the verified Manual-install / Build-from-source paths.

**#10 — the CARP `pass` secures the election, not the segment.** §8 note: `pass` stops advertisement injection but not a hostile neighbour ARP-spoofing the VIP/gateway — framed as a **general untrusted-shared-L2 exposure a plain non-CARP firewall shares equally**, not something CARP creates. Documents unicast CARP (verified on FreeBSD 14.3 `peer`/`peer6`) as a real hardening of the advertisement side, with honest caveats (manual, not in the VIP GUI, disables TTL verification, still doesn't stop ARP-spoofing).

**Prominent Single-IP WAN section.** A short "the shape" gist (private per-node WAN IPs + one floating VIP + gateway group) with a clear link to the deep-dive — gives it a top-level heading / TOC entry without duplicating the full step-by-step recipe (that stays in docs/single-ip-wan-carp.md to avoid drift). The deep-dive keeps its path, so existing forum links are unaffected.

Docs-only.