### PR TITLE
net/os-carp-vip-dhcp: re-DORA promptly on WAN link-return (1.7.0)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.6.1
+PLUGIN_VERSION=         1.7.0
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -98,8 +98,8 @@ ATTEMPT_BACKOFF_CAP = 8    # max wait between acquire attempts
 SEND_RETRY_DELAY = 2       # wait after a failed packet send before retrying
 REBIND_POLL_STEP = 10      # how often to re-try RENEW during the REBIND window
 REDORA_MIN = 10            # initial wait after a failed acquire
-# REDORA_MAX lowered from 300 so worst-case re-acquire lag stays ~45s even if the
-# link-return fast path (below) misses; the backoff doubles 10 -> 20 -> 40 -> 45.
+# Caps worst-case re-acquire lag at ~45s even if the link-return fast path (below)
+# is missed; the backoff doubles 10 -> 20 -> 40 -> 45.
 REDORA_MAX = 45            # max exponential-backoff wait after a failed acquire
 LINK_POLL_STEP = 3         # while UNBOUND, poll interface carrier this often (s) for the link-return fast path
 LINK_KICK_DEBOUNCE = 8     # min seconds between link-return re-DORA kicks (damps a flapping link)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -768,6 +768,16 @@ class Keeper:
 
     # ---- CARP role (master probe, transitions) ----
 
+    def _ifconfig(self):
+        """Captured `ifconfig <iface>` text, or None if the probe failed. Shared by
+        the CARP-role probe and the carrier check so the ifconfig invocation, decode
+        and error policy live in exactly one place."""
+        try:
+            out = subprocess.check_output(["/sbin/ifconfig", self.iface], errors="replace")
+        except (OSError, subprocess.SubprocessError):
+            return None
+        return out.decode(errors="replace") if isinstance(out, bytes) else out
+
     def _probe_carp_master(self):
         """Raw CARP-role probe for our vhid: True/False from ifconfig, None when
         the probe itself fails; no vhid configured -> True (nothing to gate on).
@@ -775,24 +785,18 @@ class Keeper:
         (no nudge unless a confirmed MASTER); the CARP-transition poll just skips."""
         if not self.vhid:
             return True
-        try:
-            out = subprocess.check_output(["/sbin/ifconfig", self.iface], errors="replace")
-            if isinstance(out, bytes):
-                out = out.decode(errors="replace")
-            return ("carp: MASTER vhid %s " % self.vhid) in out
-        except (OSError, subprocess.SubprocessError):
+        out = self._ifconfig()
+        if out is None:
             return None
+        return ("carp: MASTER vhid %s " % self.vhid) in out
 
     def _iface_link_up(self):
         """Interface carrier from ifconfig: True on 'status: active', False on a
         present-but-inactive status (no carrier / no link), None when it cannot be
         read (probe failed, or the NIC reports no status line). Used only by the
         unbound link-return fast path; a None result never disturbs the backoff."""
-        try:
-            out = subprocess.check_output(["/sbin/ifconfig", self.iface], errors="replace")
-            if isinstance(out, bytes):
-                out = out.decode(errors="replace")
-        except (OSError, subprocess.SubprocessError):
+        out = self._ifconfig()
+        if out is None:
             return None
         if "status: active" in out:
             return True

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -98,7 +98,11 @@ ATTEMPT_BACKOFF_CAP = 8    # max wait between acquire attempts
 SEND_RETRY_DELAY = 2       # wait after a failed packet send before retrying
 REBIND_POLL_STEP = 10      # how often to re-try RENEW during the REBIND window
 REDORA_MIN = 10            # initial wait after a failed acquire
-REDORA_MAX = 300           # max exponential-backoff wait after a failed acquire
+# REDORA_MAX lowered from 300 so worst-case re-acquire lag stays ~45s even if the
+# link-return fast path (below) misses; the backoff doubles 10 -> 20 -> 40 -> 45.
+REDORA_MAX = 45            # max exponential-backoff wait after a failed acquire
+LINK_POLL_STEP = 3         # while UNBOUND, poll interface carrier this often (s) for the link-return fast path
+LINK_KICK_DEBOUNCE = 8     # min seconds between link-return re-DORA kicks (damps a flapping link)
 SNIFFER_RETRY = 5          # wait before retrying a failed packet-sniffer start
 LOOP_ERROR_BACKOFF = 10    # wait after an unexpected main-loop error before retrying
 MIN_FOLLOW_INTERVAL = 60   # min seconds between follow (VIP rewrite) events -- damps flap/spoof storms
@@ -241,6 +245,11 @@ class Keeper:
         # restart (the request-IP-keyed runtime paths change on every follow).
         self._follow_state = "/var/run/carpvipdhcp-follow-%s" % _fs_safe(self.chaddr)
         self.redora_wait = REDORA_MIN
