### PR TITLE
os-carp-vip-dhcp 1.4.0: fix follow dropping the keeper + pre-publish review hardening

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.3.10
+PLUGIN_VERSION=         1.4.0
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -43,9 +43,11 @@ On the OPNsense box, as **root**:
    fetch -o - https://raw.githubusercontent.com/toreamun/opnsense-plugins/main/install.sh | sh
    ```
    *(Trust note: this bootstrap runs as **root before it can verify itself** — trust-on-first-use over GitHub TLS, since the signature check it performs lives inside the as-yet-unverified script. To establish trust yourself instead, use the verified **Manual install** or **Build from source** paths below.)*
-3. Open **Interfaces → Virtual IPs DHCP**, add a **keeper** (a per-VIP lease-holder) pointing at that CARP VIP, and **enable** it.
+3. Open **Interfaces → Virtual IPs DHCP**, add a **keeper** (a per-VIP lease-holder) pointing at that CARP VIP, and **enable** it. *(The VIP dropdown lists your CARP VIPs — if it's empty you skipped step 1; a keeper needs an existing CARP VIP to point at. And a keeper does nothing until its **Enabled** box is ticked.)*
 
 That's it — the VIP now holds a live lease. The defaults are sensible: it follows a dynamic address, keeps the gateway's ARP fresh, and runs on both nodes for seamless failover.
+
+**You'll know it's working when**, on the **Status** page (or the dashboard widget): the keeper shows **bound** to the VIP's address, the node it runs on is CARP **master**, and gateway reachability shows a **green check** (the gateway is answering the ARP nudge). On the backup you'll instead see it **standing by** (or holding its own lease, depending on mode) — that's expected. A persistent problem raises a **dashboard banner**.
 
 - **Update:** re-run the exact same command (it always fetches the latest signed release and reinstalls in place; settings are preserved). Pin a version by appending its tag, e.g. `… | sh -s -- os-carp-vip-dhcp v1.3.10`.
 - **Uninstall:** `pkg delete os-carp-vip-dhcp` — stops the daemons and cleans up (Scapy is left in place). *(A manual, no-script install is documented at the bottom.)*
@@ -83,7 +85,7 @@ Only *one* public IP on the WAN? You still get CARP failover. The shape:
 - **one floating CARP VIP** holds the single public lease — this plugin keeps it alive on the virtual MAC;
 - a **gateway group** routes the backup's own traffic out through the master over the SYNC link.
 
-That's the gist — the full recipe (IP plan, failover flow, GUI steps, lab-validation status) is in **➜ [Single-IP WAN failover](docs/single-ip-wan-carp.md)**.
+This is the **mental model, not a setup checklist** — single-IP needs the private node IPs, a gateway group, and the SYNC link wired correctly, and each mechanism is lab-validated individually but the whole stack has not yet been field-run on a live one-IP line. Don't build it from these three bullets alone: the full recipe (IP plan, failover flow, GUI steps, lab-validation status) is in **➜ [Single-IP WAN failover](docs/single-ip-wan-carp.md)**.
 
 ---
 
@@ -111,8 +113,8 @@ Some ISP gateways/BNGs ignore gratuitous ARP and **never re-ARP an expired entry
 - **The nudge:** a periodic ARP *request* from the VIP (source = leased IP + CARP MAC) for the gateway. Default 120 s — comfortably under the ARP timeout of typical *and* shorter-lived gateway caches, at one negligible broadcast per interval. Lower it toward the 30 s floor for gear with a very short ARP timeout. Sent **only while CARP master** (never from a backup). Set 0 to disable.
 - **On becoming master** (failover or a link flap re-electing CARP): an immediate nudge **and** an early lease RENEW, within ~1 s of the kernel CARP transition — neither waits for its timer.
 - **Manual nudge:** the ⚡ button on the Status page (shown on the master), or `kill -USR1` on the daemon.
-- **Reachability:** the keeper watches for the gateway's ARP **reply**; the Status page/widget show a green check when confirmed, and if several nudges go **unanswered** (a carrier dropping them) it logs a warning and flags it. No promiscuous mode is needed — the master already accepts the VIP MAC. A NIC that filters non-primary unicast can enable the advanced **“ARP listen in promiscuous mode”** fallback *(default off; it warns when on)*.
-- **Conflict detection:** if another MAC is seen using the leased IP (duplicate address / ISP reassignment), the keeper logs a warning. Advisory only; the peer node shares the CARP MAC, so it's never mistaken for a conflict.
+- **Reachability:** the keeper watches for the gateway's ARP **reply**; the Status page/widget show a green check when confirmed, and if several nudges go **unanswered** (a carrier dropping them) it logs a warning and flags it. If the gateway keeps ignoring the nudge **while the lease is held** — the silent return-path blackhole this whole feature guards against — a **dashboard banner** is raised too (it is otherwise invisible: CARP still masters and the lease is still held). No promiscuous mode is needed — the master already accepts the VIP MAC. A NIC that filters non-primary unicast can enable the advanced **“ARP listen in promiscuous mode”** fallback *(default off; it warns when on)*.
+- **Conflict detection:** if another MAC is seen using the leased IP (duplicate address / ISP reassignment), the keeper logs a warning. Advisory only (written to the keeper log, **not** pushed as an alert — check the log or the Status page); the peer node shares the CARP MAC, so it's never mistaken for a conflict.
 
 </details>
 

--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -19,6 +19,8 @@ This plugin runs a small daemon that keeps a DHCP lease alive **for the CARP VIP
   <sub><i>The Status page — the VIP holding its lease as CARP <b>master</b>, with gateway reachability confirmed (green check).</i></sub>
 </p>
 
+> **Status — independent plugin, aiming for the official tree.** This is a standalone plugin, not (yet) part of OPNsense. **If enough people find it useful, I intend to propose it for the official OPNsense community plugins** — ⭐ the repo if you'd like to see that happen.
+
 ## Is this for you?
 
 You need it if **both** of these are true:

--- a/net/os-carp-vip-dhcp/docs/single-ip-wan-carp.md
+++ b/net/os-carp-vip-dhcp/docs/single-ip-wan-carp.md
@@ -66,7 +66,7 @@ The facts that drive the design:
   group (§6.2).
 - **Important:** OpenBSD's warning that the carp device must share a subnet with
   the CARP VIP applies **only to `balancing` mode**. In ordinary master/backup,
-  **a private node IP plus a public VIP in a different subnet is spec-valid** —
+  **a private node IP plus a public VIP in a different subnet works fine** —
   that is exactly what we exploit.
 
 ---
@@ -364,6 +364,29 @@ sequenceDiagram
   with no effect on the live lease. Use a **throwaway** locally-administered MAC, not
   the real virtual MAC, so a lease-binding ISP cannot associate the probe with your
   VIP.)
+- **Follow moves the VIP address only — not the prefix or the gateway:** on an ISP
+  renumber the keeper rewrites the CARP VIP to the new address (after checking it is
+  sane, in the same routability class, and from the expected server), but it does
+  **not** touch the interface prefix or System→Gateways. A **same-subnet** change is
+  seamless. A **cross-subnet** move leaves the default route pointing at the old
+  gateway → outbound dies despite a "successful" follow. The keeper now logs a loud
+  error when the ACK's gateway (DHCP option 3) changes — read it as "update the prefix
+  and gateway by hand." If your ISP renumbers across subnets, plan for manual steps.
+- **Follow trusts the DHCP ACK, which a shared-L2 neighbour can forge:** on a genuinely
+  shared segment an attacker who reads the CARP adverts (to derive the virtual MAC) can
+  send a spoofed ACK and drive the VIP to an address of their choosing (throttled to one
+  move per 60 s). During a T2 **REBIND** the expected-server check is intentionally
+  relaxed (any server may answer — legitimate DHCP), widening the window. This is the
+  same untrusted-shared-L2 exposure as the ARP-spoofing bullet above, and moot where the
+  ISP isolates you per VLAN/port. On a shared L2, prefer **run-only-on-master** plus a
+  strict upstream, or pin the address (follow off).
+- **Stopping the service is not the same as disabling a keeper:** disabling/removing a
+  keeper and pressing Apply drops it from `keeper.conf`, so the CARP eligibility hook
+  ignores it — no demotion. Stopping the whole *service*, by contrast, freezes the
+  heartbeats; a `demote_on_lease_loss` keeper then reads as failed and the node demotes,
+  handing the VIP to the peer. To take a node out of rotation on purpose that may be
+  what you want; to pause a keeper **without** a failover, disable the keeper — don't
+  stop the service.
 - **SYNC-link failure while both WAN ports stay up:** CARP advertisements still cross the
   WAN segment, so **the master keeps its role — no spurious failover or ping-pong**
   (lab-confirmed: `pfsync` demotion penalizes only the *out-of-sync* node — a backup

--- a/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
@@ -17,6 +17,13 @@ RUN_DIR="/var/run"
 # truly stalled keeper, never a mid-cycle one. (The health *banner* uses a
 # tighter 600s ceiling -- a notice is cheap, so it can be more responsive.)
 MAX_AGE=3600
+# A run-only-on-master keeper holds no lease while it is backup, so on promotion
+# it must DORA from scratch and briefly publishes bound=- acq=<epoch>. Grace that
+# bounded acquire window: demoting during it (when demote_on_lease_loss is also
+# set) hands the VIP straight back, and the peer then DORAs and demotes too --
+# the two nodes flap the VIP between them. A genuinely stuck acquire outlasts
+# this and still demotes. Comfortably covers a slow DORA plus a retry backoff.
+ACQUIRE_GRACE=120
 
 [ -f "${CONF}" ] || exit 0
 
@@ -43,6 +50,14 @@ while IFS='|' read -r request iface chaddr demote vhid runmaster follow vendorcl
         *STANDBY*) continue ;;
         *MISMATCH*) exit 1 ;;
         *"bound=${request} "*) : ;;
+        *"bound=- "*)
+            # (Re)acquiring: grace the bounded post-promotion DORA window (acq=),
+            # else demote. A plain bound=- with no acq= (a non-gated keeper that
+            # lost its lease) has no acq token and falls through to exit 1.
+            acq=$(echo "${content}" | sed -n 's/.*[[:space:]]acq=\([0-9][0-9]*\).*/\1/p')
+            [ -n "${acq}" ] && [ $(( now - acq )) -le "${ACQUIRE_GRACE}" ] && continue
+            exit 1
+            ;;
         *) exit 1 ;;
     esac
 done < "${CONF}"

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -134,8 +134,9 @@ carpvipdhcp_restart()
 
 # Stop only the keeper with the given filesystem-safe id (the daemon(8)
 # supervisor first, so it does not respawn the child, then the child). Used by a
-# follow to replace just the affected keeper without bouncing the others; the
-# following carpvipdhcp_start brings up the renamed line from the new keeper.conf.
+# follow to retire the old-id keeper; follow_update.php then issues a separate
+# `start <new_id>` for the renamed line (a single `restart <old_id>` would skip
+# the new line, since start honours svc_id and old_id != new_id).
 carpvipdhcp_stop_id()
 {
     tid="$1"

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/library/OPNsense/System/Status/CarpVipDhcpStatus.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/library/OPNsense/System/Status/CarpVipDhcpStatus.php
@@ -45,6 +45,10 @@ class CarpVipDhcpStatus extends AbstractStatus
     private const STALE = 600;
     // Only alert once a problem has persisted this long, to ride out restarts.
     private const GRACE = 300;
+    // How long the gateway may go without answering ARP before we call the return
+    // path blackholed. The keeper nudges every ~120s; 600s = several missed
+    // replies. Only judged once the gateway has answered at least once (arpok>0).
+    private const ARP_STALE = 600;
 
     public function __construct()
     {
@@ -136,8 +140,32 @@ class CarpVipDhcpStatus extends AbstractStatus
             return null;   // intentionally idle CARP backup, heartbeat fresh
         }
         if (strpos($content, 'bound=' . $request . ' ') !== false) {
-            return null;
+            return $this->arpReachabilityReason($content);
         }
         return gettext('not holding the lease');
+    }
+
+    /**
+     * The keeper holds its lease -- but if it is also driving ARP nudges and the
+     * gateway, having answered before (arpok>0), has since gone silent for
+     * ARP_STALE, the return path is likely blackholed. That is the flagship
+     * failure mode the nudge exists to prevent, and it is otherwise invisible on
+     * the dashboard (CARP still masters, the lease is still held). We ignore
+     * arpok==0 (never seen): freshly acquired, or a NIC that drops the unicast
+     * reply (the promiscuous-listen fallback) -- flagging it would cry wolf.
+     */
+    private function arpReachabilityReason(string $content): ?string
+    {
+        if (strpos($content, ' nudge=') === false) {
+            return null;   // ARP nudge not enabled for this keeper -> no signal to judge
+        }
+        if (!preg_match('/\barpok=(\d+)/', $content, $m)) {
+            return null;
+        }
+        $arpok = (int)$m[1];
+        if ($arpok > 0 && (time() - $arpok) > self::ARP_STALE) {
+            return gettext('gateway stopped answering ARP (return path may be blackholed)');
+        }
+        return null;
     }
 }

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
@@ -157,14 +157,23 @@ if (!$rendered_ok) {
     exit(1);
 }
 
+// Replace only the keeper that just changed address, not every keeper on the
+// node. The daemon is keyed by a filesystem-safe id derived from its request IP,
+// so a follow renames it old_id -> new_id. We must stop old_id and start new_id
+// SEPARATELY: `restart <old_id>` would stop the old daemon but then
+// carpvipdhcp_start (honouring svc_id=old_id) skips the renamed new_ip line in
+// keeper.conf -> 0 keepers started -> nothing renews the lease -> the WAN
+// silently blackholes at the next expiry. Same _id() mapping as the rc script.
+$old_id = preg_replace('/[^A-Za-z0-9]/', '_', $old_ip);
+$new_id = preg_replace('/[^A-Za-z0-9]/', '_', $new_ip);
 $out = array();
 $rc = 0;
-// Bounce only the keeper that just changed address (old id), not every keeper on
-// the node; carpvipdhcp_start then launches the renamed line from keeper.conf.
-$old_id = preg_replace('/[^A-Za-z0-9]/', '_', $old_ip);
-exec('/usr/local/etc/rc.d/carpvipdhcp restart ' . escapeshellarg($old_id) . ' 2>&1', $out, $rc);
-if ($rc !== 0) {
-    fwrite(STDERR, "keeper restart failed (rc={$rc}): " . implode(' | ', $out) . "\n");
+exec('/usr/local/etc/rc.d/carpvipdhcp stop ' . escapeshellarg($old_id) . ' 2>&1', $out, $rc);
+$out2 = array();
+$rc2 = 0;
+exec('/usr/local/etc/rc.d/carpvipdhcp start ' . escapeshellarg($new_id) . ' 2>&1', $out2, $rc2);
+if ($rc2 !== 0) {
+    fwrite(STDERR, "keeper start failed (rc={$rc2}): " . implode(' | ', $out2) . "\n");
     exit(1);
 }
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -80,7 +80,17 @@ import time
 from collections import namedtuple
 from logging.handlers import RotatingFileHandler
 
-from scapy.all import ARP, Ether, IP, UDP, BOOTP, DHCP, AsyncSniffer, sendp
+# Scapy is the one heavy third-party dependency and the usual suspect when the
+# daemon won't start (missing after an upgrade, ABI mismatch, partial install).
+# Import it defensively: a bare module-level import that throws would kill the
+# process before any log handler exists -> a silent non-start with the traceback
+# going to daemon(8)'s /dev/null. Capture it instead and let main() log it once
+# logging is configured.
+try:
+    from scapy.all import ARP, Ether, IP, UDP, BOOTP, DHCP, AsyncSniffer, sendp
+    _SCAPY_IMPORT_ERROR = None
+except Exception as _scapy_exc:   # ImportError, or scapy's own import-time failures
+    _SCAPY_IMPORT_ERROR = _scapy_exc
 
 LOG = logging.getLogger("lease-keeper")
 
@@ -229,6 +239,7 @@ class Keeper:
         self._follow_fired_at = 0.0    # when we last dispatched follow_update (retry deadline)
         self._last_master = True       # last known CARP-master decision (fail to this)
         self._gated_standby = False    # currently standing by as CARP backup (run-only-on-master)
+        self._acquiring_since = None   # epoch a run-only-on-master DORA (re)started; grace for CARP
         # Follow throttle state, keyed by chaddr so it survives the follow-induced
         # restart (the request-IP-keyed runtime paths change on every follow).
         self._follow_state = "/var/run/carpvipdhcp-follow-%s" % _fs_safe(self.chaddr)
@@ -678,6 +689,13 @@ class Keeper:
             gw = self._nudge_target()
             if gw:
                 extra += " gw=%s" % gw
+        # While a run-only-on-master keeper is (re)acquiring after promotion it has
+        # no lease yet, so bound=-. Publish acq=<start> so the CARP eligibility hook
+        # can grace this bounded DORA window instead of demoting us the instant we
+        # take over -- which, paired with demote_on_lease_loss, would flap the VIP
+        # back and forth between the nodes (neither can hold it through its DORA).
+        if not self.yiaddr and self.only_when_master and self._acquiring_since:
+            extra += " acq=%d" % int(self._acquiring_since)
         self._write_hb("%d bound=%s lease=%d t1=%d t2=%d src=%s%s\n"
                        % (int(time.time()), self.yiaddr or "-", self.lease, t1, t2, src, extra))
 
@@ -734,6 +752,18 @@ class Keeper:
                 return False
             LOG.warning("ISP gave %s (VIP was %s) at %s -- following: updating the CARP VIP",
                         got, self.request_ip, phase)
+            # We rewrite the VIP *address* only, not the interface prefix or the
+            # system default gateway. If the ISP also moved the gateway (a
+            # cross-subnet renumber) the follow alone leaves the default route
+            # pointing at the old gateway -> outbound dies despite a "successful"
+            # follow. We cannot safely reconfigure System->Gateways from here, so
+            # make the operator's required action loud rather than silent.
+            if rx.router and self.router and rx.router != self.router:
+                LOG.error("follow %s -> %s also changes the gateway (%s -> %s): this looks "
+                          "like a cross-subnet renumber. The VIP address is updated but the "
+                          "interface prefix and System->Gateways are NOT -- update them "
+                          "manually or outbound routing will stay broken.",
+                          self.request_ip, got, self.router, rx.router)
             self._record_follow()
             # _follow_update reads request_ip as the old address, so remember it
             # (for the retry watchdog) and fire before overwriting request_ip.
@@ -1073,19 +1103,24 @@ class Keeper:
                 if self.yiaddr:
                     self.release()
                     self.yiaddr = None
+                self._acquiring_since = None   # standing by, not acquiring
                 self._hb_standby()
                 self._sleep(GATE_POLL)
                 return
             if self._gated_standby:
                 LOG.info("CARP master for vhid %s -- resuming DHCP (re-acquiring the lease)", self.vhid)
                 self._gated_standby = False
+                self._acquiring_since = time.time()   # start the post-promotion DORA grace
         # Acquire a lease if we do not hold one.
         if not self.yiaddr:
+            if self.only_when_master and self._acquiring_since is None:
+                self._acquiring_since = time.time()   # e.g. booted straight into master
             self._ensure_sniffer()  # a dead sniffer would silently fail every DORA
             self._hb()  # active but not holding yet -> publish bound=- (not STANDBY)
             if self.dora():
                 LOG.info("DHCP BOUND %s (lease=%ss, expires ~%s, server=%s)",
                          self.yiaddr, self.lease, self._clock_at(self.lease), self.server)
+                self._acquiring_since = None   # holding a lease again -> grace no longer applies
                 self._hb()
                 self._arp_nudge(force=True)
                 self.redora_wait = REDORA_MIN
@@ -1200,6 +1235,12 @@ def main():
     # daemon restart.
     logging.basicConfig(level=logging.DEBUG, handlers=handlers,
                         format="%(asctime)s %(levelname)s %(message)s")
+
+    if _SCAPY_IMPORT_ERROR is not None:
+        LOG.critical("cannot import scapy -- the lease keeper cannot run: %s. "
+                     "Install the matching py3<minor>-scapy package (see the plugin "
+                     "docs) and restart the service.", _SCAPY_IMPORT_ERROR)
+        return 3
 
     for label, mac in (("chaddr", a.chaddr), ("eth-src", a.eth_src)):
         if mac and not MAC_RE.match(mac):

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -744,3 +744,65 @@ def test_sniffer_filter_captures_arp_and_honours_promisc(lk, monkeypatch):
     assert "arp" in captured["filter"]        # ARP replies now reach the parser
     assert "port 67" in captured["filter"]     # ...alongside DHCP, unchanged
     assert captured["promisc"] is True         # opt-in flag reaches the socket
+
+
+# ---- run-only-on-master acquire grace (acq=): breaks demote/promote ping-pong ----
+
+def _gated_keeper(lk, hbfile):
+    return lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7",
+                     hbfile=hbfile, only_when_master=True, vhid=10)
+
+
+def test_hb_acq_token_when_gated_master_acquiring(lk, tmp_path):
+    hb = tmp_path / "hb"
+    keeper = _gated_keeper(lk, str(hb))
+    keeper.yiaddr = None                  # promoted, DORA in progress -> bound=-
+    keeper._acquiring_since = 1783350000.0
+    keeper._hb()
+    content = hb.read_text()
+    assert " bound=- " in content
+    assert " acq=1783350000" in content
+
+
+def test_hb_no_acq_token_once_bound(lk, tmp_path):
+    hb = tmp_path / "hb"
+    keeper = _gated_keeper(lk, str(hb))
+    keeper.yiaddr = "100.64.4.7"          # holding a lease -> grace no longer relevant
+    keeper._acquiring_since = 1783350000.0
+    keeper._hb()
+    assert "acq=" not in hb.read_text()
+
+
+def test_hb_no_acq_token_when_not_gated(lk, tmp_path):
+    hb = tmp_path / "hb"
+    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=str(hb))  # not only_when_master
+    keeper.yiaddr = None
+    keeper._acquiring_since = 1783350000.0
+    keeper._hb()
+    content = hb.read_text()
+    assert " bound=- " in content
+    assert "acq=" not in content          # a plain keeper demotes immediately on loss (unchanged)
+
+
+# ---- follow across a changed gateway warns loudly (cross-subnet renumber) ----
+
+def _ack_gw(lk, yiaddr, router, server="100.64.4.1"):
+    return lk.DhcpReply(5, yiaddr, server, 1800, None, None, router)
+
+
+def test_follow_warns_on_gateway_change(lk, tmp_path, caplog):
+    keeper = _follow_keeper(lk, tmp_path)
+    keeper.router = "100.64.4.1"
+    with caplog.at_level("ERROR", logger="lease-keeper"):
+        assert keeper._handle_changed_address(
+            "100.64.5.60", _ack_gw(lk, "100.64.5.60", "100.64.5.1"), "DORA", True) is True
+    assert any("cross-subnet renumber" in r.getMessage() for r in caplog.records)
+
+
+def test_follow_no_gateway_warning_when_gateway_unchanged(lk, tmp_path, caplog):
+    keeper = _follow_keeper(lk, tmp_path)
+    keeper.router = "100.64.4.1"
+    with caplog.at_level("ERROR", logger="lease-keeper"):
+        keeper._handle_changed_address(
+            "100.64.4.60", _ack_gw(lk, "100.64.4.60", "100.64.4.1"), "DORA", True)
+    assert not any("cross-subnet" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
Pre-publication hardening for os-carp-vip-dhcp, from a multi-angle review. Release **1.4.0**.

### Fixes
- **Follow no longer silently drops the keeper (WAN blackhole).** `follow_update.php` ran `rc.d carpvipdhcp restart <old_id>`, but after a follow `keeper.conf` holds the new address whose id != old_id, so `carpvipdhcp_start` (which honours `svc_id`) skipped the renamed line — "Started 0 keeper(s)." Nothing renewed the lease and the WAN blackholed at expiry, on both nodes. Now stops `<old_id>` and starts `<new_id>` as separate steps.
- **demote_on_lease_loss + run_only_on_master ping-pong closed.** A just-promoted gated keeper DORAs from scratch and briefly publishes `bound=-`; the eligibility hook used to demote on that and flap the VIP between nodes. The keeper now stamps `acq=<epoch>` and the hook graces a bounded (120s) acquire window; a genuinely stuck acquire still demotes. Plain keepers unchanged.
- **Return-path blackhole now alerts.** The dashboard banner flags a keeper that holds its lease and nudges ARP but whose gateway (having answered before) has gone silent — the flagship failure mode, previously invisible. Ignores `arpok==0` to avoid false alarms.
- **Cross-subnet follow warns.** Follow rewrites the VIP address only, not the prefix or System→Gateways; it now logs a loud error when the ACK's gateway (option 3) changes.
- **Defensive scapy import** so a missing/broken install is logged by `main()` instead of a silent non-start.

### Docs
- Caveats: cross-subnet follow, shared-L2 forged-ACK / relaxed REBIND check, stop-service-vs-disable-keeper demotion.
- Drop the "spec-valid" over-claim; advisories are log-only; empty-VIP-dropdown / keeper-enable hints; a plain-text "signs it's working"; single-IP section reframed as a mental model.
- A visible note that the plugin aims for the official community-plugins tree.

### Tests
76 unit tests pass (5 new), flake8 clean; shell hooks pass `sh -n`.
