### PR TITLE
net/os-carp-vip-dhcp: extract the ARP nudge into an ArpNudge component (1.8.2)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.8.1
+PLUGIN_VERSION=         1.8.2
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -264,6 +264,95 @@ def mac2raw(m):
     return bytes.fromhex(m.replace(":", "").replace("-", ""))
 
 
+class ArpNudge:
+    """Keep the upstream gateway's ARP entry for the leased address fresh, for
+    gateways that ignore gratuitous ARP and never re-ARP an expired entry (see
+    the README's "ARP nudge" section). Owns the nudge pacing and the gateway
+    reachability stamp; the caller supplies the current lease binding
+    (yiaddr, gateway) per call and a CARP-role probe at construction -- never
+    nudge from a backup (it would steal the VIP's traffic), so anything but a
+    confirmed MASTER fails closed (the next interval retries)."""
+
+    def __init__(self, iface, chaddr, interval, is_master):
+        self.iface = iface
+        self.chaddr = chaddr
+        # Interval floor so a typo cannot flood the segment; 0 = disabled.
+        self.interval = max(ARP_NUDGE_MIN, interval) if interval else 0
+        self._is_master = is_master    # callable -> True/False/None (None = probe failed)
+        self.last_nudge = 0.0          # epoch of the last sent nudge (0 = never)
+        # Reachability: the sniffer stamps last_reply when the gateway answers
+        # a nudge (a lone atomic float write); the status page surfaces its age.
+        self.last_reply = 0.0          # epoch of the gateway's last ARP reply (0 = none)
+        self._gw = None                # last nudge target we logged (log again on change)
+        self._warned = False           # warned once about a missing nudge target
+
+    def maybe_nudge(self, yiaddr, gateway, force=False):
+        """Refresh the gateway's ARP entry for yiaddr by broadcasting an ARP
+        request from (yiaddr, chaddr). No-op unless enabled, bound, due (or
+        forced) and CARP master."""
+        if not self.interval or not yiaddr:
+            return
+        if not force and time.time() - self.last_nudge < self.interval:
+            return
+        if self._is_master() is not True:
+            return
+        if not gateway:
+            # Enabled but no target: without this warning the nudge would be a
+            # silent no-op and the operator would believe they are protected.
+            if not self._warned:
+                LOG.warning("ARP nudge enabled but no gateway known "
+                            "(no DHCP router option or server-id) -- cannot nudge")
+                self._warned = True
+            return
+        try:
+            # This frame is shaped to satisfy three ISP access-network guards at
+            # once (README "Playing nicely" section):
+            #   * op=1 (a REQUEST, not a gratuitous announcement) -- gear that
+            #     filters unsolicited/gratuitous ARP still processes a request,
+            #     which is what refreshes the entry;
+            #   * sender (psrc=leased IP, hwsrc=chaddr=CARP MAC) is exactly the
+            #     DHCP-snooped IP<->MAC binding, so Dynamic ARP Inspection passes it;
+            #   * sending it at all exists for gateways that never re-ARP an
+            #     expired entry ("secured ARP") and would otherwise blackhole the
+            #     VIP. Only the CARP master sends it (gated above).
+            sendp(Ether(src=self.chaddr, dst="ff:ff:ff:ff:ff:ff") /
+                  ARP(op=1, hwsrc=self.chaddr, psrc=yiaddr,
+                      hwdst="00:00:00:00:00:00", pdst=gateway),
+                  iface=self.iface, verbose=0)
+            self.last_nudge = time.time()
+            # Log the first nudge (and any target change) at INFO so the default log
+            # shows the nudge is active; routine repeats at DEBUG (they fire oftener
+            # than DHCP renews). Whether the gateway actually answered is surfaced by
+            # age on the status page (via last_reply -> the heartbeat's arpok=).
+            if gateway != self._gw:
+                LOG.info("ARP nudge active: who-has %s tell %s (src %s) every %ds",
+                         gateway, yiaddr, self.chaddr, self.interval)
+                self._gw = gateway
+            else:
+                LOG.debug("ARP nudge sent: who-has %s tell %s", gateway, yiaddr)
+        except Exception as e:
+            LOG.warning("ARP nudge failed (target %s): %s", gateway, e)
+
+    def on_arp_reply(self, p, yiaddr, gateway):
+        """Stamp last_reply when the gateway answers our nudge -- a reachability
+        signal the status page surfaces by age. Only the reply to OUR who-has
+        counts: op=2 (is-at), sender = the nudge target gateway, target = our
+        leased IP. Runs on the sniffer thread; the stamp is a lone atomic write.
+        Advisory only (an on-segment attacker could forge or withhold it);
+        nothing here feeds lease/CARP/follow decisions."""
+        try:
+            arp = p[ARP]
+            if arp.op != 2:                     # 2 = is-at (reply); requests are filtered out in BPF
+                return
+            if not gateway or not yiaddr:
+                return
+            if arp.psrc == gateway and arp.pdst == yiaddr:
+                self.last_reply = time.time()
+                LOG.debug("ARP reply from %s (is-at) for %s", gateway, yiaddr)
+        except Exception as e:
+            LOG.debug("ARP reply parse error: %s", e)
+
+
 class Keeper:
     def __init__(self, iface, chaddr, request_ip=None, eth_src=None,
                  hbfile=None, release_on_exit=False, vhid=None,
@@ -278,22 +367,17 @@ class Keeper:
         self.release_on_exit = release_on_exit
         self.vhid = str(vhid) if vhid else None
         self.follow = follow
-        # ARP nudge: keep the upstream gateway's ARP entry for the leased address
-        # fresh, for gateways that ignore gratuitous ARP and never re-ARP an
-        # expired entry (see the README's "ARP nudge" section for the full story).
-        self.arp_nudge = max(ARP_NUDGE_MIN, arp_nudge) if arp_nudge else 0
+        # ARP nudge component: owns the pacing and reachability state; the
+        # keeper supplies the lease binding per nudge (_arp_nudge) and the
+        # CARP-role probe (late-bound so tests can stub _probe_carp_master).
+        self._nudge = ArpNudge(iface, self.chaddr, arp_nudge,
+                               lambda: self._probe_carp_master())
         # Promiscuous ARP capture: off by default (the CARP master already
         # accepts the VIP MAC, so the unicast reply reaches a normal socket).
         # Opt-in fallback for NICs that drop non-primary unicast MACs.
         self.arp_listen_promisc = arp_listen_promisc
         self.router = None             # default gateway (DHCP opt 3, fallback: server_id)
         self.mask_bits = None          # subnet prefix length from opt 1 (for logging + follow)
-        self._last_nudge = 0.0
-        self._nudge_gw = None          # last nudge target we logged (log again on change)
-        self._nudge_warned = False     # warned once about a missing nudge target
-        # Reachability: the sniffer stamps _last_arp_reply when the gateway answers
-        # a nudge (a lone atomic float write); the status page surfaces its age.
-        self._last_arp_reply = 0.0     # epoch of the gateway's last ARP reply (0 = none)
         self._was_master = None        # CARP role at the last nudge check (None = unknown yet)
         self._nudge_now = False        # operator asked for an immediate nudge (SIGUSR1)
         self._poll_role_now = False    # a CARP transition fired -> re-check role now (SIGUSR2)
@@ -386,27 +470,8 @@ class Keeper:
         if p.haslayer(BOOTP):
             self._on_dhcp_reply(p)
         elif p.haslayer(ARP):
-            self._on_arp_reply(p)      # gateway answering our nudge (reachability)
-
-    def _on_arp_reply(self, p):
-        """Stamp _last_arp_reply when the gateway answers our nudge -- a reachability
-        signal the status page surfaces by age. Only the reply to OUR who-has counts:
-        op=2 (is-at), sender = the nudge target gateway, target = our leased IP. Runs
-        on the sniffer thread; the stamp is a lone atomic write. Advisory only (an
-        on-segment attacker could forge or withhold it); nothing here feeds
-        lease/CARP/follow decisions."""
-        try:
-            arp = p[ARP]
-            if arp.op != 2:                     # 2 = is-at (reply); requests are filtered out in BPF
-                return
-            gw = self._nudge_target()
-            if not gw or not self.yiaddr:
-                return
-            if arp.psrc == gw and arp.pdst == self.yiaddr:
-                self._last_arp_reply = time.time()
-                LOG.debug("ARP reply from %s (is-at) for %s", gw, self.yiaddr)
-        except Exception as e:
-            LOG.debug("ARP reply parse error: %s", e)
+            # Gateway answering our nudge (reachability stamp).
+            self._nudge.on_arp_reply(p, self.yiaddr, self._nudge_target())
 
     def _chaddr_matches(self, b):
         """True if the reply's BOOTP client hardware address is our chaddr (the
@@ -707,8 +772,8 @@ class Keeper:
         # last sent nudge, 0 = never>, arpok=<epoch of the gateway's last ARP reply,
         # 0 = none seen> and the current target gateway (if known).
         extra = ""
-        if self.arp_nudge:
-            extra = " nudge=%d arpok=%d" % (int(self._last_nudge), int(self._last_arp_reply))
+        if self._nudge.interval:
+            extra = " nudge=%d arpok=%d" % (int(self._nudge.last_nudge), int(self._nudge.last_reply))
             gw = self._nudge_target()
             if gw:
                 extra += " gw=%s" % gw
@@ -951,54 +1016,9 @@ class Keeper:
         return self.router or self.server
 
     def _arp_nudge(self, force=False):
-        """Refresh the upstream gateway's ARP entry for the leased address by
-        broadcasting an ARP request from (yiaddr, chaddr). No-op unless enabled,
-        bound, due (or forced) and CARP master -- never nudge from a backup (it
-        would steal the VIP's traffic), so a failed role probe skips the nudge
-        (fails closed; the next interval retries)."""
-        if not self.arp_nudge or not self.yiaddr:
-            return
-        if not force and time.time() - self._last_nudge < self.arp_nudge:
-            return
-        if self._probe_carp_master() is not True:
-            return
-        gw = self._nudge_target()
-        if not gw:
-            # Enabled but no target: without this warning the nudge would be a
-            # silent no-op and the operator would believe they are protected.
-            if not self._nudge_warned:
-                LOG.warning("ARP nudge enabled but no gateway known "
-                            "(no DHCP router option or server-id) -- cannot nudge")
-                self._nudge_warned = True
-            return
-        try:
-            # This frame is shaped to satisfy three ISP access-network guards at
-            # once (README "Playing nicely" section):
-            #   * op=1 (a REQUEST, not a gratuitous announcement) -- gear that
-            #     filters unsolicited/gratuitous ARP still processes a request,
-            #     which is what refreshes the entry;
-            #   * sender (psrc=leased IP, hwsrc=chaddr=CARP MAC) is exactly the
-            #     DHCP-snooped IP<->MAC binding, so Dynamic ARP Inspection passes it;
-            #   * sending it at all exists for gateways that never re-ARP an
-            #     expired entry ("secured ARP") and would otherwise blackhole the
-            #     VIP. Only the CARP master sends it (gated above).
-            sendp(Ether(src=self.chaddr, dst="ff:ff:ff:ff:ff:ff") /
-                  ARP(op=1, hwsrc=self.chaddr, psrc=self.yiaddr,
-                      hwdst="00:00:00:00:00:00", pdst=gw),
-                  iface=self.iface, verbose=0)
-            self._last_nudge = time.time()
-            # Log the first nudge (and any target change) at INFO so the default log
-            # shows the nudge is active; routine repeats at DEBUG (they fire oftener
-            # than DHCP renews). Whether the gateway actually answered is surfaced by
-            # age on the status page (via _last_arp_reply -> the heartbeat's arpok=).
-            if gw != self._nudge_gw:
-                LOG.info("ARP nudge active: who-has %s tell %s (src %s) every %ds",
-                         gw, self.yiaddr, self.chaddr, self.arp_nudge)
-                self._nudge_gw = gw
-            else:
-                LOG.debug("ARP nudge sent: who-has %s tell %s", gw, self.yiaddr)
-        except Exception as e:
-            LOG.warning("ARP nudge failed (target %s): %s", gw, e)
+        """Hand the current lease binding (leased address, nudge target) to the
+        ArpNudge component; it owns the pacing, the master gate and the send."""
+        self._nudge.maybe_nudge(self.yiaddr, self._nudge_target(), force=force)
 
     # ---- main loop / sleeps ----
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -616,18 +616,14 @@ def test_arp_reply_ignores_unrelated(lk):
     assert keeper._nudge.last_reply == 0.0
 
 
-def test_sniff_dispatch_routes_arp_reply(lk):
-    keeper = _nudge_keeper(lk)
-    keeper.router = "100.64.4.254"
-    keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.254", "100.64.4.7"))
-    assert keeper._nudge.last_reply > 0
-
-
-def test_arp_reply_logged_at_debug(lk, caplog):
+def test_arp_reply_stamps_reachability_and_logs(lk, caplog):
+    # A matching is-at reply from the nudge target, dispatched through the
+    # sniffer path, stamps the reachability epoch and logs at DEBUG.
     keeper = _nudge_keeper(lk)
     keeper.router = "100.64.4.1"
     with caplog.at_level("DEBUG", logger="lease-keeper"):
         keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
+    assert keeper._nudge.last_reply > 0
     assert any("ARP reply from 100.64.4.1" in r.getMessage() for r in caplog.records)
 
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -406,36 +406,36 @@ def _nudge_keeper(lk, arp_nudge=240, hbfile=None, **kwargs):
 
 def test_nudge_off_by_default(lk):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
-    assert keeper.arp_nudge == 0
+    assert keeper._nudge.interval == 0
     keeper._arp_nudge(force=True)   # must be a no-op, not an error
-    assert keeper._last_nudge == 0.0
+    assert keeper._nudge.last_nudge == 0.0
 
 
 def test_nudge_interval_floor(lk):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, arp_nudge=1)
-    assert keeper.arp_nudge == lk.ARP_NUDGE_MIN
+    assert keeper._nudge.interval == lk.ARP_NUDGE_MIN
 
 
 def test_nudge_respects_interval_and_force(lk):
     keeper = _nudge_keeper(lk)
     keeper._arp_nudge()
-    first = keeper._last_nudge
+    first = keeper._nudge.last_nudge
     assert first > 0
     keeper._arp_nudge()             # within the interval -> skipped
-    assert keeper._last_nudge == first
+    assert keeper._nudge.last_nudge == first
     keeper._arp_nudge(force=True)   # forced (BOUND/RENEW/REBIND) -> sent
-    assert keeper._last_nudge > first
+    assert keeper._nudge.last_nudge > first
 
 
 def test_nudge_requires_gateway_and_lease(lk):
     keeper = _nudge_keeper(lk)
     keeper.server = None            # no router option and no server_id -> no target
     keeper._arp_nudge(force=True)
-    assert keeper._last_nudge == 0.0
+    assert keeper._nudge.last_nudge == 0.0
     keeper.server = "100.64.4.1"
     keeper.yiaddr = None            # not bound -> no source address
     keeper._arp_nudge(force=True)
-    assert keeper._last_nudge == 0.0
+    assert keeper._nudge.last_nudge == 0.0
 
 
 def test_nudge_works_from_router_option_alone(lk):
@@ -443,14 +443,14 @@ def test_nudge_works_from_router_option_alone(lk):
     keeper.server = None
     keeper.router = "100.64.4.254"   # DHCP option 3 alone is a valid target
     keeper._arp_nudge(force=True)
-    assert keeper._last_nudge > 0
+    assert keeper._nudge.last_nudge > 0
 
 
 def test_nudge_gated_to_carp_master(lk):
     keeper = _nudge_keeper(lk, vhid=199)
     keeper._probe_carp_master = lambda: False
     keeper._arp_nudge(force=True)
-    assert keeper._last_nudge == 0.0   # never nudge from a CARP backup
+    assert keeper._nudge.last_nudge == 0.0   # never nudge from a CARP backup
 
 
 def test_probe_carp_master_true_without_vhid(lk):
@@ -471,15 +471,15 @@ def test_probe_failure_skips_nudge(lk, monkeypatch):
     monkeypatch.setattr(lk.subprocess, "check_output", boom)
     assert keeper._probe_carp_master() is None
     keeper._arp_nudge(force=True)
-    assert keeper._last_nudge == 0.0
+    assert keeper._nudge.last_nudge == 0.0
 
 
 def test_hb_nudge_tokens_present(lk, tmp_path):
     hb = tmp_path / "hb"
     keeper = _nudge_keeper(lk, hbfile=str(hb))
     keeper.router = "100.64.4.1"
-    keeper._last_nudge = 1783350000.0
-    keeper._last_arp_reply = 1783350050.0
+    keeper._nudge.last_nudge = 1783350000.0
+    keeper._nudge.last_reply = 1783350050.0
     keeper._hb()
     content = hb.read_text()
     assert " nudge=1783350000" in content
@@ -513,14 +513,14 @@ def test_master_transition_renews_early_and_nudges(lk):
     keeper._probe_carp_master = lambda: next(states)
     keeper._poll_carp_role()             # master from the start -> no transition
     assert keeper._renew_asap is False
-    assert keeper._last_nudge == 0.0
+    assert keeper._nudge.last_nudge == 0.0
     keeper._poll_carp_role()             # backup -> remembers the role
     keeper._poll_carp_role()             # backup -> master (the forced nudge probes again)
     assert keeper._renew_asap is True
-    first = keeper._last_nudge
+    first = keeper._nudge.last_nudge
     assert first > 0
     keeper._poll_carp_role()             # still master -> nothing new
-    assert keeper._last_nudge == first
+    assert keeper._nudge.last_nudge == first
 
 
 def test_losing_master_is_logged(lk, caplog):
@@ -541,7 +541,7 @@ def test_master_transition_renews_even_with_nudge_off(lk):
     keeper._poll_carp_role()
     keeper._poll_carp_role()
     assert keeper._renew_asap is True    # the early renew is not tied to the nudge
-    assert keeper._last_nudge == 0.0     # but no nudge was sent
+    assert keeper._nudge.last_nudge == 0.0     # but no nudge was sent
 
 
 def test_hold_returns_early_for_asap_renew(lk):
@@ -559,7 +559,7 @@ def test_sigusr1_flag_services_nudge_within_a_second(lk, caplog):
     with caplog.at_level("INFO", logger="lease-keeper"):
         keeper._sleep_interruptible(1)
     assert keeper._nudge_now is False
-    assert keeper._last_nudge > 0
+    assert keeper._nudge.last_nudge > 0
     # Operator-triggered nudges must be visible in the log (the README says so).
     assert any("manual ARP nudge" in r.getMessage() for r in caplog.records)
 
@@ -578,7 +578,7 @@ def test_sigusr2_flag_rechecks_carp_role_within_a_second(lk):
     keeper._sleep_interruptible(1)                # services the flag -> re-check -> transition
     assert keeper._poll_role_now is False
     assert keeper._renew_asap is True     # backup->master: renew early
-    assert keeper._last_nudge > 0         # and nudge immediately
+    assert keeper._nudge.last_nudge > 0         # and nudge immediately
 
 
 def test_nudge_missing_gateway_warns_once(lk, caplog):
@@ -610,24 +610,24 @@ class _ArpPkt:
 def test_arp_reply_ignores_unrelated(lk):
     keeper = _nudge_keeper(lk)
     keeper.router = "100.64.4.254"
-    keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.9", "100.64.4.7"))    # wrong sender
-    keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.254", "100.64.4.99"))  # wrong target IP
-    keeper._on_arp_reply(_ArpPkt(lk, 1, "100.64.4.254", "100.64.4.7"))   # a request, not a reply
-    assert keeper._last_arp_reply == 0.0
+    keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.9", "100.64.4.7"))    # wrong sender
+    keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.254", "100.64.4.99"))  # wrong target IP
+    keeper._on_sniff(_ArpPkt(lk, 1, "100.64.4.254", "100.64.4.7"))   # a request, not a reply
+    assert keeper._nudge.last_reply == 0.0
 
 
 def test_sniff_dispatch_routes_arp_reply(lk):
     keeper = _nudge_keeper(lk)
     keeper.router = "100.64.4.254"
     keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.254", "100.64.4.7"))
-    assert keeper._last_arp_reply > 0
+    assert keeper._nudge.last_reply > 0
 
 
 def test_arp_reply_logged_at_debug(lk, caplog):
     keeper = _nudge_keeper(lk)
     keeper.router = "100.64.4.1"
     with caplog.at_level("DEBUG", logger="lease-keeper"):
-        keeper._on_arp_reply(_ArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
+        keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
     assert any("ARP reply from 100.64.4.1" in r.getMessage() for r in caplog.records)
 
 


### PR DESCRIPTION
## What

Refactor only, no behaviour change. Step 2 of trimming Keeper's state: the ARP nudge moves into a module-level `ArpNudge` component.

- `ArpNudge` owns the nudge pacing and reachability state (interval with its floor, last-nudge and last-reply epochs, logged-target and warn-once flags) plus the two behaviours: `maybe_nudge` (gates + send) and `on_arp_reply` (is-at match, reachability stamp on the sniffer thread).
- Keeper drops five mutable attributes and keeps the policy: `_nudge_target()` (router-or-server fallback is lease policy), CARP transition detection, and the signal flags. `Keeper._arp_nudge` is now a thin wrapper handing the current lease binding to the component.
- The CARP-role probe is injected at construction (late-bound), and the master gate lives at the send point inside the component, so no call path can bypass it. Fails closed on a failed probe, as before.
- Heartbeat format, log lines and gate ordering are identical.

## Why

Keeper mixed mutable state from five domains in one namespace with nothing marking ownership. This gives the nudge state a single owner with a narrow interface (identity at construction, volatile lease binding per call), and establishes the pattern for a possible future DhcpClient extraction. The nudge is deliberately the first cut: fire-and-forget out, one atomic timestamp in, no thread handoff subtleties.

## Testing

- 81 unit tests pass (two overlapping ARP-reply tests merged into one asserting both observables), flake8 clean at max-line-length 120.
- Lab, isolated fake-DHCP bench, this ref:
  - Full link-return suite: 8/8 PASS (baseline BIND, fast path ~6s, no kick while bound, never exits, never RELEASEs).
  - New end-to-end ARP-nudge wire test: 6/6 PASS. Keeper restarted with the nudge forced on, then verified on the wire: the nudge-active log line, heartbeat nudge/gw tokens, the gateway's is-at reply captured (non-promiscuous, addressed to the virtual MAC) and stamped as arpok, and a repeat nudge after the interval.

Version bump 1.8.1 to 1.8.2 (patch, refactor only).