+        # Link-return fast path (only while UNBOUND): a carrier down->up edge resets
+        # the backoff and re-DORAs at once, like dhclient's link-up -> state_reboot.
+        self._link_up = None           # last carrier state seen (None = unknown / not probed)
+        self._link_kick_at = 0.0       # epoch of the last link-return kick (debounce)
+        self._link_returned = False    # set by _sleep_interruptible on a carrier return while unbound
         self.xid = random.randint(1, 0xFFFFFFFF)
         self.server = None
         self.yiaddr = None
@@ -774,6 +783,42 @@ class Keeper:
         except (OSError, subprocess.SubprocessError):
             return None
 
+    def _iface_link_up(self):
+        """Interface carrier from ifconfig: True on 'status: active', False on a
+        present-but-inactive status (no carrier / no link), None when it cannot be
+        read (probe failed, or the NIC reports no status line). Used only by the
+        unbound link-return fast path; a None result never disturbs the backoff."""
+        try:
+            out = subprocess.check_output(["/sbin/ifconfig", self.iface], errors="replace")
+            if isinstance(out, bytes):
+                out = out.decode(errors="replace")
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if "status: active" in out:
+            return True
+        if "status: " in out:
+            return False
+        return None
+
+    def _check_link_returned(self):
+        """While UNBOUND, detect a carrier down->up edge so the keeper re-DORAs at
+        once instead of waiting out the backoff (mirrors dhclient link-up ->
+        state_reboot). Returns True only on a *seen-down* -> up transition, debounced
+        against a flapping link. An initial unknown->up is NOT a trigger (we were
+        already up), so this never fires spuriously at startup."""
+        up = self._iface_link_up()
+        if up is None:
+            return False
+        prev = self._link_up
+        self._link_up = up
+        if up and prev is False:
+            now = time.time()
+            if now - self._link_kick_at < LINK_KICK_DEBOUNCE:
+                return False
+            self._link_kick_at = now
+            return True
+        return False
+
     def _poll_carp_role(self):
         """Watch for a backup->master transition (called on the heartbeat
         cadence). Becoming master renews the lease early and, when enabled,
@@ -887,6 +932,12 @@ class Keeper:
                 # A peer-ACK observation is pending -> follow now (rationale +
                 # the dual-master window it closes are in _check_observed_follow).
                 self._check_observed_follow()
+            # Link-return fast path: only while UNBOUND, poll carrier every few
+            # seconds; a down->up edge means the WAN just came back, so stop waiting
+            # and let _run_once re-DORA immediately (the bound path skips this).
+            if self.yiaddr is None and slept % LINK_POLL_STEP == 0 and self._check_link_returned():
+                self._link_returned = True
+                return not self.stop
             # Event-driven sleep: return at once when the sniffer signals a fresh
             # observation, otherwise time out after ~1s to run the periodic checks.
             if self._wake.wait(1.0):
@@ -968,8 +1019,15 @@ class Keeper:
                 self.redora_wait = REDORA_MIN
             else:
                 LOG.warning("DHCP acquire (DISCOVER/REQUEST) failed -- retrying in %ds", self.redora_wait)
+                self._link_returned = False
                 self._sleep_interruptible(_jittered(self.redora_wait))
-                self.redora_wait = min(self.redora_wait * 2, REDORA_MAX)
+                if self._link_returned:
+                    # WAN carrier returned mid-backoff: re-acquire now instead of
+                    # waiting out the next backoff (matches native dhclient).
+                    LOG.info("WAN link returned while unbound -- re-acquiring now")
+                    self.redora_wait = REDORA_MIN
+                else:
+                    self.redora_wait = min(self.redora_wait * 2, REDORA_MAX)
             return
         # Maintain: wait until T1, then RENEW; bail early on stop.
         t1, t2, src = self._timing()

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -40,6 +40,66 @@ def test_timing_honours_server(lk):
     assert keeper._timing() == (600, 1200, "server")
 
 
+def test_redora_max_lowered(lk):
+    # Part 1 of the link-return fix: worst-case re-acquire lag is bounded (was 300s).
+    assert lk.REDORA_MIN <= lk.REDORA_MAX <= 60
+
+
+def _link_keeper(lk):
+    return lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+
+
+def test_iface_link_up_parsing(lk, monkeypatch):
+    k = _link_keeper(lk)
+    monkeypatch.setattr(lk.subprocess, "check_output",
+                        lambda *a, **kw: "igc1: flags=...\n\tstatus: active\n")
+    assert k._iface_link_up() is True
+    monkeypatch.setattr(lk.subprocess, "check_output",
+                        lambda *a, **kw: "igc1: flags=...\n\tstatus: no carrier\n")
+    assert k._iface_link_up() is False
+    monkeypatch.setattr(lk.subprocess, "check_output",
+                        lambda *a, **kw: "igc1: flags=...\n\t(no status line)\n")
+    assert k._iface_link_up() is None
+
+    def boom(*a, **kw):
+        raise OSError("iface gone")
+    monkeypatch.setattr(lk.subprocess, "check_output", boom)
+    assert k._iface_link_up() is None
+
+
+def test_check_link_returned_edge(lk):
+    k = _link_keeper(lk)
+    seq = []
+    k._iface_link_up = lambda: seq.pop(0)
+    # initial unknown -> up is NOT a trigger (we were already up)
+    seq[:] = [True]
+    assert k._check_link_returned() is False
+    assert k._link_up is True
+    # up -> up: no trigger
+    seq[:] = [True]
+    assert k._check_link_returned() is False
+    # up -> down: recorded, no trigger
+    seq[:] = [False]
+    assert k._check_link_returned() is False
+    assert k._link_up is False
+    # down -> up: TRIGGER
+    seq[:] = [True]
+    assert k._check_link_returned() is True
+    # unreadable carrier never disturbs state
+    k._iface_link_up = lambda: None
+    assert k._check_link_returned() is False
+
+
+def test_check_link_returned_debounce(lk, monkeypatch):
+    k = _link_keeper(lk)
+    monkeypatch.setattr(lk.time, "time", lambda: 1000.0)
+    k._iface_link_up = lambda: True
+    k._link_up = False                       # pretend we saw the link go down
+    assert k._check_link_returned() is True   # first down->up fires (kick_at was 0.0)
+    k._link_up = False                       # another down at the same instant
+    assert k._check_link_returned() is False  # debounced (now - kick_at = 0 < LINK_KICK_DEBOUNCE)
+
+
 def _follow_keeper(lk, tmp_path):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, follow=True)
     keeper._follow_state = str(tmp_path / "follow_state")

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -40,8 +40,8 @@ def test_timing_honours_server(lk):
     assert keeper._timing() == (600, 1200, "server")
 
 
-def test_redora_max_lowered(lk):
-    # Part 1 of the link-return fix: worst-case re-acquire lag is bounded (was 300s).
+def test_redora_max_bounded(lk):
+    # the re-DORA backoff cap stays bounded so worst-case re-acquire lag is small.
     assert lk.REDORA_MIN <= lk.REDORA_MAX <= 60
 
 


### PR DESCRIPTION
Implements #45: the keeper re-acquires promptly when the WAN carrier returns while it is UNBOUND, instead of waiting out its backoff.

## Problem
The keeper had no link-state awareness on its DORA path. After a link blip it could sit unbound for up to a full backoff (was ~300s) while OPNsense's native dhclient re-acquired instantly (it is carrier-triggered). On a source-guard / SAVI access net a leaseless VIP has no valid binding and is dropped, so this is real VIP downtime on every blip. Surfaced during a real ISP incident. Verified on a live OPNsense box that `rc.linkup` does not restart the keeper and there is no linkup `rc.syshook.d` family to hook, so this is fixed inside the daemon.

## Fix (hybrid)
- **Part 1:** lower `REDORA_MAX` 300 -> 45s, so worst-case re-acquire lag is bounded even if the fast path misses.
- **Part 2:** while UNBOUND, poll the interface carrier (`ifconfig` `status: active`) on the backoff tick; on a seen-down -> up edge (debounced) reset the backoff to `REDORA_MIN` and re-DORA at once. Unbound-only via a `self.yiaddr is None` guard, so the bound path is untouched. A shared `_ifconfig()` helper dedups the ifconfig capture with the existing CARP-role probe.

Polling was chosen over a devd/syshook signal: no OPNsense-core coupling, and it filters by interface for free. React to link-UP only; never exit on link-down (the keeper must hold the VIP through blips).

## Tests
- **Unit:** 75 pass, flake8 clean (max-line-length 120). New tests cover the carrier parse (active / inactive / unreadable), the seen-down -> up edge, the debounce window, and the lowered cap.
- **Lab (isolated fake-DHCP bench, controlled):** baseline bind; carrier down -> mid-backoff carrier up -> the keeper logs `WAN link returned while unbound -- re-acquiring now` and re-binds within ~6s (not waiting out the backoff); bound + short flap -> stays bound, no kick, no restart; never exits on link-down and never sends RELEASE. Regression harness and test plan live in the private testbench repo.

## Notes
- Ran /simplify (extracted the shared `_ifconfig()` helper; no behaviour change).
- Version bumped to 1.7.0.

Closes #45
