### PR TITLE
net/os-carp-vip-dhcp: log a readable decode of received DHCP replies (1.7.1)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.7.0
+PLUGIN_VERSION=         1.7.1
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -118,10 +118,40 @@ LOG_BACKUPS = 3
 
 # A parsed DHCP reply, snapshotted from the sniffer thread.
 # `message` (DHCP option 56) is the server's optional human-readable text, mainly
-# a NAK reason; `subnet_mask` (option 1) is used to follow a cross-subnet renumber.
-# Both are defaulted so existing 7-field constructions stay valid.
-DhcpReply = namedtuple("DhcpReply", "mtype yiaddr server_id lease t1 t2 router message subnet_mask",
-                       defaults=(None, None))
+# a NAK reason; `subnet_mask` (option 1) is used to follow a cross-subnet renumber;
+# `giaddr` (BOOTP header) is the relay agent, None when the server is directly
+# attached (no relay in path). The trailing fields are defaulted so existing
+# shorter constructions stay valid.
+DhcpReply = namedtuple("DhcpReply", "mtype yiaddr server_id lease t1 t2 router message subnet_mask giaddr",
+                       defaults=(None, None, None))
+
+# DHCP message-type names (option 53), for readable reply logging.
+MTYPE_NAMES = {1: "DISCOVER", 2: "OFFER", 3: "REQUEST", 4: "DECLINE",
+               5: "ACK", 6: "NAK", 7: "RELEASE", 8: "INFORM"}
+
+
+def _msg_text(msg):
+    """DHCP option-56 server text (usually a NAK reason) as a stripped str, or ""
+    when absent. Option 56 may arrive as bytes or str depending on the server."""
+    if isinstance(msg, bytes):
+        msg = msg.decode(errors="replace")
+    return str(msg).strip() if msg else ""
+
+
+def _fmt_reply(rx):
+    """One readable line decoding a received first-party DHCP reply. Logged at
+    DEBUG (the keeper's default level), so every reply's fields (type, addresses,
+    timers, gateway, mask, relay, server text) show in the log without a capture."""
+    txt = _msg_text(rx.message)
+    return ("%s yiaddr=%s server=%s giaddr=%s lease=%s t1=%s t2=%s gw=%s mask=%s%s"
+            % (MTYPE_NAMES.get(rx.mtype, "type=%s" % rx.mtype), rx.yiaddr or "-",
+               rx.server_id or "-", rx.giaddr or "none",
+               rx.lease if rx.lease is not None else "-",
+               rx.t1 if rx.t1 is not None else "-", rx.t2 if rx.t2 is not None else "-",
+               rx.router or "-", rx.subnet_mask or "-",
+               (" msg=%r" % txt) if txt else ""))
+
+
 MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
 
 
@@ -357,7 +387,10 @@ class Keeper:
                     msg = o[1]
                 elif o[0] == "subnet_mask":  # option 1: to follow a cross-subnet renumber
                     sm = o[1]
