### PR TITLE
os-carp-vip-dhcp: DHCP RFC-compliance fixes (PRL, RENEW server_id, backoff jitter), bump 1.6.1

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.6.0
+PLUGIN_VERSION=         1.6.1
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -496,10 +496,14 @@ class Keeper:
         return False
 
     def renew(self, rebind=False):
-        # RENEWING/REBINDING (RFC 2131 4.3.2/4.4.5): ciaddr identifies the lease,
-        # so requested_addr is omitted. RENEW (T1) still names the leasing server;
-        # REBIND (T2) drops server_id so ANY DHCP server may answer.
-        opts = [] if rebind or not self.server else [("server_id", self.server)]
+        # RENEWING/REBINDING (RFC 2131 4.3.2): ciaddr identifies the lease, so
+        # server_id AND requested_addr MUST NOT be set in either state. We always
+        # broadcast (the co-resident non-promiscuous sniffer needs the reply
+        # broadcast), so any server may answer, which is fine for a single-server
+        # ISP WAN. `rebind` is still load-bearing: it picks the log label AND
+        # (via the `phase` it sets) relaxes the expected-server check in
+        # _handle_changed_address, since at T2 any server may legitimately answer.
+        opts = []
         for _ in range(RENEW_ATTEMPTS):
             if self.stop:
                 return False

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -80,6 +80,13 @@ LOG = logging.getLogger("lease-keeper")
 OFFER, ACK, NAK = 2, 5, 6
 BOOTREPLY = 2              # BOOTP op field: a server->client reply (unrelated to OFFER)
 
+# Options we ask the server to include on every DISCOVER/REQUEST (RFC 2132 option
+# 55, Parameter Request List). Subnet mask (1) + router (3) drive follow mode's
+# cross-subnet decision; lease/server-id/T1/T2 (51/54/58/59) drive renew timing.
+# Many servers return ONLY options named in the PRL, so without this the keeper
+# can silently miss the mask/router it needs to follow a cross-subnet renumber.
+PARAM_REQ_LIST = [1, 3, 51, 54, 58, 59]
+
 # Timing / retry tunables (seconds unless noted).
 HB_REFRESH = 30            # rewrite the heartbeat at least this often while holding a lease
 DEFAULT_LEASE = 3600       # fallback lease time if the server sends none
@@ -193,6 +200,7 @@ class Keeper:
         # Opt-in fallback for NICs that drop non-primary unicast MACs.
         self.arp_listen_promisc = arp_listen_promisc
         self.router = None             # default gateway (DHCP opt 3, fallback: server_id)
+        self.mask_bits = None          # subnet prefix length from opt 1 (for logging + follow)
         self._last_nudge = 0.0
         self._nudge_gw = None          # last nudge target we logged (log again on change)
         self._nudge_warned = False     # warned once about a missing nudge target
@@ -379,6 +387,13 @@ class Keeper:
 
     # ---- DHCP protocol (send / await reply / DORA / renew / release) ----
 
+    def _dhcp_options(self, mtype, extra):
+        """The DHCP option list for a message: type, our Parameter Request List
+        (so the server returns the mask/router/timers the keeper acts on), the
+        identity options, then the per-message extras."""
+        return ([("message-type", mtype), ("param_req_list", PARAM_REQ_LIST)]
+                + self._id_opts + extra + ["end"])
+
     def _send_dhcp(self, mtype, extra, ciaddr="0.0.0.0"):
         # ciaddr is set for RENEW/REBIND (the client already owns the address);
         # the broadcast flag stays on so the reply is reliably captured by the sniffer.
@@ -386,7 +401,7 @@ class Keeper:
                IP(src=ciaddr, dst="255.255.255.255") /
                UDP(sport=68, dport=67) /
                BOOTP(chaddr=self.chraw, xid=self.xid, ciaddr=ciaddr, flags=BROADCAST_FLAG) /
-               DHCP(options=[("message-type", mtype)] + self._id_opts + extra + ["end"]))
+               DHCP(options=self._dhcp_options(mtype, extra)))
         sendp(pkt, iface=self.iface, verbose=0)
 
     def _wait_for_dhcp_reply(self, want, timeout):
@@ -416,11 +431,14 @@ class Keeper:
         return None
 
     def _absorb_reply(self, rx, default_lease):
-        """Adopt lease timing and gateway (DHCP option 3) from an ACK -- the one
-        place that knows which DhcpReply fields carry keeper state."""
+        """Adopt lease timing, gateway (opt 3) and subnet mask (opt 1) from an ACK
+        -- the one place that knows which DhcpReply fields carry keeper state.
+        gateway + mask are what the Parameter Request List asks for; keep them for
+        logging + the cross-subnet follow decision."""
         self.lease = rx.lease or default_lease
         self.t1_server, self.t2_server = rx.t1, rx.t2
         self.router = rx.router or self.router
