### PR TITLE
os-carp-vip-dhcp: clarify WAN VIP is the ISP-leased address (docs, #39)

### DIFF
--- a/net/os-carp-vip-dhcp/docs/single-ip-wan-carp.md
+++ b/net/os-carp-vip-dhcp/docs/single-ip-wan-carp.md
@@ -185,6 +185,16 @@ flowchart TB
 > production pick an unusual vhid — see [§8 vhid collision](#8-open-questions-and-risks)
 > about shared ISP L2.
 
+> **The VIP is not a network you choose:** it is whatever address the ISP leases on the
+> virtual MAC, so it always sits in the ISP gateway's subnet (the gateway must be
+> on-link). The `/24` here is illustrative; the real mask is the ISP's. If the ISP only
+> changes your *address* within that subnet, `followIp` adopts it seamlessly. If it moves
+> you to a *different* subnet with a *different* gateway, follow rewrites the VIP address
+> but not the netmask or the System > Gateways entry, so that case needs a manual fix for
+> now (the daemon logs a `cross-subnet renumber` error). Bringing follow to parity with a
+> plain DHCP interface here (adopt the new mask and gateway automatically) is tracked in
+> issue #39.
+
 ---
 
 ## 6  The backup's internet — gateway group


### PR DESCRIPTION
Answers the clarification question in #39.

Adds a note to `docs/single-ip-wan-carp.md` section 5 making explicit that the WAN CARP VIP is not a network you choose. It is whatever address the ISP leases on the virtual MAC, so it always sits in the ISP gateway's subnet (the gateway must be on-link). It also states the cross-subnet-renumber limitation: `followIp` adopts a same-subnet address change seamlessly, but a move to a different subnet or gateway updates the VIP address only (not the netmask or the System > Gateways entry) and needs a manual fix. The daemon logs a `cross-subnet renumber` error to flag it.

Docs only, no code change. #39 stays open to track a possible future opt-in that follows across subnets (auto-adopting the new mask and gateway from the DHCP ACK).
