### PR TITLE
net/os-carp-vip-dhcp: INIT-REBOOT before a full DISCOVER on startup (1.8.0)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.7.1
+PLUGIN_VERSION=         1.8.0
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -91,6 +91,7 @@ PARAM_REQ_LIST = [1, 3, 51, 54, 58, 59]
 HB_REFRESH = 30            # rewrite the heartbeat at least this often while holding a lease
 DEFAULT_LEASE = 3600       # fallback lease time if the server sends none
 DORA_ATTEMPTS = 5          # DISCOVER and REQUEST attempts per acquire
+REBOOT_ATTEMPTS = 2        # INIT-REBOOT REQUEST attempts before falling back to a full DISCOVER
 RENEW_ATTEMPTS = 3         # REQUEST attempts per renew
 REPLY_TIMEOUT = 4          # wait for an OFFER/ACK during acquire
 RENEW_TIMEOUT = 3          # wait for an ACK during renew
@@ -275,6 +276,7 @@ class Keeper:
         # restart (the request-IP-keyed runtime paths change on every follow).
         self._follow_state = "/var/run/carpvipdhcp-follow-%s" % _fs_safe(self.chaddr)
         self.redora_wait = REDORA_MIN
+        self._tried_reboot = False     # the first acquire tries INIT-REBOOT before a full DISCOVER
         # Link-return fast path (only while UNBOUND): a carrier down->up edge resets
         # the backoff and re-DORAs at once, like dhclient's link-up -> state_reboot.
         self._link_up = None           # last carrier state seen (None = unknown / not probed)
@@ -544,6 +546,58 @@ class Keeper:
                      self.server, self.yiaddr, attempt, self.xid)
             time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
         return False
+
+    def reboot(self):
+        """INIT-REBOOT (RFC 2131 4.3.2): we already know the address we want
+        (request_ip), so REQUEST it directly instead of a full DISCOVER -- one
+        exchange, and a server that is reachable but refuses the address answers
+        with a NAK (a DISCOVER it may just ignore), surfacing 'reachable but
+        refused' in the log. server_id MUST NOT be set and ciaddr stays 0 (we do
+        not own the address on the interface). Returns True once BOUND, False on
+        NAK/timeout so the caller falls back to a full DORA."""
+        if not self.request_ip:
+            return False
+        self.xid = random.randint(1, 0xFFFFFFFF)
+        extra = [("requested_addr", self.request_ip)]
+        for attempt in range(1, REBOOT_ATTEMPTS + 1):
+            if self.stop:
+                return False
+            self._ensure_sniffer()
+            self._rx = None
+            try:
+                self._send_dhcp("request", extra)
+            except Exception as e:
+                LOG.error("DHCP INIT-REBOOT send failed: %s", e)
+                time.sleep(SEND_RETRY_DELAY)
+                continue
+            rx = self._wait_for_dhcp_reply(ACK, REPLY_TIMEOUT)
+            if rx == "NAK":
+                return False   # server refused our known address -> full DISCOVER
+            if rx:
+                got = rx.yiaddr
+                if got and got != self.request_ip:
+                    return self._handle_changed_address(got, rx, "REBOOT", release_on_enforce=True)
+                self.yiaddr, self.server = self.request_ip, rx.server_id
+                self._absorb_reply(rx, DEFAULT_LEASE)
+                return True
+            LOG.info("no DHCP ACK to INIT-REBOOT for %s (attempt %d, xid 0x%08x)",
+                     self.request_ip, attempt, self.xid)
+            if attempt < REBOOT_ATTEMPTS:   # no backoff after the last try -- fall to DORA at once
+                time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
+        return False
+
+    def _acquire(self):
+        """Get a lease. The first acquire after (re)start tries INIT-REBOOT (a
+        direct REQUEST for our known address) before a full DISCOVER; after that,
+        the normal DORA. INIT-REBOOT is one exchange and surfaces a NAK when the
+        server is reachable but refuses the address."""
+        if not self._tried_reboot:
+            self._tried_reboot = True
+            if self.request_ip:
+                if self.reboot():
+                    return True
+                LOG.info("INIT-REBOOT did not bind %s -- falling back to DISCOVER", self.request_ip)
+        return self.dora()
 
     def renew(self, rebind=False):
         # RENEWING/REBINDING (RFC 2131 4.3.2): ciaddr identifies the lease, so
@@ -1044,7 +1098,7 @@ class Keeper:
         if not self.yiaddr:
             self._ensure_sniffer()  # a dead sniffer would silently fail every DORA
             self._hb()  # active but not holding yet -> publish bound=-