+        self.mask_bits = _mask_to_bits(rx.subnet_mask) or self.mask_bits
 
     def dora(self):
         """Acquire a lease via the DHCP DORA handshake -- Discover, Offer,
@@ -927,8 +945,10 @@ class Keeper:
             self._ensure_sniffer()  # a dead sniffer would silently fail every DORA
             self._hb()  # active but not holding yet -> publish bound=-
             if self.dora():
-                LOG.info("DHCP BOUND %s (lease=%ss, expires ~%s, server=%s)",
-                         self.yiaddr, self.lease, self._clock_at(self.lease), self.server)
+                LOG.info("DHCP BOUND %s (lease=%ss, expires ~%s, server=%s, gw=%s, mask=%s)",
+                         self.yiaddr, self.lease, self._clock_at(self.lease), self.server,
+                         self.router or "?",
+                         "/%d" % self.mask_bits if self.mask_bits else "none")
                 self._hb()
                 self._arp_nudge(force=True)
                 self.redora_wait = REDORA_MIN

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -173,6 +173,16 @@ def _fs_safe(s):
     return re.sub(r"[^A-Za-z0-9]", "_", s or "")
 
 
+def _jittered(base):
+    """A retransmit/backoff delay with +/-25% uniform jitter (RFC 2131 4.1
+    recommends a randomized backoff). Both HA nodes share the chaddr, so
+    jittering the acquire and REBIND retransmit cadences keeps them from
+    broadcasting in lockstep and colliding at the server. (The T1/T2 lease
+    timers are deterministic and shared too, but jittering those is a
+    lease-timing change, not a 4.1 retransmit concern, so they stay exact.)"""
+    return base * random.uniform(0.75, 1.25)
+
+
 def mac2raw(m):
     return bytes.fromhex(m.replace(":", "").replace("-", ""))
 
@@ -464,7 +474,7 @@ class Keeper:
                 break
             # xid included so the exchange can be matched against a packet capture.
             LOG.info("no DHCP OFFER (attempt %d, xid 0x%08x)", attempt, self.xid)
-            time.sleep(min(2 * attempt, ATTEMPT_BACKOFF_CAP))
+            time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
         else:
             return False
         for attempt in range(1, DORA_ATTEMPTS + 1):
@@ -492,7 +502,7 @@ class Keeper:
                 return True
             LOG.info("no DHCP ACK from %s for %s (attempt %d, xid 0x%08x)",
                      self.server, self.yiaddr, attempt, self.xid)
-            time.sleep(min(2 * attempt, ATTEMPT_BACKOFF_CAP))
+            time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
         return False
 
     def renew(self, rebind=False):
@@ -958,7 +968,7 @@ class Keeper:
                 self.redora_wait = REDORA_MIN
             else:
                 LOG.warning("DHCP acquire (DISCOVER/REQUEST) failed -- retrying in %ds", self.redora_wait)
-                self._sleep_interruptible(self.redora_wait)
+                self._sleep_interruptible(_jittered(self.redora_wait))
                 self.redora_wait = min(self.redora_wait * 2, REDORA_MAX)
             return
         # Maintain: wait until T1, then RENEW; bail early on stop.
@@ -981,7 +991,11 @@ class Keeper:
         elapsed = t1
         ok = False
         while elapsed < t2 and not self.stop:
-            step = min(REBIND_POLL_STEP, t2 - elapsed)
+            # Jitter the REBIND retransmit cadence: both nodes hit T2 together
+            # (identical lease timers), so an un-jittered step would broadcast
+            # REBIND in lockstep. Overshooting t2 slightly is harmless (the guard
+            # re-checks). Account the actual jittered wait so elapsed tracks it.
+            step = _jittered(min(REBIND_POLL_STEP, t2 - elapsed))
             if not self._sleep_interruptible(step):
                 break
             elapsed += step

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -634,3 +634,11 @@ def test_renew_omits_server_id_and_requested_addr(lk):
         wire = [o for o in keeper._dhcp_options(mtype, extra) if isinstance(o, tuple)]
         assert all(o[0] != "server_id" for o in wire)
         assert all(o[0] != "requested_addr" for o in wire)
+
+
+def test_backoff_jitter(lk):
+    # RFC 2131 §4.1 randomized backoff: the jittered delay stays within +/-25% of
+    # the base and is not constant, so two shared-chaddr nodes de-synchronize.
+    vals = [lk._jittered(8) for _ in range(200)]
+    assert all(6.0 <= v <= 10.0 for v in vals)   # 8 * [0.75, 1.25]
+    assert len(set(vals)) > 1

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -581,3 +581,32 @@ def test_follow_update_action_arity():
                 break
     assert params is not None, "[follow_update] action or its parameters line is missing"
     assert params.count("%s") >= 5, "follow_update template narrower than the daemon's 5-arg call"
+
+
+# ---- RFC 2131/2132 compliance ----
+
+def _plain_keeper(lk):
+    return lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+
+
+def test_dhcp_options_include_param_req_list(lk):
+    # Every DISCOVER/REQUEST must carry the Parameter Request List (RFC 2132 §9.8)
+    # so the server returns the subnet mask (1) + router (3) follow-mode needs.
+    keeper = _plain_keeper(lk)
+    opts = keeper._dhcp_options("discover", [("requested_addr", "100.64.4.7")])
+    assert opts[0] == ("message-type", "discover")
+    assert ("param_req_list", lk.PARAM_REQ_LIST) in opts
+    assert 1 in lk.PARAM_REQ_LIST and 3 in lk.PARAM_REQ_LIST
+    assert ("requested_addr", "100.64.4.7") in opts
+    assert opts[-1] == "end"
+
+
+def test_absorb_reply_captures_gw_and_mask(lk):
+    # The PRL asks for opt 3 (router) + opt 1 (mask); _absorb_reply keeps both so
+    # the BOUND log can surface them (and follow mode can use the mask).
+    keeper = _plain_keeper(lk)
+    rx = lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None,
+                      "100.64.4.1", None, "255.255.255.0")
+    keeper._absorb_reply(rx, lk.DEFAULT_LEASE)
+    assert keeper.router == "100.64.4.1"
+    assert keeper.mask_bits == 24

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -610,3 +610,27 @@ def test_absorb_reply_captures_gw_and_mask(lk):
     keeper._absorb_reply(rx, lk.DEFAULT_LEASE)
     assert keeper.router == "100.64.4.1"
     assert keeper.mask_bits == 24
+
+
+def test_renew_omits_server_id_and_requested_addr(lk):
+    # RFC 2131 §4.3.2: a RENEWING/REBINDING REQUEST MUST NOT carry server_id or
+    # requested_addr, and ciaddr MUST be the client's address.
+    keeper = _plain_keeper(lk)
+    keeper.server, keeper.yiaddr, keeper.lease = "100.64.4.1", "100.64.4.7", 1800
+    sent = []
+    keeper._ensure_sniffer = lambda: None
+    keeper._send_dhcp = lambda mtype, extra, ciaddr="0.0.0.0": sent.append((mtype, extra, ciaddr))
+    keeper._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
+        lk.ACK, keeper.yiaddr, keeper.server, 1800, None, None, None)
+    assert keeper.renew() is True            # RENEW (T1)
+    assert keeper.renew(rebind=True) is True  # REBIND (T2)
+    assert sent, "renew sent nothing"
+    for mtype, extra, ciaddr in sent:
+        assert mtype == "request"
+        assert ciaddr == "100.64.4.7"          # ciaddr MUST be the client's address
+        # assert on the ACTUAL assembled option list, not the stubbed extras
+        # (which are always empty here) -- so a regression that re-added
+        # server_id to renew's opts would fail this.
+        wire = [o for o in keeper._dhcp_options(mtype, extra) if isinstance(o, tuple)]
+        assert all(o[0] != "server_id" for o in wire)
+        assert all(o[0] != "requested_addr" for o in wire)


### PR DESCRIPTION
Three small, independent RFC-compliance fixes to the DHCP client (`lease-keeper.py`), from a review of RFC 2131/2132 against the daemon. Each is its own commit, unit-tested. Rebased onto main after #42 merged; version bump 1.6.0 -> 1.6.1 (patch). No behaviour change for a well-behaved single-server WAN, but each closes a real edge.

## Fixes
1. **Parameter Request List (RFC 2132 §9.8)** — the client never sent option 55, so it relied on the server *volunteering* the subnet mask (opt 1), router (opt 3) and lease timers. Many servers return only options named in the PRL, so the cross-subnet follow just merged in #42 could silently degrade to "address only" (missing the mask/router). Now sends `[1,3,51,54,58,59]` on every DISCOVER/REQUEST. This directly hardens #42's feature.
2. **Drop `server_id` from the RENEW request (RFC 2131 §4.3.2)** — a RENEWING-state DHCPREQUEST MUST NOT carry the server identifier; the client sent it at T1. A strict server could NAK and bounce the keeper into a needless re-DORA. The keeper always broadcasts the request anyway (the co-resident non-promiscuous sniffer needs the reply broadcast), so dropping `server_id` makes RENEW and REBIND wire-identical and RFC-correct.
3. **Jitter the retransmit/backoff (RFC 2131 §4.1)** — the intra-DORA waits were linear and un-jittered, and the re-acquire backoff, while exponential, was also un-jittered. Because both HA nodes share the chaddr and start together, un-jittered timers make them retransmit in lockstep and collide at the server. Added +/-25% jitter to both, and made the intra-DORA backoff exponential (2**attempt, capped).

## Deliberately NOT changed
The review confirmed several general-client behaviours are correct-by-design for this failover-VIP niche and were left alone: broadcast RENEW (the sniffer needs it), no DHCPDECLINE/ARP-probe (the address is intentionally shared), non-DUID client-id (both nodes should look like one client), and holding the address past lease expiry (an HA choice, mitigated by ARP-nudge + CARP demote-on-lease-loss). Next-tier ideas (INIT-REBOOT lease reuse on the follow-restart, carrier check before soliciting, a log-only RFC 5227 §2.4 ARP conflict detector) are noted as future work, not in this PR.

## Testing
70 unit tests pass (3 new: PRL present, RENEW omits server_id/requested_addr, backoff jitter bounds), flake8 clean. The PRL fix is best validated on the lab bench by having dnsmasq withhold option 1 and confirming follow mode still gets it once requested.
