### PR TITLE
net/os-carp-vip-dhcp: extract pure DHCP wire codec to module scope (1.8.1)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.8.0
+PLUGIN_VERSION=         1.8.1
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -117,6 +117,11 @@ ARP_NUDGE_MIN = 30         # floor for --arp-nudge so a typo cannot flood the se
 LOG_MAX_BYTES = 512 * 1024
 LOG_BACKUPS = 3
 
+# ---- DHCP wire format: parse / format / build ----
+# Pure encode/decode helpers with no Keeper state: they turn scapy packets into a
+# DhcpReply and turn a message type into an option list. The stateful protocol
+# sequences (DORA / INIT-REBOOT / renew) live in the Keeper class further down.
+
 # A parsed DHCP reply, snapshotted from the sniffer thread.
 # `message` (DHCP option 56) is the server's optional human-readable text, mainly
 # a NAK reason; `subnet_mask` (option 1) is used to follow a cross-subnet renumber;
@@ -151,6 +156,43 @@ def _fmt_reply(rx):
                rx.t1 if rx.t1 is not None else "-", rx.t2 if rx.t2 is not None else "-",
                rx.router or "-", rx.subnet_mask or "-",
                (" msg=%r" % txt) if txt else ""))
+
+
+def _parse_reply(p, yiaddr):
+    """Snapshot only the handful of DHCP options the keeper acts on into a
+    DhcpReply; the rest of the reply's option data -- untrusted, from
+    whatever answered on the wire -- is left untouched."""
+    mt = sid = lt = rt = bt = ro = msg = sm = None
+    for o in p[DHCP].options:
+        if isinstance(o, tuple):
+            if o[0] == "message-type":
+                mt = o[1]
+            elif o[0] == "server_id":
+                sid = o[1]
+            elif o[0] == "lease_time":
+                lt = o[1]
+            elif o[0] == "renewal_time":
+                rt = o[1]
+            elif o[0] == "rebinding_time":
+                bt = o[1]
+            elif o[0] == "router":
+                ro = o[1]
+            elif o[0] == "message":     # option 56: server's text (e.g. a NAK reason)
+                msg = o[1]
+            elif o[0] == "subnet_mask":  # option 1: to follow a cross-subnet renumber
+                sm = o[1]
+    gi = getattr(p[BOOTP], "giaddr", None)   # relay agent; 0.0.0.0 = directly attached
+    if gi in (None, "0.0.0.0", 0):
+        gi = None
+    return DhcpReply(mt, yiaddr, sid, lt, rt, bt, ro, msg, sm, gi)
+
+
+def _dhcp_options(mtype, extra, id_opts):
+    """The DHCP option list for a message: type, our Parameter Request List
+    (so the server returns the mask/router/timers the keeper acts on), the
+    identity options, then the per-message extras."""
+    return ([("message-type", mtype), ("param_req_list", PARAM_REQ_LIST)]
+            + id_opts + extra + ["end"])
 
 
 MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
@@ -366,34 +408,6 @@ class Keeper:
         except Exception as e:
             LOG.debug("ARP reply parse error: %s", e)
 
