### PR TITLE
os-carp-vip-dhcp: follow a cross-subnet renumber (adopt new gateway + prefix)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.5.1
+PLUGIN_VERSION=         1.6.0
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/docs/single-ip-wan-carp.md
+++ b/net/os-carp-vip-dhcp/docs/single-ip-wan-carp.md
@@ -186,14 +186,13 @@ flowchart TB
 > about shared ISP L2.
 
 > **The VIP is not a network you choose:** it is whatever address the ISP leases on the
-> virtual MAC, so it always sits in the ISP gateway's subnet (the gateway must be
-> on-link). The `/24` here is illustrative; the real mask is the ISP's. If the ISP only
-> changes your *address* within that subnet, `followIp` adopts it seamlessly. If it moves
-> you to a *different* subnet with a *different* gateway, follow rewrites the VIP address
-> but not the netmask or the System > Gateways entry, so that case needs a manual fix for
-> now (the daemon logs a `cross-subnet renumber` error). Bringing follow to parity with a
-> plain DHCP interface here (adopt the new mask and gateway automatically) is tracked in
-> issue #39.
+> virtual MAC, so it always sits in the ISP gateway's subnet. The `/24` here is
+> illustrative; the real mask is the ISP's. With `followIp` on, the plugin follows a
+> changed lease, including a cross-subnet renumber: it adopts the new address and, from
+> the DHCP ACK's subnet mask and gateway, updates the VIP prefix and the WAN gateway too,
+> so outbound keeps working (the same as a plain DHCP interface). If the ACK carries no
+> subnet mask it can only move the address, and logs a warning to fix the prefix and
+> gateway by hand.
 
 ---
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
@@ -38,10 +38,12 @@ if ($old_ip === $new_ip) {
 }
 
 // Optional cross-subnet args (all three together): the ISP moved us to a
-// different subnet, so also repoint the VIP prefix + the WAN gateway.
+// different subnet, so also repoint the VIP prefix + the WAN gateway. The
+// configd action always passes 5 params and pads a same-subnet call with empty
+// strings, so an empty old_gw means address-only, not a cross-subnet move.
 $old_gw = $new_gw = null;
 $new_bits = null;
