### PR TITLE
os-carp-vip-dhcp: fix follow_update crash on 26.1 (mwexec undefined), bump 1.5.1

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.5.0
+PLUGIN_VERSION=         1.5.1
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
@@ -128,7 +128,7 @@ if ($rc !== 0) {
 if ($old_vip_iface !== '' && $old_ip !== $new_ip) {
     $dev = get_real_interface($old_vip_iface);
     if (!empty($dev)) {
-        mwexec('/sbin/ifconfig ' . escapeshellarg($dev) . ' -alias ' . escapeshellarg($old_ip));
+        exec('/sbin/ifconfig ' . escapeshellarg($dev) . ' -alias ' . escapeshellarg($old_ip) . ' 2>&1');
     }
 }
 


### PR DESCRIPTION
## Bug
`follow_update.php` cleans up the old CARP VIP alias with `mwexec()`. That function is undefined in this script's standalone CLI context on OPNsense 26.1 (the minimal `config.inc`/`util.inc`/`interfaces.inc` bootstrap this script loads does not define it), so the call throws a fatal `Call to undefined function mwexec()`.

The call sits after the VIP has already been moved (write_config + reconfigure_vips) but before the keeper is restarted, so a follow on 26.1 dies half-way: the address follows, but the keeper never restarts onto the new address. Present in released v1.5.0; breaks any follow on 26.1.

## Fix
Use the PHP built-in `exec(... 2>&1)` instead, matching every other shell-out in this file (reconfigure_vips, configctl, rc.d all use `exec`). `mwexec` was the lone legacy call.

## Validation
Lab-confirmed on an OPNsense 26.1 clone: pre-fix the follow fatalled at the alias line; post-fix an address-only follow completes `EXIT=0` (VIP moved, keeper restarted) and a cross-subnet follow (VIP subnet + `subnet_bits` rewritten) completes clean.

Patch bump 1.5.0 to 1.5.1. The same fix also rides on #42; this splits it out so it can land independently of the cross-subnet feature.