-    def _parse_reply(self, p, yiaddr):
-        """Snapshot only the handful of DHCP options the keeper acts on into a
-        DhcpReply; the rest of the reply's option data -- untrusted, from
-        whatever answered on the wire -- is left untouched."""
-        mt = sid = lt = rt = bt = ro = msg = sm = None
-        for o in p[DHCP].options:
-            if isinstance(o, tuple):
-                if o[0] == "message-type":
-                    mt = o[1]
-                elif o[0] == "server_id":
-                    sid = o[1]
-                elif o[0] == "lease_time":
-                    lt = o[1]
-                elif o[0] == "renewal_time":
-                    rt = o[1]
-                elif o[0] == "rebinding_time":
-                    bt = o[1]
-                elif o[0] == "router":
-                    ro = o[1]
-                elif o[0] == "message":     # option 56: server's text (e.g. a NAK reason)
-                    msg = o[1]
-                elif o[0] == "subnet_mask":  # option 1: to follow a cross-subnet renumber
-                    sm = o[1]
-        gi = getattr(p[BOOTP], "giaddr", None)   # relay agent; 0.0.0.0 = directly attached
-        if gi in (None, "0.0.0.0", 0):
-            gi = None
-        return DhcpReply(mt, yiaddr, sid, lt, rt, bt, ro, msg, sm, gi)
-
     def _chaddr_matches(self, b):
         """True if the reply's BOOTP client hardware address is our chaddr (the
         CARP virtual MAC). Used to accept the PEER's ACK on the shared chaddr:
@@ -414,7 +428,7 @@ class Keeper:
             # First-party path: a reply to OUR in-flight exchange (random xid,
             # regenerated per DORA). Parsed and handed to the waiting main thread.
             if b.xid == self.xid:
-                self._rx = self._parse_reply(p, b.yiaddr)
+                self._rx = _parse_reply(p, b.yiaddr)
                 LOG.debug("DHCP reply: %s", _fmt_reply(self._rx))
                 self._ev.set()
                 return
@@ -432,7 +446,7 @@ class Keeper:
             # ACK and never acts on the sniffer thread.
             if not self.follow or not self.yiaddr or not self._chaddr_matches(b):
                 return
-            rx = self._parse_reply(p, b.yiaddr)
+            rx = _parse_reply(p, b.yiaddr)
             if (rx.mtype == ACK and rx.yiaddr and rx.yiaddr != self.yiaddr
                     and _sane_ipv4(rx.yiaddr)):
                 self._observed_change = rx
@@ -442,13 +456,6 @@ class Keeper:
 
     # ---- DHCP protocol (send / await reply / DORA / renew / release) ----
 
-    def _dhcp_options(self, mtype, extra):
-        """The DHCP option list for a message: type, our Parameter Request List
-        (so the server returns the mask/router/timers the keeper acts on), the
-        identity options, then the per-message extras."""
-        return ([("message-type", mtype), ("param_req_list", PARAM_REQ_LIST)]
-                + self._id_opts + extra + ["end"])
-
     def _send_dhcp(self, mtype, extra, ciaddr="0.0.0.0"):
         # ciaddr is set for RENEW/REBIND (the client already owns the address);
         # the broadcast flag stays on so the reply is reliably captured by the sniffer.
@@ -456,7 +463,7 @@ class Keeper:
                IP(src=ciaddr, dst="255.255.255.255") /
                UDP(sport=68, dport=67) /
                BOOTP(chaddr=self.chraw, xid=self.xid, ciaddr=ciaddr, flags=BROADCAST_FLAG) /
-               DHCP(options=self._dhcp_options(mtype, extra)))
+               DHCP(options=_dhcp_options(mtype, extra, self._id_opts)))
         sendp(pkt, iface=self.iface, verbose=0)
 
     def _wait_for_dhcp_reply(self, want, timeout):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -195,6 +195,15 @@ def _dhcp_options(mtype, extra, id_opts):
             + id_opts + extra + ["end"])
 
 
+def _mask_to_bits(mask):
+    """Dotted-quad subnet mask (DHCP option 1) -> prefix length, or None if absent
+    or unparseable."""
+    try:
+        return ipaddress.IPv4Network("0.0.0.0/%s" % mask).prefixlen
+    except (ValueError, TypeError):
+        return None
+
+
 MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
 
 
@@ -234,15 +243,6 @@ def _same_ip_class(a, b):
         return _is_localish(a) == _is_localish(b)
     except ValueError:
         return False
-
-
-def _mask_to_bits(mask):
-    """Dotted-quad subnet mask (DHCP option 1) -> prefix length, or None if absent
-    or unparseable."""
-    try:
-        return ipaddress.IPv4Network("0.0.0.0/%s" % mask).prefixlen
-    except (ValueError, TypeError):
-        return None
 
 
 def _fs_safe(s):

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -182,10 +182,10 @@ class _DhcpPkt:
     """Minimal stand-in for a scapy DHCP reply: p[BOOTP].xid/op/yiaddr and
     p[DHCP].options, with haslayer() so _on_dhcp_reply parses it."""
     def __init__(self, lk, xid, options, yiaddr="100.64.4.7",
-                 chaddr=b"\x00\x00\x5e\x00\x01\xfe", op=None):
+                 chaddr=b"\x00\x00\x5e\x00\x01\xfe", op=None, giaddr="0.0.0.0"):
         self._lk = lk
         self._bootp = types.SimpleNamespace(xid=xid, op=(lk.BOOTREPLY if op is None else op),
-                                            yiaddr=yiaddr, chaddr=chaddr)
+                                            yiaddr=yiaddr, chaddr=chaddr, giaddr=giaddr)
         self._dhcp = types.SimpleNamespace(options=options)
 
     def haslayer(self, layer):
@@ -193,6 +193,22 @@ class _DhcpPkt:
 
     def __getitem__(self, layer):
         return self._bootp if layer is self._lk.BOOTP else self._dhcp
+
+
+def test_parse_reply_extracts_fields_and_relay(lk):
+    # The pure wire decoder pulls the acted-on options into a DhcpReply and maps
+    # the relay giaddr (0.0.0.0 -> None when directly attached).
+    pkt = _DhcpPkt(lk, 0x1234, [("message-type", lk.ACK), ("server_id", "100.64.4.1"),
+                                ("lease_time", 1800), ("router", "100.64.4.1"),
+                                ("subnet_mask", "255.255.255.0"), "end"],
+                   yiaddr="100.64.4.7", giaddr="100.64.4.9")
+    rx = lk._parse_reply(pkt, "100.64.4.7")
+    assert rx.mtype == lk.ACK and rx.yiaddr == "100.64.4.7"
+    assert rx.server_id == "100.64.4.1" and rx.lease == 1800
+    assert rx.router == "100.64.4.1" and rx.subnet_mask == "255.255.255.0"
+    assert rx.giaddr == "100.64.4.9"           # relay in path
+    directly_attached = _DhcpPkt(lk, 0x1234, [("message-type", lk.ACK), "end"], giaddr="0.0.0.0")
+    assert lk._parse_reply(directly_attached, "100.64.4.7").giaddr is None
 
 
 def test_on_dhcp_reply_captures_option56_message(lk):
@@ -715,7 +731,7 @@ def test_dhcp_options_include_param_req_list(lk):
     # Every DISCOVER/REQUEST must carry the Parameter Request List (RFC 2132 §9.8)
     # so the server returns the subnet mask (1) + router (3) follow-mode needs.
     keeper = _plain_keeper(lk)
-    opts = keeper._dhcp_options("discover", [("requested_addr", "100.64.4.7")])
+    opts = lk._dhcp_options("discover", [("requested_addr", "100.64.4.7")], keeper._id_opts)
     assert opts[0] == ("message-type", "discover")
     assert ("param_req_list", lk.PARAM_REQ_LIST) in opts
     assert 1 in lk.PARAM_REQ_LIST and 3 in lk.PARAM_REQ_LIST
@@ -753,7 +769,7 @@ def test_renew_omits_server_id_and_requested_addr(lk):
         # assert on the ACTUAL assembled option list, not the stubbed extras
         # (which are always empty here) -- so a regression that re-added
         # server_id to renew's opts would fail this.
-        wire = [o for o in keeper._dhcp_options(mtype, extra) if isinstance(o, tuple)]
+        wire = [o for o in lk._dhcp_options(mtype, extra, keeper._id_opts) if isinstance(o, tuple)]
         assert all(o[0] != "server_id" for o in wire)
         assert all(o[0] != "requested_addr" for o in wire)
 


### PR DESCRIPTION
## What

Refactor only, no behaviour change. Moves the pure DHCP wire helpers out of the Keeper class to module scope and groups them under a single "DHCP wire format" section:

- `_parse_reply(p, yiaddr)`: scapy packet to DhcpReply snapshot (was a Keeper method that never used self)
- `_dhcp_options(mtype, extra, id_opts)`: option-list builder (the only Keeper coupling, `self._id_opts`, is now an explicit parameter)
- `_mask_to_bits` relocated into the same section (it decodes DHCP option 1, so it belongs with the codec, not the IP policy helpers)

The section now holds the whole pure codec: `DhcpReply`, `MTYPE_NAMES`, `_msg_text`, `_fmt_reply`, `_parse_reply`, `_dhcp_options`, `_mask_to_bits`. The stateful protocol sequences (DORA, INIT-REBOOT, renew, release) stay in Keeper.

## Why

The codec is pure encode/decode and now independently testable without a Keeper instance. This is a small, low-risk stepping stone toward a possible future DhcpClient boundary; the coupled state machine is deliberately not touched.

## Testing

- 82 unit tests pass (one new: direct `_parse_reply` field + relay giaddr decoding), flake8 clean at max-line-length 120.
- Lab regression on the isolated fake-DHCP bench, 8/8 PASS on this ref: baseline BIND through the moved codec on the wire, link-return fast path (re-bind ~7s after carrier-up), no kick while bound, keeper never exits and never sends RELEASE.

Version bump 1.8.0 to 1.8.1 (patch, refactor only).