### PR TITLE
net/os-carp-vip-dhcp: soften the ARP-conflict log wording (peer physical-MAC egress)

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -356,14 +356,17 @@ class Keeper:
             LOG.debug("ARP reply parse error: %s", e)
 
     def _on_arp_conflict(self, p):
-        """Warn if another MAC claims our leased IP -- an ARP whose sender IP is
-        ours but whose sender MAC is not our CARP MAC (the peer node shares that
-        MAC, so it is excluded). Signals a duplicate address / ISP reassignment.
-        Passive and advisory (spoofable); it only logs, never acts. Throttled so a
-        persistent conflict does not flood the log: re-warns only when the
-        offending MAC changes or after ARP_CONFLICT_REWARN (a new impostor thus
-        surfaces at once). Detection and throttle state are touched only here
-        (sniffer thread) -> single-owner."""
+        """Log if another MAC claims our leased VIP -- an ARP whose sender IP is
+        ours but whose sender MAC is not our CARP MAC. On an HA pair this is
+        usually benign: the peer node egresses VIP-sourced traffic from its OWN
+        physical WAN MAC (FreeBSD CARP does not source that traffic from the
+        virtual MAC), which on the wire is indistinguishable from a genuine
+        impostor -- both are just a non-CARP MAC using the VIP, and neither CARP
+        adverts nor the peer's DHCP expose the peer's physical MAC to whitelist
+        it. So this is purely advisory: it logs (saying as much), never acts. The
+        peer's CARP MAC (== our chaddr) is excluded outright. Throttled: re-warns
+        only when the offending MAC changes or after ARP_CONFLICT_REWARN. Touched
+        only here (sniffer thread) -> single-owner."""
         try:
             if not self.yiaddr:
                 return
@@ -378,8 +381,11 @@ class Keeper:
                 return
             self._conflict_mac = mac
             self._last_conflict_warn = now
-            LOG.warning("ARP conflict: %s is using our leased IP %s (our MAC is %s) "
-                        "-- possible duplicate address or ISP reassignment",
+            LOG.warning("%s is using our VIP %s (not our CARP MAC %s). On an HA pair "
+                        "this is almost always the peer node's own WAN MAC -- CARP "
+                        "egresses VIP traffic from the physical MAC on FreeBSD, so it is "
+                        "expected and harmless. Only a concern if that MAC belongs to "
+                        "neither node (a real duplicate address or ISP reassignment).",
                         mac, self.yiaddr, self.chaddr)
         except Exception as e:
             LOG.debug("ARP conflict parse error: %s", e)

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -622,7 +622,7 @@ def test_arp_conflict_warns(lk, caplog):
     keeper = _nudge_keeper(lk)                    # yiaddr=100.64.4.7, chaddr=00:00:5e:00:01:fe
     with caplog.at_level("WARNING", logger="lease-keeper"):
         keeper._on_arp_conflict(_ArpPkt(lk, 2, "100.64.4.7", "100.64.4.1", hwsrc="aa:bb:cc:dd:ee:ff"))
-    assert any("ARP conflict" in r.getMessage() for r in caplog.records)
+    assert any("using our VIP" in r.getMessage() for r in caplog.records)
 
 
 def test_arp_conflict_ignores_our_own_mac(lk, caplog):
@@ -630,14 +630,14 @@ def test_arp_conflict_ignores_our_own_mac(lk, caplog):
     with caplog.at_level("WARNING", logger="lease-keeper"):
         # Same as our CARP MAC (the peer node shares it) -> not a conflict.
         keeper._on_arp_conflict(_ArpPkt(lk, 1, "100.64.4.7", "100.64.4.1", hwsrc="00:00:5e:00:01:fe"))
-    assert not any("ARP conflict" in r.getMessage() for r in caplog.records)
+    assert not any("using our VIP" in r.getMessage() for r in caplog.records)
 
 
 def test_arp_conflict_ignores_other_ip(lk, caplog):
     keeper = _nudge_keeper(lk)
     with caplog.at_level("WARNING", logger="lease-keeper"):
         keeper._on_arp_conflict(_ArpPkt(lk, 1, "100.64.4.99", "100.64.4.1", hwsrc="aa:bb:cc:dd:ee:ff"))
-    assert not any("ARP conflict" in r.getMessage() for r in caplog.records)
+    assert not any("using our VIP" in r.getMessage() for r in caplog.records)
 
 
 def test_arp_conflict_throttled_per_mac(lk, caplog):
@@ -646,7 +646,7 @@ def test_arp_conflict_throttled_per_mac(lk, caplog):
     with caplog.at_level("WARNING", logger="lease-keeper"):
         keeper._on_arp_conflict(pkt)
         keeper._on_arp_conflict(pkt)              # same MAC within the re-warn window
-    warnings = [r for r in caplog.records if "ARP conflict" in r.getMessage()]
+    warnings = [r for r in caplog.records if "using our VIP" in r.getMessage()]
     assert len(warnings) == 1
 
 


### PR DESCRIPTION
The ARP-conflict detector fires when a non-CARP MAC uses the VIP. On an HA pair that's almost always benign — the peer egresses VIP-sourced traffic from its own **physical** WAN MAC (FreeBSD CARP doesn't source it from the virtual MAC), indistinguishable on the wire from a real impostor, and neither CARP adverts nor the peer's DHCP expose that physical MAC to whitelist it. The peer's shared CARP MAC is already excluded; this only rewords the message for the physical-MAC case so it reads as expected/harmless (investigate only if the MAC belongs to neither node). Advisory only, no behaviour change; docstring + 4 tests updated.