-        return DhcpReply(mt, yiaddr, sid, lt, rt, bt, ro, msg, sm)
+        gi = getattr(p[BOOTP], "giaddr", None)   # relay agent; 0.0.0.0 = directly attached
+        if gi in (None, "0.0.0.0", 0):
+            gi = None
+        return DhcpReply(mt, yiaddr, sid, lt, rt, bt, ro, msg, sm, gi)
 
     def _chaddr_matches(self, b):
         """True if the reply's BOOTP client hardware address is our chaddr (the
@@ -380,6 +413,7 @@ class Keeper:
             # regenerated per DORA). Parsed and handed to the waiting main thread.
             if b.xid == self.xid:
                 self._rx = self._parse_reply(p, b.yiaddr)
+                LOG.debug("DHCP reply: %s", _fmt_reply(self._rx))
                 self._ev.set()
                 return
             # Not our xid. In follow mode, still watch for the PEER's ACK: both HA
@@ -438,14 +472,11 @@ class Keeper:
             if rx and rx.mtype == NAK:
                 # Surface the server's option-56 text (why it refused) if present;
                 # it is the operator's main clue for a rejected renew.
-                reason = ""
-                if rx.message:
-                    m = rx.message
-                    if isinstance(m, bytes):
-                        m = m.decode(errors="replace")
-                    reason = " -- %s" % str(m).strip()
-                LOG.warning("DHCPNAK received (server %s, xid 0x%08x)%s",
-                            rx.server_id or "unknown", self.xid, reason)
+                txt = _msg_text(rx.message)
+                reason = " -- %s" % txt if txt else ""
+                LOG.warning("DHCPNAK received (server %s, xid 0x%08x%s)%s",
+                            rx.server_id or "unknown", self.xid,
+                            (" via relay %s" % rx.giaddr) if rx.giaddr else "", reason)
                 return "NAK"
         return None
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -45,6 +45,24 @@ def test_redora_max_bounded(lk):
     assert lk.REDORA_MIN <= lk.REDORA_MAX <= 60
 
 
+def test_dhcpreply_giaddr_defaults_none(lk):
+    # the new giaddr field defaults, so shorter DhcpReply constructions stay valid.
+    rx = lk.DhcpReply(5, "1.2.3.4", "1.2.3.1", 1800, None, None, None)
+    assert rx.giaddr is None
+
+
+def test_fmt_reply_readable(lk):
+    off = lk.DhcpReply(2, "100.64.4.74", "100.64.4.1", 120, 60, 105, "100.64.4.1",
+                       None, "255.255.255.0", None)
+    s = lk._fmt_reply(off)
+    assert "OFFER" in s and "yiaddr=100.64.4.74" in s and "server=100.64.4.1" in s
+    assert "giaddr=none" in s          # directly attached: no relay in path
+    nak = lk.DhcpReply(6, None, "100.64.4.1", None, None, None, None,
+                       b"no free leases", None, "100.64.4.9")
+    s2 = lk._fmt_reply(nak)
+    assert "NAK" in s2 and "giaddr=100.64.4.9" in s2 and "no free leases" in s2
+
+
 def _link_keeper(lk):
     return lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
 


### PR DESCRIPTION
Diagnostics follow-up from the incident (context: #45): the keeper logged only a terse `no DHCP OFFER` / a short BOUND summary, so diagnosing the incident required hand-running scapy probes to see fields the keeper never logged (message-type, yiaddr, server-id, `giaddr`, lease/T1/T2, option-56 text). This makes a received reply self-documenting in the keeper's own log.

## Change (logging only; no DHCP state-machine behaviour change)
- New module `_fmt_reply(rx)` logs a one-line **DEBUG** decode of every received first-party reply: type, yiaddr, server, `giaddr`, lease, T1/T2, gw, mask, and the option-56 server text. The keeper already runs at DEBUG, so this appears in the log without a packet capture.
- Capture `giaddr` (BOOTP relay agent; `0.0.0.0` -> `None` = directly attached, no relay) into `DhcpReply` (trailing defaulted field, same pattern as `message`/`subnet_mask`).
- The existing DHCPNAK warning now also shows `via relay <giaddr>` when a relay is in path.
- A shared `_msg_text()` helper dedups the option-56 bytes->str decode between `_fmt_reply` and the NAK path (from /simplify).

## Tests
77 pass, flake8 clean (max-line-length 120). New tests: `giaddr` defaults (shorter `DhcpReply` constructions stay valid) and `_fmt_reply` formatting (OFFER with no relay, NAK with relay + reason text).

## Notes
- Ran /simplify: applied the `_msg_text()` dedup; kept the `is not None` vs `or "-"` split (a 0 lease/T1/T2 is wire-legal and must render distinctly) and left the eager `_fmt_reply` call unguarded (negligible on the rare first-party path).
- Version bumped to 1.7.1 (diagnostics/logging).