-if ($argc >= 6) {
+if ($argc >= 6 && $argv[3] !== '') {
     $old_gw = $argv[3];
     $new_gw = $argv[4];
     $new_bits = (int)$argv[5];
@@ -179,13 +181,13 @@ if ($old_vip_iface !== '' && $old_ip !== $new_ip) {
 
 // Cross-subnet: the WAN gateway moved, so reapply routing (reconfigure_vips
 // re-adds the VIP but does not touch the default route). The config change above
-// is what persists; this reapply is the one path still to validate on a live box.
+// is what persists; this reapply installs the new default route.
 if ($gw_changed) {
     require_once("system.inc");
     if (function_exists('system_routing_configure')) {
         system_routing_configure();
     } else {
-        exec('/usr/local/sbin/configctl interface routing reconfigure 2>&1');
+        exec('/usr/local/sbin/configctl interface routes configure 2>&1');
     }
 }
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
@@ -248,8 +248,8 @@ if ($rc !== 0) {
     fwrite(STDERR, "manage_alias failed (rc={$rc}): " . implode(' | ', $out) . "\n");
 }
 
+$msg = "updated CARP VIP {$old_ip} -> {$new_ip}";
 if ($gw_changed) {
-    echo "updated CARP VIP {$old_ip} -> {$new_ip} and WAN gateway {$old_gw} -> {$new_gw} (/{$new_bits})\n";
-} else {
-    echo "updated CARP VIP {$old_ip} -> {$new_ip}\n";
+    $msg .= " and WAN gateway {$old_gw} -> {$new_gw} (/{$new_bits})";
 }
+echo "{$msg}\n";

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
@@ -2,13 +2,18 @@
 <?php
 
 /*
- * follow_update.php <old_ip> <new_ip>
+ * follow_update.php <old_ip> <new_ip> [<old_gw> <new_gw> <new_bits>]
  *
  * Triggered by a follow-mode keeper daemon when the ISP hands out a different
  * address. Rewrites the CARP VIP (whose current subnet is <old_ip>) and every
  * keeper that references it to <new_ip>, then re-applies the VIP and restarts
  * the keepers. Both HA nodes run this independently and converge on the same
  * address because they share the same chaddr (one ISP lease per chaddr).
+ *
+ * On a cross-subnet renumber the daemon also passes the old/new gateway and the
+ * new prefix length: the VIP's subnet_bits and the WAN gateway are updated too
+ * and routing is reapplied, so outbound keeps working (parity with a plain DHCP
+ * interface). Same-subnet moves omit those args and touch only the address.
  */
 
 require_once("config.inc");
@@ -30,6 +35,26 @@ foreach ([$old_ip, $new_ip] as $ip) {
 }
 if ($old_ip === $new_ip) {
     exit(0);
+}
+
+// Optional cross-subnet args (all three together): the ISP moved us to a
+// different subnet, so also repoint the VIP prefix + the WAN gateway.
+$old_gw = $new_gw = null;
+$new_bits = null;
+if ($argc >= 6) {
+    $old_gw = $argv[3];
+    $new_gw = $argv[4];
+    $new_bits = (int)$argv[5];
+    foreach ([$old_gw, $new_gw] as $g) {
+        if (!filter_var($g, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            fwrite(STDERR, "invalid gateway argument: {$g}\n");
+            exit(1);
+        }
+    }
+    if ($new_bits < 1 || $new_bits > 32) {
+        fwrite(STDERR, "invalid prefix bits: {$argv[5]}\n");
+        exit(1);
+    }
 }
 
 // Single-writer per node. Two follow_update runs racing on the same node (a
@@ -54,6 +79,9 @@ if (isset($config['virtualip']['vip']) && is_array($config['virtualip']['vip']))
     foreach ($config['virtualip']['vip'] as $idx => $vip) {
         if (($vip['mode'] ?? '') === 'carp' && ($vip['subnet'] ?? '') === $old_ip) {
             $config['virtualip']['vip'][$idx]['subnet'] = $new_ip;
+            if ($new_bits !== null) {
+                $config['virtualip']['vip'][$idx]['subnet_bits'] = $new_bits;
+            }
             $old_vip_iface = $vip['interface'] ?? '';
             $vip_changed = true;
         }
@@ -81,7 +109,24 @@ if (isset($config['OPNsense']['CarpVipDhcp']['keepers']['keeper'])) {
     }
 }
 
-if (!$vip_changed && !$keeper_changed) {
+// 2b. Cross-subnet: repoint the WAN gateway on the VIP's interface (the entry
+// whose current gateway is old_gw) to the new gateway.
+$gw_changed = false;
+if ($new_gw !== null && $old_vip_iface !== ''
+        && isset($config['gateways']['gateway_item']) && is_array($config['gateways']['gateway_item'])) {
+    foreach ($config['gateways']['gateway_item'] as $gidx => $gw) {
+        if (($gw['interface'] ?? '') === $old_vip_iface && ($gw['gateway'] ?? '') === $old_gw
+                && ($gw['ipprotocol'] ?? 'inet') === 'inet') {
+            $config['gateways']['gateway_item'][$gidx]['gateway'] = $new_gw;
+            $gw_changed = true;
+        }
+    }
+    if (!$gw_changed) {
+        fwrite(STDERR, "warning: no IPv4 gateway on {$old_vip_iface} with address {$old_gw} to repoint\n");
+    }
+}
+
+if (!$vip_changed && !$keeper_changed && !$gw_changed) {
     // Nothing referenced old_ip. Either there is genuinely nothing to do, or a
     // previous run (or the peer node) already migrated the config to new_ip and
     // this is a retry. If a CARP VIP already carries new_ip, fall through and
@@ -129,6 +174,18 @@ if ($old_vip_iface !== '' && $old_ip !== $new_ip) {
     $dev = get_real_interface($old_vip_iface);
     if (!empty($dev)) {
         exec('/sbin/ifconfig ' . escapeshellarg($dev) . ' -alias ' . escapeshellarg($old_ip) . ' 2>&1');
+    }
+}
+
+// Cross-subnet: the WAN gateway moved, so reapply routing (reconfigure_vips
+// re-adds the VIP but does not touch the default route). The config change above
+// is what persists; this reapply is the one path still to validate on a live box.
+if ($gw_changed) {
+    require_once("system.inc");
+    if (function_exists('system_routing_configure')) {
+        system_routing_configure();
+    } else {
+        exec('/usr/local/sbin/configctl interface routing reconfigure 2>&1');
     }
 }
 
@@ -189,4 +246,8 @@ if ($rc !== 0) {
     fwrite(STDERR, "manage_alias failed (rc={$rc}): " . implode(' | ', $out) . "\n");
 }
 
-echo "updated CARP VIP {$old_ip} -> {$new_ip}\n";
+if ($gw_changed) {
+    echo "updated CARP VIP {$old_ip} -> {$new_ip} and WAN gateway {$old_gw} -> {$new_gw} (/{$new_bits})\n";
+} else {
+    echo "updated CARP VIP {$old_ip} -> {$new_ip}\n";
+}

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -107,9 +107,10 @@ LOG_BACKUPS = 3
 
 # A parsed DHCP reply, snapshotted from the sniffer thread.
 # `message` (DHCP option 56) is the server's optional human-readable text, mainly
-# a NAK reason. Defaulted so existing 7-field constructions stay valid.
-DhcpReply = namedtuple("DhcpReply", "mtype yiaddr server_id lease t1 t2 router message",
-                       defaults=(None,))
+# a NAK reason; `subnet_mask` (option 1) is used to follow a cross-subnet renumber.
+# Both are defaulted so existing 7-field constructions stay valid.
+DhcpReply = namedtuple("DhcpReply", "mtype yiaddr server_id lease t1 t2 router message subnet_mask",
+                       defaults=(None, None))
 MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
 
 
@@ -149,6 +150,15 @@ def _same_ip_class(a, b):
         return _is_localish(a) == _is_localish(b)
     except ValueError:
         return False
+
+
+def _mask_to_bits(mask):
+    """Dotted-quad subnet mask (DHCP option 1) -> prefix length, or None if absent
+    or unparseable."""
+    try:
+        return ipaddress.IPv4Network("0.0.0.0/%s" % mask).prefixlen
+    except (ValueError, TypeError):
+        return None
 
 
 def _fs_safe(s):
@@ -208,6 +218,7 @@ class Keeper:
         self._followed_ip = None       # last address we asked configd to follow to
         self._follow_from = None       # address we followed FROM (for the retry watchdog)
         self._follow_fired_at = 0.0    # when we last dispatched follow_update (retry deadline)
+        self._follow_gw_args = []      # extra follow_update args on a cross-subnet move: [old_gw, new_gw, bits]
         # Follow throttle state, keyed by chaddr so it survives the follow-induced
         # restart (the request-IP-keyed runtime paths change on every follow).
         self._follow_state = "/var/run/carpvipdhcp-follow-%s" % _fs_safe(self.chaddr)
@@ -300,7 +311,7 @@ class Keeper:
         """Snapshot only the handful of DHCP options the keeper acts on into a
         DhcpReply; the rest of the reply's option data -- untrusted, from
         whatever answered on the wire -- is left untouched."""
-        mt = sid = lt = rt = bt = ro = msg = None
+        mt = sid = lt = rt = bt = ro = msg = sm = None
         for o in p[DHCP].options:
             if isinstance(o, tuple):
                 if o[0] == "message-type":
@@ -317,7 +328,9 @@ class Keeper:
                     ro = o[1]
                 elif o[0] == "message":     # option 56: server's text (e.g. a NAK reason)
                     msg = o[1]
-        return DhcpReply(mt, yiaddr, sid, lt, rt, bt, ro, msg)
+                elif o[0] == "subnet_mask":  # option 1: to follow a cross-subnet renumber
+                    sm = o[1]
+        return DhcpReply(mt, yiaddr, sid, lt, rt, bt, ro, msg, sm)
 
     def _chaddr_matches(self, b):
         """True if the reply's BOOTP client hardware address is our chaddr (the
@@ -617,18 +630,23 @@ class Keeper:
                 return False
             LOG.warning("ISP gave %s (VIP was %s) at %s -- following: updating the CARP VIP",
                         got, self.request_ip, phase)
-            # We rewrite the VIP *address* only, not the interface prefix or the
-            # system default gateway. If the ISP also moved the gateway (a
-            # cross-subnet renumber) the follow alone leaves the default route
-            # pointing at the old gateway -> outbound dies despite a "successful"
-            # follow. We cannot safely reconfigure System->Gateways from here, so
-            # make the operator's required action loud rather than silent.
+            # If the ISP also moved the gateway (a cross-subnet renumber), follow the
+            # new gateway + prefix too so outbound keeps working -- parity with what a
+            # plain DHCP interface does. Needs the new subnet mask (opt 1) to set the
+            # VIP prefix; without it we can only move the address, so warn instead.
+            self._follow_gw_args = []
             if rx.router and self.router and rx.router != self.router:
-                LOG.error("follow %s -> %s also changes the gateway (%s -> %s): this looks "
-                          "like a cross-subnet renumber. The VIP address is updated but the "
-                          "interface prefix and System->Gateways are NOT -- update them "
-                          "manually or outbound routing will stay broken.",
-                          self.request_ip, got, self.router, rx.router)
+                bits = _mask_to_bits(rx.subnet_mask)
+                if bits:
+                    LOG.warning("follow %s -> %s also moves the gateway (%s -> %s), subnet "
+                                "/%d -- following across the subnet", self.request_ip, got,
+                                self.router, rx.router, bits)
+                    self._follow_gw_args = [self.router, rx.router, str(bits)]
+                else:
+                    LOG.error("follow %s -> %s changes the gateway (%s -> %s) but the ACK "
+                              "carried no subnet mask -- updating the VIP address only; fix the "
+                              "interface prefix + System->Gateways by hand", self.request_ip,
+                              got, self.router, rx.router)
             self._record_follow()
             # _follow_update reads request_ip as the old address, so remember it
             # (for the retry watchdog) and fire before overwriting request_ip.
@@ -667,8 +685,9 @@ class Keeper:
         """Dispatch the configd follow_update action (old -> new) and stamp the
         retry deadline. Separate from _follow_update so the watchdog can re-drive
         a stalled follow without tripping the _followed_ip equality guard."""
-        subprocess.Popen(["/usr/local/sbin/configctl", "-d", "carpvipdhcp",
-                          "follow_update", old_ip, new_ip])
+        cmd = ["/usr/local/sbin/configctl", "-d", "carpvipdhcp", "follow_update", old_ip, new_ip]
+        cmd += self._follow_gw_args   # cross-subnet: [old_gw, new_gw, bits]; empty on a same-subnet move
+        subprocess.Popen(cmd)
         self._follow_fired_at = time.time()
 
     def _follow_watchdog(self):

--- a/net/os-carp-vip-dhcp/src/opnsense/service/conf/actions.d/actions_carpvipdhcp.conf
+++ b/net/os-carp-vip-dhcp/src/opnsense/service/conf/actions.d/actions_carpvipdhcp.conf
@@ -42,9 +42,13 @@ type:script
 message:restarting carpvipdhcp keeper
 template:OPNsense/CarpVipDhcp
 
+# 5 params: old_ip new_ip [old_gw new_gw bits]. The daemon sends 2 on a
+# same-subnet move and 5 on a cross-subnet renumber; configd pads a short call
+# to 5 with empty strings, and passing MORE args than %s tokens would fail with
+# "Parameter mismatch", so the token count must cover the widest call.
 [follow_update]
 command:/usr/local/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
-parameters:%s %s
+parameters:%s %s %s %s %s
 type:script
 message:carpvipdhcp follow ISP address change
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -521,25 +521,38 @@ def test_sniffer_filter_captures_arp_and_honours_promisc(lk, monkeypatch):
     assert captured["promisc"] is True         # opt-in flag reaches the socket
 
 
-# ---- follow across a changed gateway warns loudly (cross-subnet renumber) ----
+# ---- follow across a changed gateway (cross-subnet renumber) ----
 
-def _ack_gw(lk, yiaddr, router, server="100.64.4.1"):
-    return lk.DhcpReply(5, yiaddr, server, 1800, None, None, router)
+def _ack_gw(lk, yiaddr, router, server="100.64.4.1", mask=None):
+    return lk.DhcpReply(5, yiaddr, server, 1800, None, None, router, None, mask)
 
 
-def test_follow_warns_on_gateway_change(lk, tmp_path, caplog):
+def test_follow_across_subnet_with_mask(lk, tmp_path, caplog):
     keeper = _follow_keeper(lk, tmp_path)
     keeper.router = "100.64.4.1"
-    with caplog.at_level("ERROR", logger="lease-keeper"):
+    with caplog.at_level("WARNING", logger="lease-keeper"):
         assert keeper._handle_changed_address(
-            "100.64.5.60", _ack_gw(lk, "100.64.5.60", "100.64.5.1"), "DORA", True) is True
-    assert any("cross-subnet renumber" in r.getMessage() for r in caplog.records)
+            "100.64.5.60", _ack_gw(lk, "100.64.5.60", "100.64.5.1", mask="255.255.255.0"),
+            "DORA", True) is True
+    # gateway + prefix are handed to follow_update so outbound follows the new subnet
+    assert keeper._follow_gw_args == ["100.64.4.1", "100.64.5.1", "24"]
+    assert any("following across the subnet" in r.getMessage() for r in caplog.records)
 
 
-def test_follow_no_gateway_warning_when_gateway_unchanged(lk, tmp_path, caplog):
+def test_follow_gateway_change_without_mask_warns(lk, tmp_path, caplog):
     keeper = _follow_keeper(lk, tmp_path)
     keeper.router = "100.64.4.1"
-    with caplog.at_level("ERROR", logger="lease-keeper"):
+    with caplog.at_level("ERROR", logger="lease-keeper"):   # no mask in the ACK
         keeper._handle_changed_address(
-            "100.64.4.60", _ack_gw(lk, "100.64.4.60", "100.64.4.1"), "DORA", True)
-    assert not any("cross-subnet" in r.getMessage() for r in caplog.records)
+            "100.64.5.60", _ack_gw(lk, "100.64.5.60", "100.64.5.1"), "DORA", True)
+    # without a mask we can't set the prefix: address-only follow + a fix-by-hand warning
+    assert keeper._follow_gw_args == []
+    assert any("carried no subnet mask" in r.getMessage() for r in caplog.records)
+
+
+def test_follow_no_gateway_change_no_extra_args(lk, tmp_path):
+    keeper = _follow_keeper(lk, tmp_path)
+    keeper.router = "100.64.4.1"
+    keeper._handle_changed_address(          # same gateway -> no cross-subnet extras
+        "100.64.4.60", _ack_gw(lk, "100.64.4.60", "100.64.4.1"), "DORA", True)
+    assert keeper._follow_gw_args == []

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1,4 +1,5 @@
 """Unit tests for the lease-keeper daemon's pure helpers and follow decision."""
+import os
 import time
 import types
 
@@ -556,3 +557,27 @@ def test_follow_no_gateway_change_no_extra_args(lk, tmp_path):
     keeper._handle_changed_address(          # same gateway -> no cross-subnet extras
         "100.64.4.60", _ack_gw(lk, "100.64.4.60", "100.64.4.1"), "DORA", True)
     assert keeper._follow_gw_args == []
+
+
+def test_follow_update_action_arity():
+    """The configd [follow_update] action must accept as many params as the
+    daemon can send: _fire_follow_update passes old_ip + new_ip plus
+    _follow_gw_args ([old_gw, new_gw, bits] on a cross-subnet move) = 5. configd
+    raises "Parameter mismatch" when more args than %s tokens are passed, so a
+    narrower template would silently break every cross-subnet follow via
+    configctl (a boundary the direct-call tests above never cross)."""
+    conf = os.path.join(
+        os.path.dirname(__file__), "..", "src", "opnsense", "service",
+        "conf", "actions.d", "actions_carpvipdhcp.conf")
+    params = None
+    in_section = False
+    with open(conf) as fh:
+        for raw in fh:
+            line = raw.strip()
+            if line.startswith("[") and line.endswith("]"):
+                in_section = (line == "[follow_update]")
+            elif in_section and line.startswith("parameters:"):
+                params = line.split(":", 1)[1]
+                break
+    assert params is not None, "[follow_update] action or its parameters line is missing"
+    assert params.count("%s") >= 5, "follow_update template narrower than the daemon's 5-arg call"


### PR DESCRIPTION
Closes #39. Rebased on main after the #43 hotfix merged (so this branch inherits the mwexec fix from main; version 1.6.0).

Follows a cross-subnet renumber: when the ISP moves the lease to a different subnet with a different gateway, follow mode now adopts the new gateway and prefix too, not just the address, so outbound keeps working. This is parity with what a plain DHCP interface already does; the plugin didn't, only because the lease lives on a CARP VIP rather than the native DHCP path.

## Changes (lean, no new option or GUI)
- **Daemon** (`lease-keeper.py`): parse the subnet mask (DHCP option 1) into `DhcpReply`; on a follow whose gateway changed, hand `[old_gw, new_gw, prefix-bits]` to `follow_update`. If the ACK carries no mask, fall back to the previous address-only follow plus a fix-by-hand warning.
- **`follow_update.php`**: with those extra args, set the CARP VIP's `subnet_bits` and repoint the WAN `gateway_item`, then reapply routing.
- **Docs**: `single-ip-wan-carp.md` now states the cross-subnet case is followed.

No new config field or GUI: it is a natural extension of `followIp`, and trusting the DHCP-provided gateway is the same trust a plain DHCP WAN already extends. Version bump to **1.6.0** (minor: new follow capability).

## Integration-API audit fixes
A review of every configd/shell/legacy-PHP call the plugin makes surfaced two issues in the follow path (a third, `mwexec()` undefined on 26.1, landed separately as the #43 hotfix and is now in main):
- **configd action arity**: `[follow_update]` declared `parameters:%s %s` (2), but the daemon passes 5 args on a cross-subnet renumber. configd raises `Parameter mismatch` when given more args than `%s` tokens, so every cross-subnet follow was rejected before the script ran (the 2-arg same-subnet path was fine). Widened the template to 5 tokens (configd pads a short same-subnet call with empty strings, so the script treats an empty `old_gw` as address-only). Added a unit test asserting the token count covers the daemon's widest call.
- **Routing fallback action name**: the `system_routing_configure()` fallback ran `configctl interface routing reconfigure`, which is not a real action; corrected to `interface routes configure` (`[routes.configure]`). Only reached if the function is absent (it is present on 26.1), but the string was wrong.

## Lab validation (OPNsense 26.1, two clones on a Proxmox bench)
Drove `follow_update.php` directly on a lab clone with the production slave stopped:
- **PHP lint** clean (also confirmed by CI); `system_routing_configure()` confirmed present on 26.1.
- **Address-only follow** and **cross-subnet follow (argc 6, bits=24)** both complete `EXIT=0`: VIP subnet and `subnet_bits` rewritten, reverted clean.
- **Dynamic-gateway finding**: a DHCP WAN carries an empty (dynamic) `gateway_item`, so there is no static IPv4 gateway to repoint; `follow_update` correctly skips it and OPNsense follows the gateway natively. The gateway-repoint + routing-reapply branch therefore only applies to a static-gateway single-IP WAN and was not exercised end-to-end on the DHCP bench; it rests on the confirmed `system_routing_configure()` presence, the PHP lint, and the unit tests.
- Note: the lab called the script directly, which bypasses configd, so it did not cover the action-arity path above. That path is now covered by the new unit test and the corrected action definition.

67 unit tests pass, flake8 clean, PHP/shell/XML CI green. Supersedes the docs-only clarification in #41 (already merged).