-            if self.dora():
+            if self._acquire():
                 LOG.info("DHCP BOUND %s (lease=%ss, expires ~%s, server=%s, gw=%s, mask=%s)",
                          self.yiaddr, self.lease, self._clock_at(self.lease), self.server,
                          self.router or "?",

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -590,7 +590,12 @@ class Keeper:
         """Get a lease. The first acquire after (re)start tries INIT-REBOOT (a
         direct REQUEST for our known address) before a full DISCOVER; after that,
         the normal DORA. INIT-REBOOT is one exchange and surfaces a NAK when the
-        server is reachable but refuses the address."""
+        server is reachable but refuses the address.
+
+        Startup-only (the `_tried_reboot` latch): a genuine on-time lease expiry
+        re-acquires via DISCOVER (RFC 2131 4.4.5), NOT INIT-REBOOT. We do not track
+        lease expiry across a restart -- the server arbitrates the requested address
+        (ACK if still ours, NAK/silence -> fall back to DISCOVER)."""
         if not self._tried_reboot:
             self._tried_reboot = True
             if self.request_ip:

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -51,6 +51,50 @@ def test_dhcpreply_giaddr_defaults_none(lk):
     assert rx.giaddr is None
 
 
+def _reboot_keeper(lk):
+    k = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    k._ensure_sniffer = lambda: None
+    k.sent = []
+    k._send_dhcp = lambda mtype, extra, ciaddr="0.0.0.0": k.sent.append((mtype, extra, ciaddr))
+    return k
+
+
+def test_reboot_request_shape_and_bind(lk):
+    k = _reboot_keeper(lk)
+    k._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
+        lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, None)
+    assert k.reboot() is True
+    assert k.yiaddr == "100.64.4.7" and k.server == "100.64.4.1"
+    mtype, extra, ciaddr = k.sent[0]
+    assert mtype == "request" and ciaddr == "0.0.0.0"          # INIT-REBOOT: ciaddr stays 0
+    assert ("requested_addr", "100.64.4.7") in extra           # option 50 = our known address
+    assert not any(o[0] == "server_id" for o in extra if isinstance(o, tuple))  # RFC 4.3.2: no server-id
+
+
+def test_reboot_nak_falls_through(lk):
+    k = _reboot_keeper(lk)
+    k._wait_for_dhcp_reply = lambda want, timeout: "NAK"
+    assert k.reboot() is False
+    assert k.yiaddr is None
+
+
+def test_reboot_skipped_without_request_ip(lk):
+    k = lk.Keeper("eth0", "00:00:5e:00:01:fe", None, hbfile=None)
+    assert k.reboot() is False        # no known address -> nothing to reboot-request
+
+
+def test_acquire_reboot_first_then_dora(lk):
+    k = _reboot_keeper(lk)
+    calls = []
+    k.reboot = lambda: (calls.append("reboot"), False)[1]
+    k.dora = lambda: (calls.append("dora"), True)[1]
+    assert k._acquire() is True
+    assert calls == ["reboot", "dora"]      # first acquire: INIT-REBOOT then DISCOVER fallback
+    calls.clear()
+    assert k._acquire() is True
+    assert calls == ["dora"]                # subsequent acquires: DISCOVER only
+
+
 def test_fmt_reply_readable(lk):
     off = lk.DhcpReply(2, "100.64.4.74", "100.64.4.1", 120, 60, 105, "100.64.4.1",
                        None, "255.255.255.0", None)


### PR DESCRIPTION
On the first acquire after (re)start the keeper already knows the address it wants (the configured VIP), so it now does INIT-REBOOT (RFC 2131 4.3.2): a direct broadcast DHCPREQUEST for that address instead of a full DISCOVER.

## Why
- One exchange (REQUEST -> ACK) instead of DISCOVER -> OFFER -> REQUEST -> ACK: a faster, lower-churn reacquire at startup.
- Diagnostic: a server that is reachable but refuses the address answers a REQUEST with a NAK (a DISCOVER it may just be ignored), so "reachable but refused" now shows in the keeper's own log at startup instead of a silent "no OFFER".

## How
- New `reboot()`: broadcast REQUEST with option 50 = the known address, NO server_id, ciaddr 0 (RFC 4.3.2). ACK binds; NAK or timeout falls back to a full DORA. An ACK for a different address routes through the same follow/enforce hardening as DORA.
- New `_acquire()` seam: the first acquire tries `reboot()` once (gated by `_tried_reboot`), then `dora()`. Subsequent re-acquires use DORA (RFC: INIT-REBOOT is the startup state; after a genuine lease expiry the client DISCOVERs).
- If no address is configured (`--request` unset), INIT-REBOOT is skipped.

## Tests
- Unit: 81 pass, flake8 clean. New tests cover the REQUEST shape (option 50 present, no server_id, ciaddr 0) + bind on ACK, NAK fall-through, skipped-without-a-request-address, and the `_acquire` reboot-then-DORA ordering.
- Lab, end to end: against a controlled DHCP server the ACK path binds in a single REQUEST/ACK (no DISCOVER on the wire) and the NAK path logs the refusal and falls back to a full DISCOVER that binds; against a real DHCP server the INIT-REBOOT REQUEST-first is ACKed and binds.

## Notes
- Ran /simplify: kept the shared follow/enforce reuse (extracting the retry skeleton would touch the DORA path); the only fix applied was skipping the backoff sleep after the last reboot attempt.
- Version bumped to 1.8.0.
