### PR TITLE
net/os-carp-vip-dhcp: finish the component restructuring: DhcpClient + FollowPolicy, daemon rename, lint-clean (1.8.3)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,32 @@
+# Pylint config aligned with this repo's flake8 settings in setup.cfg
+# (OPNsense practice: max line length 120).
+[FORMAT]
+max-line-length=120
+
+[BASIC]
+# Allow a dash in module names for this plugin's daemon, lease-keeper.py:
+# the filename is established on deployed systems (rc.d script and configd
+# actions reference it). Upstream OPNsense overwhelmingly uses plain or
+# underscored names; dashes are rare exceptions (core has a few, e.g.
+# rule-updater.py).
+module-rgx=[a-z][a-z0-9_-]*$
+# Short names idiomatic in the network code and tests:
+# p = scapy packet, rx = parsed reply, b = BOOTP layer, gw = gateway,
+# c/k/n = component instances in tests, t1/t2 = DHCP timers.
+good-names=p,rx,b,gw,c,k,n,s,t1,t2,ok,e,f,a,m,fd,pf,ap,lk
+
+[MESSAGES CONTROL]
+# broad-exception-caught: the daemons must never die on unexpected input --
+#   catch-all with logging is the documented posture (see lease-keeper.py's
+#   module docstring, "All I/O wrapped in try/except").
+# design metrics (too-many-*, too-few-public-methods): single-file daemons;
+#   constructor/loop sizes are deliberate and reviewed, not accidental.
+disable=broad-exception-caught,
+        too-many-arguments,
+        too-many-positional-arguments,
+        too-many-instance-attributes,
+        too-many-return-statements,
+        too-many-branches,
+        too-many-statements,
+        too-many-lines,
+        too-few-public-methods

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,26 +1,15 @@
-# Pylint config aligned with this repo's flake8 settings in setup.cfg
-# (OPNsense practice: max line length 120).
+# Pylint config: PROJECT-WIDE conventions only. Local deviations from the
+# default design limits are annotated inline at the deviation site, so the
+# strict defaults keep applying everywhere else.
 [FORMAT]
+# Aligned with the flake8 settings in setup.cfg (OPNsense practice).
 max-line-length=120
 
 [BASIC]
-# Short names idiomatic in the network code and tests:
+# Short names idiomatic across this codebase's network code and tests:
 # p = scapy packet, rx = parsed reply, b = BOOTP layer, gw = gateway,
-# c/k/n = component instances in tests, t1/t2 = DHCP timers.
+# c/k/n = component or keeper instances in tests, t1/t2 = DHCP timers,
+# m = MAC string, e = exception, f = file handle, fd/pf = descriptors,
+# a/ap = parsed args / parser, s = formatted string, ok = loop result,
+# lk = the daemon-module test fixture.
 good-names=p,rx,b,gw,c,k,n,s,t1,t2,ok,e,f,a,m,fd,pf,ap,lk
-
-[MESSAGES CONTROL]
-# broad-exception-caught: the daemons must never die on unexpected input --
-#   catch-all with logging is the documented posture (see lease-keeper.py's
-#   module docstring, "All I/O wrapped in try/except").
-# design metrics (too-many-*, too-few-public-methods): single-file daemons;
-#   constructor/loop sizes are deliberate and reviewed, not accidental.
-disable=broad-exception-caught,
-        too-many-arguments,
-        too-many-positional-arguments,
-        too-many-instance-attributes,
-        too-many-return-statements,
-        too-many-branches,
-        too-many-statements,
-        too-many-lines,
-        too-few-public-methods

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,12 +4,6 @@
 max-line-length=120
 
 [BASIC]
-# Allow a dash in module names for this plugin's daemon, lease-keeper.py:
-# the filename is established on deployed systems (rc.d script and configd
-# actions reference it). Upstream OPNsense overwhelmingly uses plain or
-# underscored names; dashes are rare exceptions (core has a few, e.g.
-# rule-updater.py).
-module-rgx=[a-z][a-z0-9_-]*$
 # Short names idiomatic in the network code and tests:
 # p = scapy packet, rx = parsed reply, b = BOOTP layer, gw = gateway,
 # c/k/n = component instances in tests, t1/t2 = DHCP timers.

--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.8.2
+PLUGIN_VERSION=         1.8.3
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -4,7 +4,7 @@
 # REQUIRE: LOGIN
 # KEYWORD: shutdown
 #
-# rc(8) wrapper for the CARP-VIP DHCP lease keepers (lease-keeper.py).
+# rc(8) wrapper for the CARP-VIP DHCP lease keepers (lease_keeper.py).
 # Reads /usr/local/etc/carpvipdhcp/keeper.conf (rendered by the configd template):
 # one line per enabled keeper ->
 #   REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE|ARP_LISTEN_PROMISC.
@@ -14,7 +14,7 @@
 
 name="carpvipdhcp"
 rcvar="carpvipdhcp_enable"
-keeper="/usr/local/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py"
+keeper="/usr/local/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py"
 conf="/usr/local/etc/carpvipdhcp/keeper.conf"
 run_dir="/var/run"
 log_dir="/var/log"
@@ -78,7 +78,7 @@ carpvipdhcp_start()
 # supervisors, whose proctitle can also contain the script path).
 _keeper_children()
 {
-    pgrep -f "python3.*OPNsense/CarpVipDhcp/lease-keeper.py" 2>/dev/null
+    pgrep -f "python3.*OPNsense/CarpVipDhcp/lease[-_]keeper.py" 2>/dev/null
 }
 
 # Signal every keeper child and its daemon(8) supervisor (the child's parent, so

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/keeperconf.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/keeperconf.py
@@ -3,6 +3,15 @@
 Lives in the same directory as its consumers (status.py, logparse.py), which
 Python puts on sys.path when configd runs them, so no packaging is needed.
 """
+import re
+
+CONFFILE = "/usr/local/etc/carpvipdhcp/keeper.conf"
+
+
+def keeper_id(request_ip):
+    """Filesystem-safe keeper id (mirrors the daemon's _fs_safe charset; the
+    two must stay in lockstep or the per-keeper file names diverge)."""
+    return re.sub(r"[^A-Za-z0-9]", "_", request_ip)
 
 
 def keeper_lines(path):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/keeperconf.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/keeperconf.py
@@ -1,0 +1,20 @@
+"""Shared keeper.conf access for the CarpVipDhcp configd scripts.
+
+Lives in the same directory as its consumers (status.py, logparse.py), which
+Python puts on sys.path when configd runs them, so no packaging is needed.
+"""
+
+
+def keeper_lines(path):
+    """Yield the |-split field list of each active (non-comment) keeper.conf
+    line; yields nothing when the file is absent or unreadable."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#") or "|" not in line:
+            continue
+        yield line.split("|")

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -61,6 +61,7 @@ import threading
 import time
 from collections import namedtuple
 from logging.handlers import RotatingFileHandler
+from typing import Any
 
 # Scapy is the one heavy third-party dependency and the usual suspect when the
 # daemon won't start (missing after an upgrade, ABI mismatch, partial install).
@@ -69,10 +70,16 @@ from logging.handlers import RotatingFileHandler
 # going to daemon(8)'s /dev/null. Capture it instead and let main() log it once
 # logging is configured.
 try:
-    from scapy.all import ARP, Ether, IP, UDP, BOOTP, DHCP, AsyncSniffer, sendp
+    from scapy.all import (  # type: ignore  # pylint: disable=import-error
+        ARP, Ether, IP, UDP, BOOTP, DHCP, AsyncSniffer, sendp)
     _SCAPY_IMPORT_ERROR = None
 except Exception as _scapy_exc:   # ImportError, or scapy's own import-time failures
     _SCAPY_IMPORT_ERROR = _scapy_exc
+    # Bind the names so the module still loads (main() exits with the captured
+    # error before any of them is used). Typed Any so type checkers do not
+    # flag every scapy call site as calling None.
+    _missing: Any = None                                # pylint: disable=invalid-name
+    ARP = Ether = IP = UDP = BOOTP = DHCP = AsyncSniffer = sendp = _missing  # pylint: disable=invalid-name
 
 LOG = logging.getLogger("lease-keeper")
 
@@ -113,6 +120,10 @@ T2_FACTOR = 0.875          # rebind by this fraction of the lease (RFC default)
 MIN_T1 = 30                # floor for the renew timer (very short leases)
 REBIND_MARGIN = 15         # ensure T2 is at least this far past T1
 BROADCAST_FLAG = 0x8000    # BOOTP flags: ask the server to broadcast OFFER/ACK
+ETHER_BROADCAST = "ff:ff:ff:ff:ff:ff"
+IPV4_BROADCAST = "255.255.255.255"   # limited broadcast (never routed off-link)
+DHCP_SERVER_PORT = 67
+DHCP_CLIENT_PORT = 68
 ARP_NUDGE_MIN = 30         # floor for --arp-nudge so a typo cannot flood the segment
 LOG_MAX_BYTES = 512 * 1024
 LOG_BACKUPS = 3
@@ -149,13 +160,12 @@ def _fmt_reply(rx):
     DEBUG (the keeper's default level), so every reply's fields (type, addresses,
     timers, gateway, mask, relay, server text) show in the log without a capture."""
     txt = _msg_text(rx.message)
-    return ("%s yiaddr=%s server=%s giaddr=%s lease=%s t1=%s t2=%s gw=%s mask=%s%s"
-            % (MTYPE_NAMES.get(rx.mtype, "type=%s" % rx.mtype), rx.yiaddr or "-",
-               rx.server_id or "-", rx.giaddr or "none",
-               rx.lease if rx.lease is not None else "-",
-               rx.t1 if rx.t1 is not None else "-", rx.t2 if rx.t2 is not None else "-",
-               rx.router or "-", rx.subnet_mask or "-",
-               (" msg=%r" % txt) if txt else ""))
+    mtype = MTYPE_NAMES.get(rx.mtype, f"type={rx.mtype}")
+    msg = f" msg={txt!r}" if txt else ""
+    return (f"{mtype} yiaddr={rx.yiaddr or '-'} server={rx.server_id or '-'} "
+            f"giaddr={rx.giaddr or 'none'} lease={'-' if rx.lease is None else rx.lease} "
+            f"t1={'-' if rx.t1 is None else rx.t1} t2={'-' if rx.t2 is None else rx.t2} "
+            f"gw={rx.router or '-'} mask={rx.subnet_mask or '-'}{msg}")
 
 
 def _parse_reply(p, yiaddr):
@@ -199,7 +209,7 @@ def _mask_to_bits(mask):
     """Dotted-quad subnet mask (DHCP option 1) -> prefix length, or None if absent
     or unparseable."""
     try:
-        return ipaddress.IPv4Network("0.0.0.0/%s" % mask).prefixlen
+        return ipaddress.IPv4Network(f"0.0.0.0/{mask}").prefixlen
     except (ValueError, TypeError):
         return None
 
@@ -212,7 +222,7 @@ _CGNAT = ipaddress.ip_network("100.64.0.0/10")
 # Static BPF capture filter: DHCP (broadcast OFFER/ACK) + ARP replies to our nudge
 # (arp[6:2]=2). A boundary, not an optimization -- it keeps everything else (incl. the
 # segment's broadcast who-has flood) out of the Python parser.
-SNIFFER_FILTER = "(udp and (port 67 or port 68)) or (arp and arp[6:2] = 2)"
+SNIFFER_FILTER = f"(udp and (port {DHCP_SERVER_PORT} or port {DHCP_CLIENT_PORT})) or (arp and arp[6:2] = 2)"
 
 
 def _sane_ipv4(ip):
@@ -261,6 +271,7 @@ def _jittered(base):
 
 
 def mac2raw(m):
+    """Colon/dash-separated MAC string -> 6 raw bytes (BOOTP chaddr)."""
     return bytes.fromhex(m.replace(":", "").replace("-", ""))
 
 
@@ -316,9 +327,9 @@ class DhcpClient:
     def _send_dhcp(self, mtype, extra, ciaddr="0.0.0.0"):
         # ciaddr is set for RENEW/REBIND (the client already owns the address);
         # the broadcast flag stays on so the reply is reliably captured by the sniffer.
-        pkt = (Ether(src=self.eth_src, dst="ff:ff:ff:ff:ff:ff") /
-               IP(src=ciaddr, dst="255.255.255.255") /
-               UDP(sport=68, dport=67) /
+        pkt = (Ether(src=self.eth_src, dst=ETHER_BROADCAST) /
+               IP(src=ciaddr, dst=IPV4_BROADCAST) /
+               UDP(sport=DHCP_CLIENT_PORT, dport=DHCP_SERVER_PORT) /
                BOOTP(chaddr=self.chraw, xid=self.xid, ciaddr=ciaddr, flags=BROADCAST_FLAG) /
                DHCP(options=_dhcp_options(mtype, extra, self._id_opts)))
         sendp(pkt, iface=self.iface, verbose=0)
@@ -339,10 +350,10 @@ class DhcpClient:
                 # Surface the server's option-56 text (why it refused) if present;
                 # it is the operator's main clue for a rejected renew.
                 txt = _msg_text(rx.message)
-                reason = " -- %s" % txt if txt else ""
+                reason = f" -- {txt}" if txt else ""
                 LOG.warning("DHCPNAK received (server %s, xid 0x%08x%s)%s",
                             rx.server_id or "unknown", self.xid,
-                            (" via relay %s" % rx.giaddr) if rx.giaddr else "", reason)
+                            f" via relay {rx.giaddr}" if rx.giaddr else "", reason)
                 return "NAK"
         return None
 
@@ -357,9 +368,11 @@ class DhcpClient:
         self.mask_bits = _mask_to_bits(rx.subnet_mask) or self.mask_bits
 
     def adopt(self, rx):
-        """Bind to the (validated) changed address in rx. The on_changed_address
-        hook calls this once its follow policy accepts the new address, so the
-        lease state stays owned here while the decision stays with the caller."""
+        """Bind to the address in rx: the ACK that completes a DORA, or a
+        validated changed address the caller's follow policy accepted (the
+        on_changed_address hook calls this, so the lease state stays owned here
+        while the decision stays with the caller). The server refreshes from
+        the ACK's server-id, keeping the previous one when the ACK has none."""
         self.yiaddr = rx.yiaddr
         self.server = rx.server_id or self.server
         self._absorb_reply(rx, DEFAULT_LEASE)
@@ -387,6 +400,7 @@ class DhcpClient:
                 if self.reboot(request_ip):
                     return True
                 LOG.info("INIT-REBOOT did not bind %s -- falling back to DISCOVER", request_ip)
+
         return self.dora(request_ip)
 
     def dora(self, request_ip=None):
@@ -394,6 +408,8 @@ class DhcpClient:
         Request, Ack. Returns True once BOUND, False on failure/NAK."""
         self.xid = random.randint(1, 0xFFFFFFFF)
         extra = [("requested_addr", request_ip)] if request_ip else []
+
+        # DISCOVER until an OFFER arrives (or the attempts run out).
         for attempt in range(1, DORA_ATTEMPTS + 1):
             if self._should_stop():
                 return False
@@ -416,6 +432,8 @@ class DhcpClient:
             time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
         else:
             return False
+
+        # REQUEST the offered address until the ACK lands.
         for attempt in range(1, DORA_ATTEMPTS + 1):
             if self._should_stop():
                 return False
@@ -436,8 +454,7 @@ class DhcpClient:
                 got = rx.yiaddr
                 if request_ip and got != request_ip:
                     return self._on_changed(got, rx, "DORA", True)
-                self.yiaddr = got
-                self._absorb_reply(rx, DEFAULT_LEASE)
+                self.adopt(rx)
                 return True
             LOG.info("no DHCP ACK from %s for %s (attempt %d, xid 0x%08x)",
                      self.server, self.yiaddr, attempt, self.xid)
@@ -454,6 +471,7 @@ class DhcpClient:
         NAK/timeout so the caller falls back to a full DORA."""
         if not request_ip:
             return False
+
         self.xid = random.randint(1, 0xFFFFFFFF)
         extra = [("requested_addr", request_ip)]
         for attempt in range(1, REBOOT_ATTEMPTS + 1):
@@ -484,6 +502,9 @@ class DhcpClient:
         return False
 
     def renew(self, rebind=False):
+        """REQUEST an extension of the held lease. Returns True on a fresh ACK,
+        False on NAK/timeout/unbound (the caller escalates: RENEW -> REBIND ->
+        re-acquire)."""
         # RENEWING/REBINDING (RFC 2131 4.3.2): ciaddr identifies the lease, so
         # server_id AND requested_addr MUST NOT be set in either state. We always
         # broadcast (the co-resident non-promiscuous sniffer needs the reply
@@ -492,6 +513,10 @@ class DhcpClient:
         # (via the `phase` it sets) relaxes the expected-server check in the
         # caller's on_changed_address hook, since at T2 any server may
         # legitimately answer.
+        yiaddr = self.yiaddr
+        if not yiaddr:
+            return False   # nothing bound -> nothing to renew
+
         opts = []
         for _ in range(RENEW_ATTEMPTS):
             if self._should_stop():
@@ -499,7 +524,7 @@ class DhcpClient:
             self._ensure_sniffer()
             self._rx = None
             try:
-                self._send_dhcp("request", opts, ciaddr=self.yiaddr)
+                self._send_dhcp("request", opts, ciaddr=yiaddr)
             except Exception as e:
                 LOG.error("DHCP %s send failed: %s", "REBIND" if rebind else "RENEW", e)
                 return False
@@ -526,10 +551,11 @@ class DhcpClient:
             yiaddr, server = self.yiaddr, self.server
         if not yiaddr:
             return
+
         try:
-            pkt = (Ether(src=self.eth_src, dst="ff:ff:ff:ff:ff:ff") /
-                   IP(src=yiaddr, dst=server or "255.255.255.255") /
-                   UDP(sport=68, dport=67) /
+            pkt = (Ether(src=self.eth_src, dst=ETHER_BROADCAST) /
+                   IP(src=yiaddr, dst=server or IPV4_BROADCAST) /
+                   UDP(sport=DHCP_CLIENT_PORT, dport=DHCP_SERVER_PORT) /
                    BOOTP(chaddr=self.chraw, xid=self.xid, ciaddr=yiaddr) /
                    DHCP(options=[("message-type", "release"),
                                  ("server_id", server), "end"]))
@@ -597,6 +623,7 @@ class ArpNudge:
                             "(no DHCP router option or server-id) -- cannot nudge")
                 self._warned = True
             return
+
         try:
             # This frame is shaped to satisfy three ISP access-network guards at
             # once (README "Playing nicely" section):
@@ -608,7 +635,7 @@ class ArpNudge:
             #   * sending it at all exists for gateways that never re-ARP an
             #     expired entry ("secured ARP") and would otherwise blackhole the
             #     VIP. Only the CARP master sends it (gated above).
-            sendp(Ether(src=self.chaddr, dst="ff:ff:ff:ff:ff:ff") /
+            sendp(Ether(src=self.chaddr, dst=ETHER_BROADCAST) /
                   ARP(op=1, hwsrc=self.chaddr, psrc=yiaddr,
                       hwdst="00:00:00:00:00:00", pdst=gateway),
                   iface=self.iface, verbose=0)
@@ -647,6 +674,12 @@ class ArpNudge:
 
 
 class Keeper:
+    """Policy and orchestration around the components: owns the packet sniffer
+    (feeding DHCP replies to DhcpClient and ARP replies to ArpNudge), the
+    follow/enforce decision for a changed address, the heartbeat, the CARP
+    role watch, the acquire pacing (backoff + link-return fast path) and the
+    signal-driven operator actions. The lease itself lives in DhcpClient."""
+
     def __init__(self, iface, chaddr, request_ip=None, eth_src=None,
                  hbfile=None, release_on_exit=False, vhid=None,
                  follow=False, vendor_class=None, client_id=None, hostname=None,
@@ -663,7 +696,7 @@ class Keeper:
         # keeper supplies the lease binding per nudge (_arp_nudge) and the
         # CARP-role probe (late-bound so tests can stub _probe_carp_master).
         self._nudge = ArpNudge(iface, self.chaddr, arp_nudge,
-                               lambda: self._probe_carp_master())
+                               lambda: self._probe_carp_master())  # pylint: disable=unnecessary-lambda
         # Promiscuous ARP capture: off by default (the CARP master already
         # accepts the VIP MAC, so the unicast reply reaches a normal socket).
         # Opt-in fallback for NICs that drop non-primary unicast MACs.
@@ -691,7 +724,7 @@ class Keeper:
         self._dhcp = DhcpClient(
             iface, self.chaddr, self.eth_src, id_opts,
             should_stop=lambda: self.stop,
-            ensure_sniffer=lambda: self._ensure_sniffer(),
+            ensure_sniffer=lambda: self._ensure_sniffer(),  # pylint: disable=unnecessary-lambda
             on_changed_address=self._handle_changed_address)
         self._followed_ip = None       # last address we asked configd to follow to
         self._follow_from = None       # address we followed FROM (for the retry watchdog)
@@ -699,7 +732,7 @@ class Keeper:
         self._follow_gw_args = []      # extra follow_update args on a cross-subnet move: [old_gw, new_gw, bits]
         # Follow throttle state, keyed by chaddr so it survives the follow-induced
         # restart (the request-IP-keyed runtime paths change on every follow).
-        self._follow_state = "/var/run/carpvipdhcp-follow-%s" % _fs_safe(self.chaddr)
+        self._follow_state = f"/var/run/carpvipdhcp-follow-{_fs_safe(self.chaddr)}"
         self.redora_wait = REDORA_MIN
         # Link-return fast path (only while UNBOUND): a carrier down->up edge resets
         # the backoff and re-DORAs at once, like dhclient's link-up -> state_reboot.
@@ -813,9 +846,9 @@ class Keeper:
         # Write atomically (temp + rename) so a crash mid-write can't leave a partial file.
         if not self.hbfile:
             return
-        tmp = "%s.tmp" % self.hbfile
+        tmp = f"{self.hbfile}.tmp"
         try:
-            with open(tmp, "w") as f:
+            with open(tmp, "w", encoding="utf-8") as f:
                 f.write(content)
             os.replace(tmp, self.hbfile)
         except Exception as e:
@@ -829,16 +862,16 @@ class Keeper:
         # 0 = none seen> and the current target gateway (if known).
         extra = ""
         if self._nudge.interval:
-            extra = " nudge=%d arpok=%d" % (int(self._nudge.last_nudge), int(self._nudge.last_reply))
+            extra = f" nudge={int(self._nudge.last_nudge)} arpok={int(self._nudge.last_reply)}"
             gw = self._nudge_target()
             if gw:
-                extra += " gw=%s" % gw
-        self._write_hb("%d bound=%s lease=%d t1=%d t2=%d src=%s%s\n"
-                       % (int(time.time()), self._dhcp.yiaddr or "-", self._dhcp.lease, t1, t2, src, extra))
+                extra += f" gw={gw}"
+        self._write_hb(f"{int(time.time())} bound={self._dhcp.yiaddr or '-'} "
+                       f"lease={self._dhcp.lease} t1={t1} t2={t2} src={src}{extra}\n")
 
     def _hb_mismatch(self, got):
         # Write a clear marker into the heartbeat file so a supervisor/human sees the mismatch.
-        self._write_hb("%d MISMATCH got=%s want=%s\n" % (int(time.time()), got, self.request_ip))
+        self._write_hb(f"{int(time.time())} MISMATCH got={got} want={self.request_ip}\n")
 
     # ---- follow mode (adopt a changed ISP address, with spoof hardening) ----
 
@@ -846,15 +879,16 @@ class Keeper:
         """Epoch of this chaddr's last follow (persisted so the throttle survives
         the follow-induced restart). 0 if never / unreadable."""
         try:
-            return float(open(self._follow_state).read().strip())
+            with open(self._follow_state, encoding="utf-8") as f:
+                return float(f.read().strip())
         except (OSError, ValueError):
             return 0.0
 
     def _record_follow(self):
         try:
             tmp = self._follow_state + ".tmp"
-            with open(tmp, "w") as f:
-                f.write("%d" % int(time.time()))
+            with open(tmp, "w", encoding="utf-8") as f:
+                f.write(str(int(time.time())))
             os.replace(tmp, self._follow_state)
         except OSError as e:
             LOG.warning("could not persist follow timestamp: %s", e)
@@ -882,11 +916,13 @@ class Keeper:
                 LOG.error("%s: ACK from unexpected server %s (leased from %s) -- not following",
                           phase, rx.server_id, self._dhcp.server)
                 return False
+
             waited = time.time() - self._last_follow_time()
             if waited < MIN_FOLLOW_INTERVAL:
                 LOG.warning("%s: follow %s -> %s throttled (%.0fs < %ds) -- deferring",
                             phase, self.request_ip, got, waited, MIN_FOLLOW_INTERVAL)
                 return False
+
             LOG.warning("ISP gave %s (VIP was %s) at %s -- following: updating the CARP VIP",
                         got, self.request_ip, phase)
             # If the ISP also moved the gateway (a cross-subnet renumber), follow the
@@ -907,6 +943,7 @@ class Keeper:
                               "carried no subnet mask -- updating the VIP address only; fix the "
                               "interface prefix + System->Gateways by hand", self.request_ip,
                               got, old_router, rx.router)
+
             self._record_follow()
             # _follow_update reads request_ip as the old address, so remember it
             # (for the retry watchdog) and fire before overwriting request_ip.
@@ -947,7 +984,7 @@ class Keeper:
         a stalled follow without tripping the _followed_ip equality guard."""
         cmd = ["/usr/local/sbin/configctl", "-d", "carpvipdhcp", "follow_update", old_ip, new_ip]
         cmd += self._follow_gw_args   # cross-subnet: [old_gw, new_gw, bits]; empty on a same-subnet move
-        subprocess.Popen(cmd)
+        subprocess.Popen(cmd)  # pylint: disable=consider-using-with
         self._follow_fired_at = time.time()
 
     def _follow_watchdog(self):
@@ -1007,7 +1044,7 @@ class Keeper:
         out = self._ifconfig()
         if out is None:
             return None
-        return ("carp: MASTER vhid %s " % self.vhid) in out
+        return f"carp: MASTER vhid {self.vhid} " in out
 
     def _iface_link_up(self):
         """Interface carrier from ifconfig: True on 'status: active', False on a
@@ -1146,13 +1183,15 @@ class Keeper:
         return not self.stop
 
     def run(self):
+        """The daemon main loop: sniffer up, then maintain the lease until
+        stopped. Never raises; returns the process exit code."""
         # Start the packet sniffer, retrying forever: a keeper must self-heal, not
         # die, if the interface is briefly unavailable at startup.
         while not self.stop and not self._start_sniffer():
             LOG.warning("sniffer start failed -- retrying in %ds", SNIFFER_RETRY)
             self._sleep(SNIFFER_RETRY)
         # eth-src matters for L2 debugging but only when it differs from the chaddr.
-        ethsrc = (" eth-src=%s" % self.eth_src) if self.eth_src != self.chaddr else ""
+        ethsrc = f" eth-src={self.eth_src}" if self.eth_src != self.chaddr else ""
         LOG.info("lease-keeper active on %s: chaddr=%s%s request=%s",
                  self.iface, self.chaddr, ethsrc, self.request_ip or "any")
         time.sleep(0.5)
@@ -1173,7 +1212,8 @@ class Keeper:
         if self.release_on_exit:
             self._dhcp.release()
         try:
-            self._sniffer.stop()
+            if self._sniffer:
+                self._sniffer.stop()
         except Exception:
             pass
         LOG.info("stopped")
@@ -1191,7 +1231,7 @@ class Keeper:
                 LOG.info("DHCP BOUND %s (lease=%ss, expires ~%s, server=%s, gw=%s, mask=%s)",
                          self._dhcp.yiaddr, self._dhcp.lease, _clock_at(self._dhcp.lease),
                          self._dhcp.server, self._dhcp.router or "?",
-                         "/%d" % self._dhcp.mask_bits if self._dhcp.mask_bits else "none")
+                         f"/{self._dhcp.mask_bits}" if self._dhcp.mask_bits else "none")
                 self._hb()
                 self._arp_nudge(force=True)
                 self.redora_wait = REDORA_MIN
@@ -1224,6 +1264,7 @@ class Keeper:
             self._arp_nudge(force=True)
             return
         LOG.warning("DHCP RENEW failed at T1 -- trying REBIND until T2")
+
         elapsed = t1
         ok = False
         while elapsed < t2 and not self.stop:
@@ -1245,11 +1286,14 @@ class Keeper:
             self._hb()
             self._arp_nudge(force=True)
             return
+
         LOG.error("DHCP lease expired -- re-acquiring (back to DISCOVER)")
         self._dhcp.expire()
 
 
 def acquire_pidfile(path):
+    """Single-instance guard: atomically claim the pidfile, replacing a stale
+    one; exits the process if another live instance holds it."""
     if not path:
         return None
     # Atomic create (O_EXCL) so two near-simultaneous starts can't both win.
@@ -1261,7 +1305,8 @@ def acquire_pidfile(path):
             return path
         except FileExistsError:
             try:
-                old = int(open(path).read().strip())
+                with open(path, encoding="utf-8") as f:
+                    old = int(f.read().strip())
                 os.kill(old, 0)
                 LOG.error("already running (pid %d) -- exiting", old)
                 sys.exit(4)
@@ -1276,7 +1321,10 @@ def acquire_pidfile(path):
             sys.exit(5)
 
 
+# main() drives the Keeper internals directly (signal flags, the --once path).
+# pylint: disable=protected-access
 def main():
+    """CLI entry point: parse args, wire up the Keeper and signals, run."""
     ap = argparse.ArgumentParser(description="Robust DHCP lease-keeper (chaddr decoupled from the iface MAC)")
     ap.add_argument("--iface", required=True)
     ap.add_argument("--chaddr", required=True)
@@ -1302,7 +1350,7 @@ def main():
     ap.add_argument("--release-on-exit", action="store_true")
     a = ap.parse_args()
 
-    handlers = [logging.StreamHandler()]
+    handlers: list[logging.Handler] = [logging.StreamHandler()]
     if a.logfile:
         try:
             handlers.append(RotatingFileHandler(a.logfile, maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUPS))
@@ -1348,13 +1396,13 @@ def main():
         # Only sets a flag; the sleep loops service it within a second, so no
         # network I/O happens inside the signal handler itself.
         k._nudge_now = True
-    signal.signal(signal.SIGUSR1, _sig_arp_nudge)
+    signal.signal(signal.SIGUSR1, _sig_arp_nudge)  # type: ignore[attr-defined]  # pylint: disable=no-member
 
     def _sig_carp(*_):
         # CARP transition (rc.syshook.d/carp/50-carpvipdhcp sends SIGUSR2). Only
         # sets a flag; the sleep loop re-checks the CARP role within a second.
         k._poll_role_now = True
-    signal.signal(signal.SIGUSR2, _sig_carp)
+    signal.signal(signal.SIGUSR2, _sig_carp)  # type: ignore[attr-defined]  # pylint: disable=no-member
 
     if a.once:
         if not k._start_sniffer():
@@ -1365,7 +1413,8 @@ def main():
         if ok:
             k._dhcp.release()
         try:
-            k._sniffer.stop()
+            if k._sniffer:
+                k._sniffer.stop()
         except Exception:
             pass
         return 0 if ok else 1

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease-keeper.py
@@ -118,9 +118,9 @@ LOG_MAX_BYTES = 512 * 1024
 LOG_BACKUPS = 3
 
 # ---- DHCP wire format: parse / format / build ----
-# Pure encode/decode helpers with no Keeper state: they turn scapy packets into a
+# Pure encode/decode helpers with no client state: they turn scapy packets into a
 # DhcpReply and turn a message type into an option list. The stateful protocol
-# sequences (DORA / INIT-REBOOT / renew) live in the Keeper class further down.
+# sequences (DORA / INIT-REBOOT / renew) live in the DhcpClient class further down.
 
 # A parsed DHCP reply, snapshotted from the sniffer thread.
 # `message` (DHCP option 56) is the server's optional human-readable text, mainly
@@ -264,6 +264,299 @@ def mac2raw(m):
     return bytes.fromhex(m.replace(":", "").replace("-", ""))
 
 
+def _clock_at(offset):
+    """Local wall-clock HH:MM of a moment `offset` seconds from now. Log
+    lines state future moments (renew/rebind/lease expiry) as relative
+    durations; the clock time saves the reader the mental arithmetic."""
+    return time.strftime("%H:%M", time.localtime(time.time() + offset))
+
+
+class DhcpClient:
+    """RFC 2131 client for one chaddr: owns the lease state (yiaddr, server,
+    lease/T1/T2, router, mask) and the stateful protocol sequences
+    (INIT-REBOOT / DORA / RENEW / REBIND / RELEASE) with their send/await
+    machinery. It does NOT own the packet capture: the sniffer owner hands
+    xid-matched replies to feed(). Policy stays with the caller through three
+    injected hooks: should_stop (abort mid-sequence), ensure_sniffer (capture
+    must be alive before a send), and on_changed_address(got, rx, phase,
+    release_on_enforce) -> bool for an ACK whose address differs from the
+    expected one (True = the caller validated and adopted it, see adopt())."""
+
+    def __init__(self, iface, chaddr, eth_src, id_opts,
+                 should_stop, ensure_sniffer, on_changed_address):
+        self.iface = iface
+        self.chaddr = chaddr
+        self.chraw = mac2raw(chaddr)
+        self.eth_src = eth_src
+        # Optional DHCP request options (empty -> not sent); added to every
+        # DISCOVER/REQUEST/RENEW so the server sees a consistent client identity.
+        self._id_opts = id_opts
+        self._should_stop = should_stop
+        self._ensure_sniffer = ensure_sniffer
+        self._on_changed = on_changed_address
+        self.xid = random.randint(1, 0xFFFFFFFF)
+        self.yiaddr = None
+        self.server = None
+        self.lease = DEFAULT_LEASE
+        self.t1_server = None          # server-provided renewal time (DHCP opt 58)
+        self.t2_server = None          # server-provided rebinding time (DHCP opt 59)
+        self.router = None             # default gateway (DHCP opt 3, fallback: server_id)
+        self.mask_bits = None          # subnet prefix length from opt 1 (for logging + follow)
+        self._tried_reboot = False     # the first acquire tries INIT-REBOOT before a full DISCOVER
+        self._rx = None                # latest DhcpReply snapshot (set via feed(), sniffer thread)
+        self._ev = threading.Event()
+
+    def feed(self, rx):
+        """Hand a first-party (xid-matched) DhcpReply to the waiting sequence.
+        Called on the sniffer thread; a lone ref-assign plus the event set."""
+        self._rx = rx
+        LOG.debug("DHCP reply: %s", _fmt_reply(rx))
+        self._ev.set()
+
+    def _send_dhcp(self, mtype, extra, ciaddr="0.0.0.0"):
+        # ciaddr is set for RENEW/REBIND (the client already owns the address);
+        # the broadcast flag stays on so the reply is reliably captured by the sniffer.
+        pkt = (Ether(src=self.eth_src, dst="ff:ff:ff:ff:ff:ff") /
+               IP(src=ciaddr, dst="255.255.255.255") /
+               UDP(sport=68, dport=67) /
+               BOOTP(chaddr=self.chraw, xid=self.xid, ciaddr=ciaddr, flags=BROADCAST_FLAG) /
+               DHCP(options=_dhcp_options(mtype, extra, self._id_opts)))
+        sendp(pkt, iface=self.iface, verbose=0)
+
+    def _wait_for_dhcp_reply(self, want, timeout):
+        """Wait up to timeout for a reply of message-type `want`. Returns the
+        DhcpReply on match, the string "NAK" on DHCPNAK, or None on timeout.
+        Returning the snapshot avoids re-reading self._rx (set by the sniffer
+        thread) after the wait."""
+        end = time.time() + timeout
+        while time.time() < end and not self._should_stop():
+            self._ev.clear()
+            self._ev.wait(min(1.0, max(0.05, end - time.time())))
+            rx = self._rx
+            if rx and rx.mtype == want:
+                return rx
+            if rx and rx.mtype == NAK:
+                # Surface the server's option-56 text (why it refused) if present;
+                # it is the operator's main clue for a rejected renew.
+                txt = _msg_text(rx.message)
+                reason = " -- %s" % txt if txt else ""
+                LOG.warning("DHCPNAK received (server %s, xid 0x%08x%s)%s",
+                            rx.server_id or "unknown", self.xid,
+                            (" via relay %s" % rx.giaddr) if rx.giaddr else "", reason)
+                return "NAK"
+        return None
+
+    def _absorb_reply(self, rx, default_lease):
+        """Adopt lease timing, gateway (opt 3) and subnet mask (opt 1) from an ACK
+        -- the one place that knows which DhcpReply fields carry lease state.
+        gateway + mask are what the Parameter Request List asks for; keep them for
+        logging + the cross-subnet follow decision."""
+        self.lease = rx.lease or default_lease
+        self.t1_server, self.t2_server = rx.t1, rx.t2
+        self.router = rx.router or self.router
+        self.mask_bits = _mask_to_bits(rx.subnet_mask) or self.mask_bits
+
+    def adopt(self, rx):
+        """Bind to the (validated) changed address in rx. The on_changed_address
+        hook calls this once its follow policy accepts the new address, so the
+        lease state stays owned here while the decision stays with the caller."""
+        self.yiaddr = rx.yiaddr
+        self.server = rx.server_id or self.server
+        self._absorb_reply(rx, DEFAULT_LEASE)
+
+    def expire(self):
+        """Forget the held binding WITHOUT a RELEASE (on-time lease expiry, or a
+        grant the policy refused to keep): yiaddr clears so the next cycle
+        re-acquires via DISCOVER; server/router stay as hints for logging and
+        the caller's nudge target."""
+        self.yiaddr = None
+
+    def acquire(self, request_ip):
+        """Get a lease. The first acquire after (re)start tries INIT-REBOOT (a
+        direct REQUEST for our known address) before a full DISCOVER; after that,
+        the normal DORA. INIT-REBOOT is one exchange and surfaces a NAK when the
+        server is reachable but refuses the address.
+
+        Startup-only (the `_tried_reboot` latch): a genuine on-time lease expiry
+        re-acquires via DISCOVER (RFC 2131 4.4.5), NOT INIT-REBOOT. We do not track
+        lease expiry across a restart -- the server arbitrates the requested address
+        (ACK if still ours, NAK/silence -> fall back to DISCOVER)."""
+        if not self._tried_reboot:
+            self._tried_reboot = True
+            if request_ip:
+                if self.reboot(request_ip):
+                    return True
+                LOG.info("INIT-REBOOT did not bind %s -- falling back to DISCOVER", request_ip)
+        return self.dora(request_ip)
+
+    def dora(self, request_ip=None):
+        """Acquire a lease via the DHCP DORA handshake -- Discover, Offer,
+        Request, Ack. Returns True once BOUND, False on failure/NAK."""
+        self.xid = random.randint(1, 0xFFFFFFFF)
+        extra = [("requested_addr", request_ip)] if request_ip else []
+        for attempt in range(1, DORA_ATTEMPTS + 1):
+            if self._should_stop():
+                return False
+            self._ensure_sniffer()
+            self._rx = None
+            try:
+                self._send_dhcp("discover", extra)
+            except Exception as e:
+                LOG.error("DHCP DISCOVER send failed: %s", e)
+                time.sleep(SEND_RETRY_DELAY)
+                continue
+            rx = self._wait_for_dhcp_reply(OFFER, REPLY_TIMEOUT)
+            if rx == "NAK":
+                return False
+            if rx:
+                self.yiaddr, self.server = rx.yiaddr, rx.server_id
+                break
+            # xid included so the exchange can be matched against a packet capture.
+            LOG.info("no DHCP OFFER (attempt %d, xid 0x%08x)", attempt, self.xid)
+            time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
+        else:
+            return False
+        for attempt in range(1, DORA_ATTEMPTS + 1):
+            if self._should_stop():
+                return False
+            self._rx = None
+            try:
+                self._send_dhcp(
+                    "request",
+                    [("server_id", self.server), ("requested_addr", self.yiaddr)],
+                )
+            except Exception as e:
+                LOG.error("DHCP REQUEST send failed: %s", e)
+                time.sleep(SEND_RETRY_DELAY)
+                continue
+            rx = self._wait_for_dhcp_reply(ACK, REPLY_TIMEOUT)
+            if rx == "NAK":
+                return False   # NAK -> back to INIT; the run loop re-acquires (DISCOVER)
+            if rx:
+                got = rx.yiaddr
+                if request_ip and got != request_ip:
+                    return self._on_changed(got, rx, "DORA", True)
+                self.yiaddr = got
+                self._absorb_reply(rx, DEFAULT_LEASE)
+                return True
+            LOG.info("no DHCP ACK from %s for %s (attempt %d, xid 0x%08x)",
+                     self.server, self.yiaddr, attempt, self.xid)
+            time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
+        return False
+
+    def reboot(self, request_ip):
+        """INIT-REBOOT (RFC 2131 4.3.2): we already know the address we want
+        (request_ip), so REQUEST it directly instead of a full DISCOVER -- one
+        exchange, and a server that is reachable but refuses the address answers
+        with a NAK (a DISCOVER it may just ignore), surfacing 'reachable but
+        refused' in the log. server_id MUST NOT be set and ciaddr stays 0 (we do
+        not own the address on the interface). Returns True once BOUND, False on
+        NAK/timeout so the caller falls back to a full DORA."""
+        if not request_ip:
+            return False
+        self.xid = random.randint(1, 0xFFFFFFFF)
+        extra = [("requested_addr", request_ip)]
+        for attempt in range(1, REBOOT_ATTEMPTS + 1):
+            if self._should_stop():
+                return False
+            self._ensure_sniffer()
+            self._rx = None
+            try:
+                self._send_dhcp("request", extra)
+            except Exception as e:
+                LOG.error("DHCP INIT-REBOOT send failed: %s", e)
+                time.sleep(SEND_RETRY_DELAY)
+                continue
+            rx = self._wait_for_dhcp_reply(ACK, REPLY_TIMEOUT)
+            if rx == "NAK":
+                return False   # server refused our known address -> full DISCOVER
+            if rx:
+                got = rx.yiaddr
+                if got and got != request_ip:
+                    return self._on_changed(got, rx, "REBOOT", True)
+                self.yiaddr, self.server = request_ip, rx.server_id
+                self._absorb_reply(rx, DEFAULT_LEASE)
+                return True
+            LOG.info("no DHCP ACK to INIT-REBOOT for %s (attempt %d, xid 0x%08x)",
+                     request_ip, attempt, self.xid)
+            if attempt < REBOOT_ATTEMPTS:   # no backoff after the last try -- fall to DORA at once
+                time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
+        return False
+
+    def renew(self, rebind=False):
+        # RENEWING/REBINDING (RFC 2131 4.3.2): ciaddr identifies the lease, so
+        # server_id AND requested_addr MUST NOT be set in either state. We always
+        # broadcast (the co-resident non-promiscuous sniffer needs the reply
+        # broadcast), so any server may answer, which is fine for a single-server
+        # ISP WAN. `rebind` is still load-bearing: it picks the log label AND
+        # (via the `phase` it sets) relaxes the expected-server check in the
+        # caller's on_changed_address hook, since at T2 any server may
+        # legitimately answer.
+        opts = []
+        for _ in range(RENEW_ATTEMPTS):
+            if self._should_stop():
+                return False
+            self._ensure_sniffer()
+            self._rx = None
+            try:
+                self._send_dhcp("request", opts, ciaddr=self.yiaddr)
+            except Exception as e:
+                LOG.error("DHCP %s send failed: %s", "REBIND" if rebind else "RENEW", e)
+                return False
+            rx = self._wait_for_dhcp_reply(ACK, RENEW_TIMEOUT)
+            if rx == "NAK":
+                return False   # NAK -> re-DORA
+            if rx:
+                got = rx.yiaddr
+                if got and got != self.yiaddr:
+                    # Some dynamic servers change the address at renewal (ACK with a
+                    # new yiaddr) instead of NAKing. Route it through the same
+                    # follow / enforce decision (and hardening) as the initial DORA.
+                    phase = "REBIND" if rebind else "RENEW"
+                    return self._on_changed(got, rx, phase, False)
+                self._absorb_reply(rx, self.lease)
+                return True
+        return False
+
+    def release(self, yiaddr=None, server=None):
+        """RELEASE a lease -- the held one by default, or an explicit
+        (yiaddr, server) pair (the enforce path releases an address it was
+        granted but refuses to keep)."""
+        if yiaddr is None:
+            yiaddr, server = self.yiaddr, self.server
+        if not yiaddr:
+            return
+        try:
+            pkt = (Ether(src=self.eth_src, dst="ff:ff:ff:ff:ff:ff") /
+                   IP(src=yiaddr, dst=server or "255.255.255.255") /
+                   UDP(sport=68, dport=67) /
+                   BOOTP(chaddr=self.chraw, xid=self.xid, ciaddr=yiaddr) /
+                   DHCP(options=[("message-type", "release"),
+                                 ("server_id", server), "end"]))
+            sendp(pkt, iface=self.iface, verbose=0)
+            LOG.info("DHCP RELEASE of lease %s sent (server %s)", yiaddr, server or "broadcast")
+        except Exception as e:
+            LOG.error("RELEASE failed: %s", e)
+
+    def timing(self):
+        """Effective renew (T1) / rebind (T2) seconds and where they came from.
+
+        Uses server-provided DHCP option 58/59 when present and sane, otherwise
+        the RFC-suggested 0.5 / 0.875 of the lease time.
+        """
+        lease = max(1, self.lease)
+        t1 = self.t1_server if self.t1_server else int(lease * T1_FACTOR)
+        t2 = self.t2_server if self.t2_server else int(lease * T2_FACTOR)
+        # Keep both timers inside the lease; only apply the MIN_T1 floor when the
+        # lease is long enough to accommodate it (very short leases renew sooner).
+        t1 = min(t1, lease)
+        if lease > MIN_T1:
+            t1 = max(MIN_T1, t1)
+        t2 = min(max(t1 + REBIND_MARGIN, t2), lease)
+        src = "server" if (self.t1_server or self.t2_server) else "derived"
+        return t1, t2, src
+
+
 class ArpNudge:
     """Keep the upstream gateway's ARP entry for the leased address fresh, for
     gateways that ignore gratuitous ARP and never re-ARP an expired entry (see
@@ -360,7 +653,6 @@ class Keeper:
                  arp_nudge=0, arp_listen_promisc=False):
         self.iface = iface
         self.chaddr = chaddr.lower()
-        self.chraw = mac2raw(chaddr)
         self.request_ip = request_ip
         self.eth_src = (eth_src or chaddr).lower()
         self.hbfile = hbfile
@@ -376,8 +668,6 @@ class Keeper:
         # accepts the VIP MAC, so the unicast reply reaches a normal socket).
         # Opt-in fallback for NICs that drop non-primary unicast MACs.
         self.arp_listen_promisc = arp_listen_promisc
-        self.router = None             # default gateway (DHCP opt 3, fallback: server_id)
-        self.mask_bits = None          # subnet prefix length from opt 1 (for logging + follow)
         self._was_master = None        # CARP role at the last nudge check (None = unknown yet)
         self._nudge_now = False        # operator asked for an immediate nudge (SIGUSR1)
         self._poll_role_now = False    # a CARP transition fired -> re-check role now (SIGUSR2)
@@ -387,13 +677,22 @@ class Keeper:
         # ISP interplay: satisfies servers that only lease to a known vendor-class
         # (opt 60), client-id (61) or hostname (12) -- the "client identity checks"
         # row of the README's ISP-security section.
-        self._id_opts = []
+        id_opts = []
         if vendor_class:
-            self._id_opts.append(("vendor_class_id", vendor_class))
+            id_opts.append(("vendor_class_id", vendor_class))
         if client_id:
-            self._id_opts.append(("client_id", client_id.encode()))
+            id_opts.append(("client_id", client_id.encode()))
         if hostname:
-            self._id_opts.append(("hostname", hostname))
+            id_opts.append(("hostname", hostname))
+        # DHCP client component: owns the lease state and the protocol sequences;
+        # the keeper owns the sniffer (feeding it xid-matched replies) and the
+        # policy hooks. should_stop/ensure_sniffer are late-bound lambdas so
+        # tests can stub the keeper attributes after construction.
+        self._dhcp = DhcpClient(
+            iface, self.chaddr, self.eth_src, id_opts,
+            should_stop=lambda: self.stop,
+            ensure_sniffer=lambda: self._ensure_sniffer(),
+            on_changed_address=self._handle_changed_address)
         self._followed_ip = None       # last address we asked configd to follow to
         self._follow_from = None       # address we followed FROM (for the retry watchdog)
         self._follow_fired_at = 0.0    # when we last dispatched follow_update (retry deadline)
@@ -402,26 +701,17 @@ class Keeper:
         # restart (the request-IP-keyed runtime paths change on every follow).
         self._follow_state = "/var/run/carpvipdhcp-follow-%s" % _fs_safe(self.chaddr)
         self.redora_wait = REDORA_MIN
-        self._tried_reboot = False     # the first acquire tries INIT-REBOOT before a full DISCOVER
         # Link-return fast path (only while UNBOUND): a carrier down->up edge resets
         # the backoff and re-DORAs at once, like dhclient's link-up -> state_reboot.
         self._link_up = None           # last carrier state seen (None = unknown / not probed)
         self._link_kick_at = 0.0       # epoch of the last link-return kick (debounce)
         self._link_returned = False    # set by _sleep_interruptible on a carrier return while unbound
-        self.xid = random.randint(1, 0xFFFFFFFF)
-        self.server = None
-        self.yiaddr = None
-        self.lease = DEFAULT_LEASE
-        self.t1_server = None          # server-provided renewal time (DHCP opt 58)
-        self.t2_server = None          # server-provided rebinding time (DHCP opt 59)
         self.stop = False
-        self._rx = None                # latest DhcpReply snapshot (set by the sniffer thread)
         # Follow mode: a changed ISP address first seen in the PEER's ACK (both
         # HA nodes run an identical keeper on the same shared chaddr). The sniffer
         # writes it (a lone atomic ref-assign); the main thread consumes it and
         # drives the hardened follow -- see _on_dhcp_reply / _check_observed_follow.
         self._observed_change = None
-        self._ev = threading.Event()
         # General early-wake for the maintain-loop sleep (_sleep_interruptible): lets it
         # return before the 1s tick when there is pending work. Currently the
         # sniffer sets it on an observed address change so the follow fires in
@@ -471,7 +761,7 @@ class Keeper:
             self._on_dhcp_reply(p)
         elif p.haslayer(ARP):
             # Gateway answering our nudge (reachability stamp).
-            self._nudge.on_arp_reply(p, self.yiaddr, self._nudge_target())
+            self._nudge.on_arp_reply(p, self._dhcp.yiaddr, self._nudge_target())
 
     def _chaddr_matches(self, b):
         """True if the reply's BOOTP client hardware address is our chaddr (the
@@ -481,7 +771,7 @@ class Keeper:
             raw = bytes(getattr(b, "chaddr", b"") or b"")
         except (TypeError, ValueError):
             return False
-        return raw[:6] == self.chraw
+        return raw[:6] == self._dhcp.chraw
 
     def _on_dhcp_reply(self, p):
         try:
@@ -491,11 +781,9 @@ class Keeper:
             if b.op != BOOTREPLY:
                 return
             # First-party path: a reply to OUR in-flight exchange (random xid,
-            # regenerated per DORA). Parsed and handed to the waiting main thread.
-            if b.xid == self.xid:
-                self._rx = _parse_reply(p, b.yiaddr)
-                LOG.debug("DHCP reply: %s", _fmt_reply(self._rx))
-                self._ev.set()
+            # regenerated per DORA). Parsed and fed to the waiting client sequence.
+            if b.xid == self._dhcp.xid:
+                self._dhcp.feed(_parse_reply(p, b.yiaddr))
                 return
             # Not our xid. In follow mode, still watch for the PEER's ACK: both HA
             # nodes run an identical keeper on the SAME chaddr (the CARP virtual
@@ -509,247 +797,15 @@ class Keeper:
             # thread -- which routes it through the same follow hardening
             # (sane / same-class / expected-server / throttle) as a first-party
             # ACK and never acts on the sniffer thread.
-            if not self.follow or not self.yiaddr or not self._chaddr_matches(b):
+            if not self.follow or not self._dhcp.yiaddr or not self._chaddr_matches(b):
                 return
             rx = _parse_reply(p, b.yiaddr)
-            if (rx.mtype == ACK and rx.yiaddr and rx.yiaddr != self.yiaddr
+            if (rx.mtype == ACK and rx.yiaddr and rx.yiaddr != self._dhcp.yiaddr
                     and _sane_ipv4(rx.yiaddr)):
                 self._observed_change = rx
                 self._wake.set()   # wake the maintain-loop sleep now, don't wait for the tick
         except Exception as e:
             LOG.debug("DHCP reply parse error: %s", e)
-
-    # ---- DHCP protocol (send / await reply / DORA / renew / release) ----
-
-    def _send_dhcp(self, mtype, extra, ciaddr="0.0.0.0"):
-        # ciaddr is set for RENEW/REBIND (the client already owns the address);
-        # the broadcast flag stays on so the reply is reliably captured by the sniffer.
-        pkt = (Ether(src=self.eth_src, dst="ff:ff:ff:ff:ff:ff") /
-               IP(src=ciaddr, dst="255.255.255.255") /
-               UDP(sport=68, dport=67) /
-               BOOTP(chaddr=self.chraw, xid=self.xid, ciaddr=ciaddr, flags=BROADCAST_FLAG) /
-               DHCP(options=_dhcp_options(mtype, extra, self._id_opts)))
-        sendp(pkt, iface=self.iface, verbose=0)
-
-    def _wait_for_dhcp_reply(self, want, timeout):
-        """Wait up to timeout for a reply of message-type `want`. Returns the
-        DhcpReply on match, the string "NAK" on DHCPNAK, or None on timeout.
-        Returning the snapshot avoids re-reading self._rx (set by the sniffer
-        thread) after the wait."""
-        end = time.time() + timeout
-        while time.time() < end and not self.stop:
-            self._ev.clear()
-            self._ev.wait(min(1.0, max(0.05, end - time.time())))
-            rx = self._rx
-            if rx and rx.mtype == want:
-                return rx
-            if rx and rx.mtype == NAK:
-                # Surface the server's option-56 text (why it refused) if present;
-                # it is the operator's main clue for a rejected renew.
-                txt = _msg_text(rx.message)
-                reason = " -- %s" % txt if txt else ""
-                LOG.warning("DHCPNAK received (server %s, xid 0x%08x%s)%s",
-                            rx.server_id or "unknown", self.xid,
-                            (" via relay %s" % rx.giaddr) if rx.giaddr else "", reason)
-                return "NAK"
-        return None
-
-    def _absorb_reply(self, rx, default_lease):
-        """Adopt lease timing, gateway (opt 3) and subnet mask (opt 1) from an ACK
-        -- the one place that knows which DhcpReply fields carry keeper state.
-        gateway + mask are what the Parameter Request List asks for; keep them for
-        logging + the cross-subnet follow decision."""
-        self.lease = rx.lease or default_lease
-        self.t1_server, self.t2_server = rx.t1, rx.t2
-        self.router = rx.router or self.router
-        self.mask_bits = _mask_to_bits(rx.subnet_mask) or self.mask_bits
-
-    def dora(self):
-        """Acquire a lease via the DHCP DORA handshake -- Discover, Offer,
-        Request, Ack. Returns True once BOUND, False on failure/NAK."""
-        self.xid = random.randint(1, 0xFFFFFFFF)
-        extra = [("requested_addr", self.request_ip)] if self.request_ip else []
-        for attempt in range(1, DORA_ATTEMPTS + 1):
-            if self.stop:
-                return False
-            self._ensure_sniffer()
-            self._rx = None
-            try:
-                self._send_dhcp("discover", extra)
-            except Exception as e:
-                LOG.error("DHCP DISCOVER send failed: %s", e)
-                time.sleep(SEND_RETRY_DELAY)
-                continue
-            rx = self._wait_for_dhcp_reply(OFFER, REPLY_TIMEOUT)
-            if rx == "NAK":
-                return False
-            if rx:
-                self.yiaddr, self.server = rx.yiaddr, rx.server_id
-                break
-            # xid included so the exchange can be matched against a packet capture.
-            LOG.info("no DHCP OFFER (attempt %d, xid 0x%08x)", attempt, self.xid)
-            time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
-        else:
-            return False
-        for attempt in range(1, DORA_ATTEMPTS + 1):
-            if self.stop:
-                return False
-            self._rx = None
-            try:
-                self._send_dhcp(
-                    "request",
-                    [("server_id", self.server), ("requested_addr", self.yiaddr)],
-                )
-            except Exception as e:
-                LOG.error("DHCP REQUEST send failed: %s", e)
-                time.sleep(SEND_RETRY_DELAY)
-                continue
-            rx = self._wait_for_dhcp_reply(ACK, REPLY_TIMEOUT)
-            if rx == "NAK":
-                return False   # NAK -> back to INIT; the run loop re-acquires (DISCOVER)
-            if rx:
-                got = rx.yiaddr
-                if self.request_ip and got != self.request_ip:
-                    return self._handle_changed_address(got, rx, "DORA", release_on_enforce=True)
-                self.yiaddr = got
-                self._absorb_reply(rx, DEFAULT_LEASE)
-                return True
-            LOG.info("no DHCP ACK from %s for %s (attempt %d, xid 0x%08x)",
-                     self.server, self.yiaddr, attempt, self.xid)
-            time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
-        return False
-
-    def reboot(self):
-        """INIT-REBOOT (RFC 2131 4.3.2): we already know the address we want
-        (request_ip), so REQUEST it directly instead of a full DISCOVER -- one
-        exchange, and a server that is reachable but refuses the address answers
-        with a NAK (a DISCOVER it may just ignore), surfacing 'reachable but
-        refused' in the log. server_id MUST NOT be set and ciaddr stays 0 (we do
-        not own the address on the interface). Returns True once BOUND, False on
-        NAK/timeout so the caller falls back to a full DORA."""
-        if not self.request_ip:
-            return False
-        self.xid = random.randint(1, 0xFFFFFFFF)
-        extra = [("requested_addr", self.request_ip)]
-        for attempt in range(1, REBOOT_ATTEMPTS + 1):
-            if self.stop:
-                return False
-            self._ensure_sniffer()
-            self._rx = None
-            try:
-                self._send_dhcp("request", extra)
-            except Exception as e:
-                LOG.error("DHCP INIT-REBOOT send failed: %s", e)
-                time.sleep(SEND_RETRY_DELAY)
-                continue
-            rx = self._wait_for_dhcp_reply(ACK, REPLY_TIMEOUT)
-            if rx == "NAK":
-                return False   # server refused our known address -> full DISCOVER
-            if rx:
-                got = rx.yiaddr
-                if got and got != self.request_ip:
-                    return self._handle_changed_address(got, rx, "REBOOT", release_on_enforce=True)
-                self.yiaddr, self.server = self.request_ip, rx.server_id
-                self._absorb_reply(rx, DEFAULT_LEASE)
-                return True
-            LOG.info("no DHCP ACK to INIT-REBOOT for %s (attempt %d, xid 0x%08x)",
-                     self.request_ip, attempt, self.xid)
-            if attempt < REBOOT_ATTEMPTS:   # no backoff after the last try -- fall to DORA at once
-                time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
-        return False
-
-    def _acquire(self):
-        """Get a lease. The first acquire after (re)start tries INIT-REBOOT (a
-        direct REQUEST for our known address) before a full DISCOVER; after that,
-        the normal DORA. INIT-REBOOT is one exchange and surfaces a NAK when the
-        server is reachable but refuses the address.
-
-        Startup-only (the `_tried_reboot` latch): a genuine on-time lease expiry
-        re-acquires via DISCOVER (RFC 2131 4.4.5), NOT INIT-REBOOT. We do not track
-        lease expiry across a restart -- the server arbitrates the requested address
-        (ACK if still ours, NAK/silence -> fall back to DISCOVER)."""
-        if not self._tried_reboot:
-            self._tried_reboot = True
-            if self.request_ip:
-                if self.reboot():
-                    return True
-                LOG.info("INIT-REBOOT did not bind %s -- falling back to DISCOVER", self.request_ip)
-        return self.dora()
-
-    def renew(self, rebind=False):
-        # RENEWING/REBINDING (RFC 2131 4.3.2): ciaddr identifies the lease, so
-        # server_id AND requested_addr MUST NOT be set in either state. We always
-        # broadcast (the co-resident non-promiscuous sniffer needs the reply
-        # broadcast), so any server may answer, which is fine for a single-server
-        # ISP WAN. `rebind` is still load-bearing: it picks the log label AND
-        # (via the `phase` it sets) relaxes the expected-server check in
-        # _handle_changed_address, since at T2 any server may legitimately answer.
-        opts = []
-        for _ in range(RENEW_ATTEMPTS):
-            if self.stop:
-                return False
-            self._ensure_sniffer()
-            self._rx = None
-            try:
-                self._send_dhcp("request", opts, ciaddr=self.yiaddr)
-            except Exception as e:
-                LOG.error("DHCP %s send failed: %s", "REBIND" if rebind else "RENEW", e)
-                return False
-            rx = self._wait_for_dhcp_reply(ACK, RENEW_TIMEOUT)
-            if rx == "NAK":
-                return False   # NAK -> re-DORA
-            if rx:
-                got = rx.yiaddr
-                if got and got != self.yiaddr:
-                    # Some dynamic servers change the address at renewal (ACK with a
-                    # new yiaddr) instead of NAKing. Route it through the same
-                    # follow / enforce decision (and hardening) as the initial DORA.
-                    phase = "REBIND" if rebind else "RENEW"
-                    return self._handle_changed_address(got, rx, phase, release_on_enforce=False)
-                self._absorb_reply(rx, self.lease)
-                return True
-        return False
-
-    def release(self):
-        if not self.yiaddr:
-            return
-        try:
-            pkt = (Ether(src=self.eth_src, dst="ff:ff:ff:ff:ff:ff") /
-                   IP(src=self.yiaddr, dst=self.server or "255.255.255.255") /
-                   UDP(sport=68, dport=67) /
-                   BOOTP(chaddr=self.chraw, xid=self.xid, ciaddr=self.yiaddr) /
-                   DHCP(options=[("message-type", "release"),
-                                 ("server_id", self.server), "end"]))
-            sendp(pkt, iface=self.iface, verbose=0)
-            LOG.info("DHCP RELEASE of lease %s sent (server %s)", self.yiaddr, self.server or "broadcast")
-        except Exception as e:
-            LOG.error("RELEASE failed: %s", e)
-
-    # ---- lease timing ----
-
-    def _timing(self):
-        """Effective renew (T1) / rebind (T2) seconds and where they came from.
-
-        Uses server-provided DHCP option 58/59 when present and sane, otherwise
-        the RFC-suggested 0.5 / 0.875 of the lease time.
-        """
-        lease = max(1, self.lease)
-        t1 = self.t1_server if self.t1_server else int(lease * T1_FACTOR)
-        t2 = self.t2_server if self.t2_server else int(lease * T2_FACTOR)
-        # Keep both timers inside the lease; only apply the MIN_T1 floor when the
-        # lease is long enough to accommodate it (very short leases renew sooner).
-        t1 = min(t1, lease)
-        if lease > MIN_T1:
-            t1 = max(MIN_T1, t1)
-        t2 = min(max(t1 + REBIND_MARGIN, t2), lease)
-        src = "server" if (self.t1_server or self.t2_server) else "derived"
-        return t1, t2, src
-
-    def _clock_at(self, offset):
-        """Local wall-clock HH:MM of a moment `offset` seconds from now. Log
-        lines state future moments (renew/rebind/lease expiry) as relative
-        durations; the clock time saves the reader the mental arithmetic."""
-        return time.strftime("%H:%M", time.localtime(time.time() + offset))
 
     # ---- heartbeat / status file ----
 
@@ -767,7 +823,7 @@ class Keeper:
             LOG.warning("heartbeat write failed (%s): %s", self.hbfile, e)
 
     def _hb(self):
-        t1, t2, src = self._timing()
+        t1, t2, src = self._dhcp.timing()
         # Publish nudge state so the status page can show it: nudge=<epoch of the
         # last sent nudge, 0 = never>, arpok=<epoch of the gateway's last ARP reply,
         # 0 = none seen> and the current target gateway (if known).
@@ -778,7 +834,7 @@ class Keeper:
             if gw:
                 extra += " gw=%s" % gw
         self._write_hb("%d bound=%s lease=%d t1=%d t2=%d src=%s%s\n"
-                       % (int(time.time()), self.yiaddr or "-", self.lease, t1, t2, src, extra))
+                       % (int(time.time()), self._dhcp.yiaddr or "-", self._dhcp.lease, t1, t2, src, extra))
 
     def _hb_mismatch(self, got):
         # Write a clear marker into the heartbeat file so a supervisor/human sees the mismatch.
@@ -822,9 +878,9 @@ class Keeper:
                           "(possible spoofed ACK from %s)", phase, self.request_ip, got,
                           rx.server_id)
                 return False
-            if phase != "REBIND" and rx.server_id and self.server and rx.server_id != self.server:
+            if phase != "REBIND" and rx.server_id and self._dhcp.server and rx.server_id != self._dhcp.server:
                 LOG.error("%s: ACK from unexpected server %s (leased from %s) -- not following",
-                          phase, rx.server_id, self.server)
+                          phase, rx.server_id, self._dhcp.server)
                 return False
             waited = time.time() - self._last_follow_time()
             if waited < MIN_FOLLOW_INTERVAL:
@@ -838,35 +894,36 @@ class Keeper:
             # plain DHCP interface does. Needs the new subnet mask (opt 1) to set the
             # VIP prefix; without it we can only move the address, so warn instead.
             self._follow_gw_args = []
-            if rx.router and self.router and rx.router != self.router:
+            old_router = self._dhcp.router
+            if rx.router and old_router and rx.router != old_router:
                 bits = _mask_to_bits(rx.subnet_mask)
                 if bits:
                     LOG.warning("follow %s -> %s also moves the gateway (%s -> %s), subnet "
                                 "/%d -- following across the subnet", self.request_ip, got,
-                                self.router, rx.router, bits)
-                    self._follow_gw_args = [self.router, rx.router, str(bits)]
+                                old_router, rx.router, bits)
+                    self._follow_gw_args = [old_router, rx.router, str(bits)]
                 else:
                     LOG.error("follow %s -> %s changes the gateway (%s -> %s) but the ACK "
                               "carried no subnet mask -- updating the VIP address only; fix the "
                               "interface prefix + System->Gateways by hand", self.request_ip,
-                              got, self.router, rx.router)
+                              got, old_router, rx.router)
             self._record_follow()
             # _follow_update reads request_ip as the old address, so remember it
             # (for the retry watchdog) and fire before overwriting request_ip.
             self._follow_from = self.request_ip
             self._follow_update(got)
             self.request_ip = got
-            self.yiaddr, self.server = got, rx.server_id or self.server
-            self._absorb_reply(rx, DEFAULT_LEASE)
+            self._dhcp.adopt(rx)
             return True
         # Enforce: a fixed reservation must always return request_ip.
         LOG.error("%s: IP mismatch -- server %s gave %s, requested %s (reservation problem?)",
                   phase, rx.server_id, got, self.request_ip)
         self._hb_mismatch(got)
         if release_on_enforce:
-            self.yiaddr, self.server = got, rx.server_id
-            self.release()
-            self.yiaddr = None
+            self._dhcp.release(got, rx.server_id)
+            # DORA's OFFER phase already recorded a tentative yiaddr; drop it so
+            # the run loop re-acquires instead of renewing the refused grant.
+            self._dhcp.expire()
         return False
 
     def _follow_update(self, new_ip):
@@ -922,10 +979,10 @@ class Keeper:
         if rx is None:
             return
         self._observed_change = None
-        if not self.follow or not rx.yiaddr or rx.yiaddr == self.yiaddr:
+        if not self.follow or not rx.yiaddr or rx.yiaddr == self._dhcp.yiaddr:
             return
         LOG.info("observed peer DHCP ACK for %s (we hold %s) -- following early to converge",
-                 rx.yiaddr, self.yiaddr)
+                 rx.yiaddr, self._dhcp.yiaddr)
         self._handle_changed_address(rx.yiaddr, rx, "OBSERVED", release_on_enforce=False)
 
     # ---- CARP role (master probe, transitions) ----
@@ -1013,12 +1070,12 @@ class Keeper:
     def _nudge_target(self):
         """The gateway whose ARP cache the nudge maintains: DHCP option 3 from
         the last ACK, falling back to the leasing server's address."""
-        return self.router or self.server
+        return self._dhcp.router or self._dhcp.server
 
     def _arp_nudge(self, force=False):
         """Hand the current lease binding (leased address, nudge target) to the
         ArpNudge component; it owns the pacing, the master gate and the send."""
-        self._nudge.maybe_nudge(self.yiaddr, self._nudge_target(), force=force)
+        self._nudge.maybe_nudge(self._dhcp.yiaddr, self._nudge_target(), force=force)
 
     # ---- main loop / sleeps ----
 
@@ -1056,7 +1113,7 @@ class Keeper:
             # Link-return fast path: only while UNBOUND, poll carrier every few
             # seconds; a down->up edge means the WAN just came back, so stop waiting
             # and let _run_once re-DORA immediately (the bound path skips this).
-            if self.yiaddr is None and slept % LINK_POLL_STEP == 0 and self._check_link_returned():
+            if self._dhcp.yiaddr is None and slept % LINK_POLL_STEP == 0 and self._check_link_returned():
                 self._link_returned = True
                 return not self.stop
             # Event-driven sleep: return at once when the sniffer signals a fresh
@@ -1114,7 +1171,7 @@ class Keeper:
                 self._sleep(LOOP_ERROR_BACKOFF)
         # shutdown
         if self.release_on_exit:
-            self.release()
+            self._dhcp.release()
         try:
             self._sniffer.stop()
         except Exception:
@@ -1127,14 +1184,14 @@ class Keeper:
         on every state transition; any exception it raises is caught by run() and
         retried, so a transient fault can never terminate the keeper."""
         # Acquire a lease if we do not hold one.
-        if not self.yiaddr:
+        if not self._dhcp.yiaddr:
             self._ensure_sniffer()  # a dead sniffer would silently fail every DORA
             self._hb()  # active but not holding yet -> publish bound=-
-            if self._acquire():
+            if self._dhcp.acquire(self.request_ip):
                 LOG.info("DHCP BOUND %s (lease=%ss, expires ~%s, server=%s, gw=%s, mask=%s)",
-                         self.yiaddr, self.lease, self._clock_at(self.lease), self.server,
-                         self.router or "?",
-                         "/%d" % self.mask_bits if self.mask_bits else "none")
+                         self._dhcp.yiaddr, self._dhcp.lease, _clock_at(self._dhcp.lease),
+                         self._dhcp.server, self._dhcp.router or "?",
+                         "/%d" % self._dhcp.mask_bits if self._dhcp.mask_bits else "none")
                 self._hb()
                 self._arp_nudge(force=True)
                 self.redora_wait = REDORA_MIN
@@ -1151,18 +1208,18 @@ class Keeper:
                     self.redora_wait = min(self.redora_wait * 2, REDORA_MAX)
             return
         # Maintain: wait until T1, then RENEW; bail early on stop.
-        t1, t2, src = self._timing()
+        t1, t2, src = self._dhcp.timing()
         # The renew/rebind plan is verbose and identical every cycle for a stable
         # lease, so log it at DEBUG -- the default (INFO) log stays clean and
         # "RENEW ok" already carries the lease + expiry. Raise the keeper's log
         # level to see it.
         LOG.debug("DHCP lease %ds; renew at T1=%ds (~%s), rebind by T2=%ds (~%s) (timing source: %s)",
-                  self.lease, t1, self._clock_at(t1), t2, self._clock_at(t2), src)
+                  self._dhcp.lease, t1, _clock_at(t1), t2, _clock_at(t2), src)
         if not self._hold_lease(t1):
             return
-        if self.renew():
+        if self._dhcp.renew():
             LOG.info("DHCP RENEW ok %s (lease=%ss, expires ~%s)",
-                     self.yiaddr, self.lease, self._clock_at(self.lease))
+                     self._dhcp.yiaddr, self._dhcp.lease, _clock_at(self._dhcp.lease))
             self._hb()
             self._arp_nudge(force=True)
             return
@@ -1179,17 +1236,17 @@ class Keeper:
                 break
             elapsed += step
             self._hb()   # still holding the lease until T2 -- keep the heartbeat fresh
-            if self.renew(rebind=True):
+            if self._dhcp.renew(rebind=True):
                 ok = True
                 break
         if ok:
             LOG.info("DHCP REBIND ok %s (lease=%ss, expires ~%s)",
-                     self.yiaddr, self.lease, self._clock_at(self.lease))
+                     self._dhcp.yiaddr, self._dhcp.lease, _clock_at(self._dhcp.lease))
             self._hb()
             self._arp_nudge(force=True)
             return
         LOG.error("DHCP lease expired -- re-acquiring (back to DISCOVER)")
-        self.yiaddr = None
+        self._dhcp.expire()
 
 
 def acquire_pidfile(path):
@@ -1303,10 +1360,10 @@ def main():
         if not k._start_sniffer():
             return 3
         time.sleep(0.5)
-        ok = k.dora()
-        LOG.info("DHCP claim %s -> %s", k.chaddr, k.yiaddr if ok else "FAIL")
+        ok = k._dhcp.dora(a.request)
+        LOG.info("DHCP claim %s -> %s", k.chaddr, k._dhcp.yiaddr if ok else "FAIL")
         if ok:
-            k.release()
+            k._dhcp.release()
         try:
             k._sniffer.stop()
         except Exception:

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -117,6 +117,7 @@ REDORA_MAX = 45            # max exponential-backoff wait after a failed acquire
 LINK_POLL_STEP = 3         # while UNBOUND, poll interface carrier this often (s) for the link-return fast path
 LINK_KICK_DEBOUNCE = 8     # min seconds between link-return re-DORA kicks (damps a flapping link)
 SNIFFER_RETRY = 5          # wait before retrying a failed packet-sniffer start
+SNIFFER_WARMUP = 0.5       # let the capture thread attach before the first send
 LOOP_ERROR_BACKOFF = 10    # wait after an unexpected main-loop error before retrying
 MIN_FOLLOW_INTERVAL = 60   # min seconds between follow (VIP rewrite) events -- damps flap/spoof storms
 FOLLOW_RETRY_DEADLINE = 120  # re-drive follow_update if we are not restarted within this after firing
@@ -146,6 +147,15 @@ LOG_BACKUPS = 3
 # shorter constructions stay valid.
 DhcpReply = namedtuple("DhcpReply", "mtype yiaddr server_id lease t1 t2 router message subnet_mask giaddr",
                        defaults=(None, None, None))
+
+# Changed-address phase labels: which exchange saw the differing ACK. Log
+# text and policy input at once -- FollowPolicy relaxes its expected-server
+# check on PHASE_REBIND (at T2 any server may legitimately answer).
+PHASE_DORA = "DORA"
+PHASE_REBOOT = "REBOOT"
+PHASE_RENEW = "RENEW"
+PHASE_REBIND = "REBIND"
+PHASE_OBSERVED = "OBSERVED"
 
 # DHCP message-type names (option 53), for readable reply logging.
 MTYPE_NAMES = {1: "DISCOVER", 2: "OFFER", 3: "REQUEST", 4: "DECLINE",
@@ -266,6 +276,12 @@ def _fs_safe(s):
     return re.sub(r"[^A-Za-z0-9]", "_", s or "")
 
 
+def _new_xid():
+    """A fresh random transaction id (nonzero 32-bit, regenerated per exchange
+    so stale replies cannot match)."""
+    return random.randint(1, 0xFFFFFFFF)
+
+
 def _jittered(base):
     """A retransmit/backoff delay with +/-25% uniform jitter (RFC 2131 4.1
     recommends a randomized backoff). Both HA nodes share the chaddr, so
@@ -321,7 +337,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         self._ensure_sniffer = ensure_sniffer
         self._on_changed = on_changed_address
 
-        self.xid = random.randint(1, 0xFFFFFFFF)
+        self.xid = _new_xid()
         self.yiaddr = None
         self.server = None
         self.lease = DEFAULT_LEASE
@@ -426,7 +442,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         (DISCOVER until an OFFER arrives) then the REQUESTING phase (REQUEST
         the offer until the ACK lands). Returns True once BOUND, False on
         failure/NAK."""
-        self.xid = random.randint(1, 0xFFFFFFFF)
+        self.xid = _new_xid()
         return self._discover(request_ip) and self._request_offer(request_ip)
 
     def _discover(self, request_ip):
@@ -478,7 +494,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             if rx:
                 got = rx.yiaddr
                 if request_ip and got != request_ip:
-                    return self._on_changed(got, rx, "DORA", True)
+                    return self._on_changed(got, rx, PHASE_DORA, True)
                 self.adopt(rx)
                 return True
             LOG.info("no DHCP ACK from %s for %s (attempt %d, xid 0x%08x)",
@@ -504,7 +520,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         if not request_ip:
             return False
 
-        self.xid = random.randint(1, 0xFFFFFFFF)
+        self.xid = _new_xid()
         extra = [("requested_addr", request_ip)]
         for attempt in range(1, REBOOT_ATTEMPTS + 1):
             if self._should_stop():
@@ -523,7 +539,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             if rx:
                 got = rx.yiaddr
                 if got and got != request_ip:
-                    return self._on_changed(got, rx, "REBOOT", True)
+                    return self._on_changed(got, rx, PHASE_REBOOT, True)
                 self.yiaddr, self.server = request_ip, rx.server_id
                 self._absorb_reply(rx, DEFAULT_LEASE)
                 return True
@@ -560,7 +576,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             try:
                 self._send_dhcp("request", opts, ciaddr=yiaddr)
             except Exception as e:
-                LOG.error("DHCP %s send failed: %s", "REBIND" if rebind else "RENEW", e)
+                LOG.error("DHCP %s send failed: %s", PHASE_REBIND if rebind else PHASE_RENEW, e)
                 return False
             rx = self._wait_for_dhcp_reply(ACK, RENEW_TIMEOUT)
             if rx == "NAK":
@@ -571,7 +587,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                     # Some dynamic servers change the address at renewal (ACK with a
                     # new yiaddr) instead of NAKing. Route it through the same
                     # follow / enforce decision (and hardening) as the initial DORA.
-                    phase = "REBIND" if rebind else "RENEW"
+                    phase = PHASE_REBIND if rebind else PHASE_RENEW
                     return self._on_changed(got, rx, phase, False)
                 self._absorb_reply(rx, self.lease)
                 return True
@@ -774,7 +790,7 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
                           "(possible spoofed ACK from %s)", phase, self.target, got,
                           rx.server_id)
                 return False
-            if phase != "REBIND" and rx.server_id and self._dhcp.server and rx.server_id != self._dhcp.server:
+            if phase != PHASE_REBIND and rx.server_id and self._dhcp.server and rx.server_id != self._dhcp.server:
                 LOG.error("%s: ACK from unexpected server %s (leased from %s) -- not following",
                           phase, rx.server_id, self._dhcp.server)
                 return False
@@ -887,7 +903,7 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
             return
         LOG.info("observed peer DHCP ACK for %s (we hold %s) -- following early to converge",
                  rx.yiaddr, self._dhcp.yiaddr)
-        self.on_changed_address(rx.yiaddr, rx, "OBSERVED", release_on_enforce=False)
+        self.on_changed_address(rx.yiaddr, rx, PHASE_OBSERVED, release_on_enforce=False)
 
 
 class Keeper:  # pylint: disable=too-many-instance-attributes
@@ -1291,7 +1307,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         ethsrc = f" eth-src={self.eth_src}" if self.eth_src != self.chaddr else ""
         LOG.info("lease-keeper active on %s: chaddr=%s%s request=%s",
                  self.iface, self.chaddr, ethsrc, self._follow.target or "any")
-        time.sleep(0.5)
+        time.sleep(SNIFFER_WARMUP)
 
         while not self._stop:
             # The keeper must NEVER die on a bad DHCP state: catch any unexpected
@@ -1465,7 +1481,7 @@ def _claim_once(k):
     """--once mode: claim, report, release -- a wiring test, not service mode."""
     if not k._start_sniffer():
         return 3
-    time.sleep(0.5)
+    time.sleep(SNIFFER_WARMUP)
     ok = k._dhcp.dora(k._follow.target)
     LOG.info("DHCP claim %s -> %s", k.chaddr, k._dhcp.yiaddr if ok else "FAIL")
     if ok:

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -48,6 +48,11 @@ Usage:
   lease_keeper.py --iface <if> --chaddr <mac> --request <ip>
   lease_keeper.py ... --once            # one-shot claim+verify+release (test)
 """
+# The daemon must never die on unexpected input: catch-all with logging is
+# the documented posture (see "All I/O wrapped in try/except" above).
+# pylint: disable=broad-exception-caught
+# A single deployable file is a deliberate constraint of this daemon.
+# pylint: disable=too-many-lines
 import argparse
 import ipaddress
 import logging
@@ -282,7 +287,7 @@ def _clock_at(offset):
     return time.strftime("%H:%M", time.localtime(time.time() + offset))
 
 
-class DhcpClient:
+class DhcpClient:  # pylint: disable=too-many-instance-attributes
     """RFC 2131 client for one chaddr: owns the lease state (yiaddr, server,
     lease/T1/T2, router, mask) and the stateful protocol sequences
     (INIT-REBOOT / DORA / RENEW / REBIND / RELEASE) with their send/await
@@ -293,7 +298,7 @@ class DhcpClient:
     release_on_enforce) -> bool for an ACK whose address differs from the
     expected one (True = the caller validated and adopted it, see adopt())."""
 
-    def __init__(self, iface, chaddr, eth_src, id_opts,
+    def __init__(self, iface, chaddr, eth_src, id_opts,  # pylint: disable=R0913,R0917
                  should_stop, ensure_sniffer, on_changed_address):
         self.iface = iface
         self.chaddr = chaddr
@@ -403,7 +408,7 @@ class DhcpClient:
 
         return self.dora(request_ip)
 
-    def dora(self, request_ip=None):
+    def dora(self, request_ip=None):  # pylint: disable=too-many-return-statements
         """Acquire a lease via the DHCP DORA handshake -- Discover, Offer,
         Request, Ack. Returns True once BOUND, False on failure/NAK."""
         self.xid = random.randint(1, 0xFFFFFFFF)
@@ -461,7 +466,7 @@ class DhcpClient:
             time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
         return False
 
-    def reboot(self, request_ip):
+    def reboot(self, request_ip):  # pylint: disable=too-many-return-statements
         """INIT-REBOOT (RFC 2131 4.3.2): we already know the address we want
         (request_ip), so REQUEST it directly instead of a full DISCOVER -- one
         exchange, and a server that is reachable but refuses the address answers
@@ -501,7 +506,7 @@ class DhcpClient:
                 time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
         return False
 
-    def renew(self, rebind=False):
+    def renew(self, rebind=False):  # pylint: disable=too-many-return-statements
         """REQUEST an extension of the held lease. Returns True on a fresh ACK,
         False on NAK/timeout/unbound (the caller escalates: RENEW -> REBIND ->
         re-acquire)."""
@@ -583,7 +588,7 @@ class DhcpClient:
         return t1, t2, src
 
 
-class ArpNudge:
+class ArpNudge:  # pylint: disable=too-many-instance-attributes
     """Keep the upstream gateway's ARP entry for the leased address fresh, for
     gateways that ignore gratuitous ARP and never re-ARP an expired entry (see
     the README's "ARP nudge" section). Owns the nudge pacing and the gateway
@@ -673,14 +678,14 @@ class ArpNudge:
             LOG.debug("ARP reply parse error: %s", e)
 
 
-class Keeper:
+class Keeper:  # pylint: disable=too-many-instance-attributes,too-few-public-methods
     """Policy and orchestration around the components: owns the packet sniffer
     (feeding DHCP replies to DhcpClient and ARP replies to ArpNudge), the
     follow/enforce decision for a changed address, the heartbeat, the CARP
     role watch, the acquire pacing (backoff + link-return fast path) and the
     signal-driven operator actions. The lease itself lives in DhcpClient."""
 
-    def __init__(self, iface, chaddr, request_ip=None, eth_src=None,
+    def __init__(self, iface, chaddr, request_ip=None, eth_src=None,  # pylint: disable=R0913,R0917
                  hbfile=None, release_on_exit=False, vhid=None,
                  follow=False, vendor_class=None, client_id=None, hostname=None,
                  arp_nudge=0, arp_listen_promisc=False):
@@ -1219,7 +1224,7 @@ class Keeper:
         LOG.info("stopped")
         return 0
 
-    def _run_once(self):
+    def _run_once(self):  # pylint: disable=too-many-branches,too-many-statements
         """One iteration of the maintain loop. Returns to run() (which loops again)
         on every state transition; any exception it raises is caught by run() and
         retried, so a transient fault can never terminate the keeper."""
@@ -1323,7 +1328,7 @@ def acquire_pidfile(path):
 
 # main() drives the Keeper internals directly (signal flags, the --once path).
 # pylint: disable=protected-access
-def main():
+def main():  # pylint: disable=too-many-branches,too-many-statements
     """CLI entry point: parse args, wire up the Keeper and signals, run."""
     ap = argparse.ArgumentParser(description="Robust DHCP lease-keeper (chaddr decoupled from the iface MAC)")
     ap.add_argument("--iface", required=True)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -694,12 +694,194 @@ class ArpNudge:  # pylint: disable=too-many-instance-attributes
             LOG.debug("ARP reply parse error: %s", e)
 
 
+class FollowPolicy:  # pylint: disable=too-many-instance-attributes
+    """Decides what happens when the server grants a DIFFERENT address than
+    the target this keeper exists to hold. In follow mode: validate the new
+    address (plausibility, routability class, expected server), throttle
+    against flap/spoof storms, drive the configd VIP rewrite and adopt it
+    into the DHCP client. Otherwise (enforce, a fixed reservation): alarm,
+    release the refused grant and stay unbound. Owns the target address
+    (rewritten on a successful follow), the persisted follow throttle, the
+    apply-retry watchdog and the peer-ACK observation handoff."""
+
+    def __init__(self, target, follow, chaddr, dhcp, hb_mismatch):
+        self.target = target           # the address this keeper is meant to hold
+        self.follow = follow
+        self._dhcp = dhcp
+        self._hb_mismatch = hb_mismatch
+        self._followed_ip = None       # last address we asked configd to follow to
+        self._follow_from = None       # address we followed FROM (for the retry watchdog)
+        self._fired_at = 0.0           # when we last dispatched follow_update (retry deadline)
+        self._gw_args = []             # extra follow_update args on a cross-subnet move: [old_gw, new_gw, bits]
+        # Throttle state, keyed by chaddr so it survives the follow-induced
+        # restart (the target-keyed runtime paths change on every follow).
+        self._state_file = f"/var/run/carpvipdhcp-follow-{_fs_safe(chaddr)}"
+        # A changed ISP address first seen in the PEER's ACK (both HA nodes run
+        # an identical keeper on the same shared chaddr). The sniffer thread
+        # records it via observe() -- a lone atomic ref-assign -- and the main
+        # thread consumes it in check_observed().
+        self._observed = None
+
+    def _last_follow_time(self):
+        """Epoch of this chaddr's last follow (persisted so the throttle survives
+        the follow-induced restart). 0 if never / unreadable."""
+        try:
+            with open(self._state_file, encoding="utf-8") as f:
+                return float(f.read().strip())
+        except (OSError, ValueError):
+            return 0.0
+
+    def _record_follow(self):
+        try:
+            tmp = self._state_file + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                f.write(str(int(time.time())))
+            os.replace(tmp, self._state_file)
+        except OSError as e:
+            LOG.warning("could not persist follow timestamp: %s", e)
+
+    def on_changed_address(self, got, rx, phase, release_on_enforce):
+        """An ACK arrived whose address differs from the one we hold/request.
+
+        In follow mode: validate the address (sane, same routability class, from
+        the expected server), throttle against flap/spoof storms, then adopt it
+        (rewrite the CARP VIP). Otherwise (enforce): alarm on the mismatch.
+        Returns True if we are now bound to `got`, False if the caller should
+        re-acquire.
+        """
+        if self.follow:
+            if not _sane_ipv4(got):
+                LOG.error("%s: ACK yiaddr %r from server %s implausible -- not following",
+                          phase, got, rx.server_id)
+                return False
+            if not _same_ip_class(self.target, got):
+                LOG.error("%s: refusing to follow %s -> %s across address class "
+                          "(possible spoofed ACK from %s)", phase, self.target, got,
+                          rx.server_id)
+                return False
+            if phase != "REBIND" and rx.server_id and self._dhcp.server and rx.server_id != self._dhcp.server:
+                LOG.error("%s: ACK from unexpected server %s (leased from %s) -- not following",
+                          phase, rx.server_id, self._dhcp.server)
+                return False
+
+            waited = time.time() - self._last_follow_time()
+            if waited < MIN_FOLLOW_INTERVAL:
+                LOG.warning("%s: follow %s -> %s throttled (%.0fs < %ds) -- deferring",
+                            phase, self.target, got, waited, MIN_FOLLOW_INTERVAL)
+                return False
+
+            LOG.warning("ISP gave %s (VIP was %s) at %s -- following: updating the CARP VIP",
+                        got, self.target, phase)
+            # If the ISP also moved the gateway (a cross-subnet renumber), follow the
+            # new gateway + prefix too so outbound keeps working -- parity with what a
+            # plain DHCP interface does. Needs the new subnet mask (opt 1) to set the
+            # VIP prefix; without it we can only move the address, so warn instead.
+            self._gw_args = []
+            old_router = self._dhcp.router
+            if rx.router and old_router and rx.router != old_router:
+                bits = _mask_to_bits(rx.subnet_mask)
+                if bits:
+                    LOG.warning("follow %s -> %s also moves the gateway (%s -> %s), subnet "
+                                "/%d -- following across the subnet", self.target, got,
+                                old_router, rx.router, bits)
+                    self._gw_args = [old_router, rx.router, str(bits)]
+                else:
+                    LOG.error("follow %s -> %s changes the gateway (%s -> %s) but the ACK "
+                              "carried no subnet mask -- updating the VIP address only; fix the "
+                              "interface prefix + System->Gateways by hand", self.target,
+                              got, old_router, rx.router)
+
+            self._record_follow()
+            # _follow_update reads target as the old address, so remember it
+            # (for the retry watchdog) and fire before overwriting target.
+            self._follow_from = self.target
+            self._follow_update(got)
+            self.target = got
+            self._dhcp.adopt(rx)
+            return True
+        # Enforce: a fixed reservation must always return the target.
+        LOG.error("%s: IP mismatch -- server %s gave %s, requested %s (reservation problem?)",
+                  phase, rx.server_id, got, self.target)
+        self._hb_mismatch(got, self.target)
+        if release_on_enforce:
+            self._dhcp.release(got, rx.server_id)
+            # DORA's OFFER phase already recorded a tentative yiaddr; drop it so
+            # the run loop re-acquires instead of renewing the refused grant.
+            self._dhcp.expire()
+        return False
+
+    def _follow_update(self, new_ip):
+        """Ask configd to rewrite the CARP VIP (and this keeper's reference) from
+        the target to new_ip, then reconfigure. Fire-and-forget: the resulting
+        service restart replaces this daemon with one bound to the new address."""
+        if new_ip == self._followed_ip:
+            return   # already asked for this address
+        try:
+            self._fire_follow_update(self.target, new_ip)
+            # Only mark as handled once the request was actually dispatched, so a
+            # spawn failure is retried next cycle instead of getting stuck.
+            self._followed_ip = new_ip
+            LOG.info("requested CARP VIP update %s -> %s", self.target, new_ip)
+        except Exception as e:
+            LOG.error("follow_update request failed: %s", e)
+
+    def _fire_follow_update(self, old_ip, new_ip):
+        """Dispatch the configd follow_update action (old -> new) and stamp the
+        retry deadline. Separate from _follow_update so the watchdog can re-drive
+        a stalled follow without tripping the _followed_ip equality guard."""
+        cmd = ["/usr/local/sbin/configctl", "-d", "carpvipdhcp", "follow_update", old_ip, new_ip]
+        cmd += self._gw_args   # cross-subnet: [old_gw, new_gw, bits]; empty on a same-subnet move
+        subprocess.Popen(cmd)  # pylint: disable=consider-using-with
+        self._fired_at = time.time()
+
+    def watchdog(self):
+        """Re-drive a follow that never took effect. After a successful follow,
+        follow_update restarts this daemon within a few seconds; if we are still
+        alive well past FOLLOW_RETRY_DEADLINE, its apply failed or stalled, so
+        re-dispatch it (idempotent: it reconverges whether the config already
+        moved or not, and its rc.d restart <old-id> eventually replaces us)."""
+        if not (self.follow and self._followed_ip and self._follow_from):
+            return
+        if time.time() - self._fired_at < FOLLOW_RETRY_DEADLINE:
+            return
+        LOG.warning("follow %s -> %s not applied within %ds -- re-driving",
+                    self._follow_from, self._followed_ip, FOLLOW_RETRY_DEADLINE)
+        try:
+            self._fire_follow_update(self._follow_from, self._followed_ip)
+        except Exception as e:
+            LOG.error("follow_update retry failed: %s", e)
+
+    def observe(self, rx):
+        """Record a peer-ACK observation (sniffer thread; a lone ref-assign);
+        the main loop consumes it in check_observed()."""
+        self._observed = rx
+
+    def check_observed(self):
+        """Adopt an address change first seen in the PEER's DHCP ACK (same shared
+        chaddr) without waiting for our own renewal timer. The sniffer only
+        records the observation; the follow itself runs here on the main thread,
+        through the same hardening/throttle as a first-party ACK. This collapses
+        the follow window that would otherwise leave the two nodes on different
+        VIP prefixes long enough for the backup to promote (transient
+        dual-master; see docs/single-ip-wan-carp.md section 3)."""
+        rx = self._observed
+        if rx is None:
+            return
+        self._observed = None
+        if not self.follow or not rx.yiaddr or rx.yiaddr == self._dhcp.yiaddr:
+            return
+        LOG.info("observed peer DHCP ACK for %s (we hold %s) -- following early to converge",
+                 rx.yiaddr, self._dhcp.yiaddr)
+        self.on_changed_address(rx.yiaddr, rx, "OBSERVED", release_on_enforce=False)
+
+
 class Keeper:  # pylint: disable=too-many-instance-attributes
-    """Policy and orchestration around the components: owns the packet sniffer
-    (feeding DHCP replies to DhcpClient and ARP replies to ArpNudge), the
-    follow/enforce decision for a changed address, the heartbeat, the CARP
-    role watch, the acquire pacing (backoff + link-return fast path) and the
-    signal-driven operator actions. The lease itself lives in DhcpClient."""
+    """Orchestration around the components: owns the packet sniffer (feeding
+    DHCP replies to DhcpClient, ARP replies to ArpNudge and peer-ACK
+    observations to FollowPolicy), the heartbeat, the CARP role watch, the
+    acquire pacing (backoff + link-return fast path) and the signal-driven
+    operator actions. The lease lives in DhcpClient; the changed-address
+    decision and the target address live in FollowPolicy."""
 
     def __init__(self, iface, chaddr, request_ip=None, eth_src=None,  # pylint: disable=R0913,R0917
                  hbfile=None, release_on_exit=False, vhid=None,
@@ -707,12 +889,10 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                  arp_nudge=0, arp_listen_promisc=False):
         self.iface = iface
         self.chaddr = chaddr.lower()
-        self.request_ip = request_ip
         self.eth_src = (eth_src or chaddr).lower()
         self.hbfile = hbfile
         self.release_on_exit = release_on_exit
         self.vhid = str(vhid) if vhid else None
-        self.follow = follow
         # ARP nudge component: owns the pacing and reachability state; the
         # keeper supplies the lease binding per nudge (_arp_nudge) and the
         # CARP-role probe (late-bound so tests can stub _probe_carp_master).
@@ -746,14 +926,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             iface, self.chaddr, self.eth_src, id_opts,
             should_stop=lambda: self.stop,
             ensure_sniffer=lambda: self._ensure_sniffer(),  # pylint: disable=unnecessary-lambda
-            on_changed_address=self._handle_changed_address)
-        self._followed_ip = None       # last address we asked configd to follow to
-        self._follow_from = None       # address we followed FROM (for the retry watchdog)
-        self._follow_fired_at = 0.0    # when we last dispatched follow_update (retry deadline)
-        self._follow_gw_args = []      # extra follow_update args on a cross-subnet move: [old_gw, new_gw, bits]
-        # Follow throttle state, keyed by chaddr so it survives the follow-induced
-        # restart (the request-IP-keyed runtime paths change on every follow).
-        self._follow_state = f"/var/run/carpvipdhcp-follow-{_fs_safe(self.chaddr)}"
+            on_changed_address=self._on_changed_address)
+        # Follow/enforce policy component: owns the target address and the
+        # follow bookkeeping; drives the client via adopt()/release()/expire().
+        self._follow = FollowPolicy(request_ip, follow, self.chaddr, self._dhcp,
+                                    self._hb_mismatch)
         self.redora_wait = REDORA_MIN
         # Link-return fast path (only while UNBOUND): a carrier down->up edge resets
         # the backoff and re-DORAs at once, like dhclient's link-up -> state_reboot.
@@ -761,11 +938,6 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._link_kick_at = 0.0       # epoch of the last link-return kick (debounce)
         self._link_returned = False    # set by _sleep_interruptible on a carrier return while unbound
         self.stop = False
-        # Follow mode: a changed ISP address first seen in the PEER's ACK (both
-        # HA nodes run an identical keeper on the same shared chaddr). The sniffer
-        # writes it (a lone atomic ref-assign); the main thread consumes it and
-        # drives the hardened follow -- see _on_dhcp_reply / _check_observed_follow.
-        self._observed_change = None
         # General early-wake for the maintain-loop sleep (_sleep_interruptible): lets it
         # return before the 1s tick when there is pending work. Currently the
         # sniffer sets it on an observed address change so the follow fires in
@@ -851,12 +1023,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             # thread -- which routes it through the same follow hardening
             # (sane / same-class / expected-server / throttle) as a first-party
             # ACK and never acts on the sniffer thread.
-            if not self.follow or not self._dhcp.yiaddr or not self._chaddr_matches(b):
+            if not self._follow.follow or not self._dhcp.yiaddr or not self._chaddr_matches(b):
                 return
             rx = _parse_reply(p, b.yiaddr)
             if (rx.mtype == ACK and rx.yiaddr and rx.yiaddr != self._dhcp.yiaddr
                     and _sane_ipv4(rx.yiaddr)):
-                self._observed_change = rx
+                self._follow.observe(rx)
                 self._wake.set()   # wake the maintain-loop sleep now, don't wait for the tick
         except Exception as e:
             LOG.debug("DHCP reply parse error: %s", e)
@@ -890,158 +1062,14 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._write_hb(f"{int(time.time())} bound={self._dhcp.yiaddr or '-'} "
                        f"lease={self._dhcp.lease} t1={t1} t2={t2} src={src}{extra}\n")
 
-    def _hb_mismatch(self, got):
+    def _hb_mismatch(self, got, want):
         # Write a clear marker into the heartbeat file so a supervisor/human sees the mismatch.
-        self._write_hb(f"{int(time.time())} MISMATCH got={got} want={self.request_ip}\n")
+        self._write_hb(f"{int(time.time())} MISMATCH got={got} want={want}\n")
 
-    # ---- follow mode (adopt a changed ISP address, with spoof hardening) ----
-
-    def _last_follow_time(self):
-        """Epoch of this chaddr's last follow (persisted so the throttle survives
-        the follow-induced restart). 0 if never / unreadable."""
-        try:
-            with open(self._follow_state, encoding="utf-8") as f:
-                return float(f.read().strip())
-        except (OSError, ValueError):
-            return 0.0
-
-    def _record_follow(self):
-        try:
-            tmp = self._follow_state + ".tmp"
-            with open(tmp, "w", encoding="utf-8") as f:
-                f.write(str(int(time.time())))
-            os.replace(tmp, self._follow_state)
-        except OSError as e:
-            LOG.warning("could not persist follow timestamp: %s", e)
-
-    def _handle_changed_address(self, got, rx, phase, release_on_enforce):
-        """An ACK arrived whose address differs from the one we hold/request.
-
-        In follow mode: validate the address (sane, same routability class, from
-        the expected server), throttle against flap/spoof storms, then adopt it
-        (rewrite the CARP VIP). Otherwise (enforce): alarm on the mismatch.
-        Returns True if we are now bound to `got`, False if the caller should
-        re-acquire.
-        """
-        if self.follow:
-            if not _sane_ipv4(got):
-                LOG.error("%s: ACK yiaddr %r from server %s implausible -- not following",
-                          phase, got, rx.server_id)
-                return False
-            if not _same_ip_class(self.request_ip, got):
-                LOG.error("%s: refusing to follow %s -> %s across address class "
-                          "(possible spoofed ACK from %s)", phase, self.request_ip, got,
-                          rx.server_id)
-                return False
-            if phase != "REBIND" and rx.server_id and self._dhcp.server and rx.server_id != self._dhcp.server:
-                LOG.error("%s: ACK from unexpected server %s (leased from %s) -- not following",
-                          phase, rx.server_id, self._dhcp.server)
-                return False
-
-            waited = time.time() - self._last_follow_time()
-            if waited < MIN_FOLLOW_INTERVAL:
-                LOG.warning("%s: follow %s -> %s throttled (%.0fs < %ds) -- deferring",
-                            phase, self.request_ip, got, waited, MIN_FOLLOW_INTERVAL)
-                return False
-
-            LOG.warning("ISP gave %s (VIP was %s) at %s -- following: updating the CARP VIP",
-                        got, self.request_ip, phase)
-            # If the ISP also moved the gateway (a cross-subnet renumber), follow the
-            # new gateway + prefix too so outbound keeps working -- parity with what a
-            # plain DHCP interface does. Needs the new subnet mask (opt 1) to set the
-            # VIP prefix; without it we can only move the address, so warn instead.
-            self._follow_gw_args = []
-            old_router = self._dhcp.router
-            if rx.router and old_router and rx.router != old_router:
-                bits = _mask_to_bits(rx.subnet_mask)
-                if bits:
-                    LOG.warning("follow %s -> %s also moves the gateway (%s -> %s), subnet "
-                                "/%d -- following across the subnet", self.request_ip, got,
-                                old_router, rx.router, bits)
-                    self._follow_gw_args = [old_router, rx.router, str(bits)]
-                else:
-                    LOG.error("follow %s -> %s changes the gateway (%s -> %s) but the ACK "
-                              "carried no subnet mask -- updating the VIP address only; fix the "
-                              "interface prefix + System->Gateways by hand", self.request_ip,
-                              got, old_router, rx.router)
-
-            self._record_follow()
-            # _follow_update reads request_ip as the old address, so remember it
-            # (for the retry watchdog) and fire before overwriting request_ip.
-            self._follow_from = self.request_ip
-            self._follow_update(got)
-            self.request_ip = got
-            self._dhcp.adopt(rx)
-            return True
-        # Enforce: a fixed reservation must always return request_ip.
-        LOG.error("%s: IP mismatch -- server %s gave %s, requested %s (reservation problem?)",
-                  phase, rx.server_id, got, self.request_ip)
-        self._hb_mismatch(got)
-        if release_on_enforce:
-            self._dhcp.release(got, rx.server_id)
-            # DORA's OFFER phase already recorded a tentative yiaddr; drop it so
-            # the run loop re-acquires instead of renewing the refused grant.
-            self._dhcp.expire()
-        return False
-
-    def _follow_update(self, new_ip):
-        """Ask configd to rewrite the CARP VIP (and this keeper's reference) from
-        request_ip to new_ip, then reconfigure. Fire-and-forget: the resulting
-        service restart replaces this daemon with one bound to the new address."""
-        if new_ip == self._followed_ip:
-            return   # already asked for this address
-        try:
-            self._fire_follow_update(self.request_ip, new_ip)
-            # Only mark as handled once the request was actually dispatched, so a
-            # spawn failure is retried next cycle instead of getting stuck.
-            self._followed_ip = new_ip
-            LOG.info("requested CARP VIP update %s -> %s", self.request_ip, new_ip)
-        except Exception as e:
-            LOG.error("follow_update request failed: %s", e)
-
-    def _fire_follow_update(self, old_ip, new_ip):
-        """Dispatch the configd follow_update action (old -> new) and stamp the
-        retry deadline. Separate from _follow_update so the watchdog can re-drive
-        a stalled follow without tripping the _followed_ip equality guard."""
-        cmd = ["/usr/local/sbin/configctl", "-d", "carpvipdhcp", "follow_update", old_ip, new_ip]
-        cmd += self._follow_gw_args   # cross-subnet: [old_gw, new_gw, bits]; empty on a same-subnet move
-        subprocess.Popen(cmd)  # pylint: disable=consider-using-with
-        self._follow_fired_at = time.time()
-
-    def _follow_watchdog(self):
-        """Re-drive a follow that never took effect. After a successful follow,
-        follow_update restarts this daemon within a few seconds; if we are still
-        alive well past FOLLOW_RETRY_DEADLINE, its apply failed or stalled, so
-        re-dispatch it (idempotent: it reconverges whether the config already
-        moved or not, and its rc.d restart <old-id> eventually replaces us)."""
-        if not (self.follow and self._followed_ip and self._follow_from):
-            return
-        if time.time() - self._follow_fired_at < FOLLOW_RETRY_DEADLINE:
-            return
-        LOG.warning("follow %s -> %s not applied within %ds -- re-driving",
-                    self._follow_from, self._followed_ip, FOLLOW_RETRY_DEADLINE)
-        try:
-            self._fire_follow_update(self._follow_from, self._followed_ip)
-        except Exception as e:
-            LOG.error("follow_update retry failed: %s", e)
-
-    def _check_observed_follow(self):
-        """Adopt an address change first seen in the PEER's DHCP ACK (same shared
-        chaddr) without waiting for our own renewal timer. The sniffer only
-        records the observation; the follow itself runs here on the main thread,
-        through the same hardening/throttle as a first-party ACK. This collapses
-        the follow window that would otherwise leave the two nodes on different
-        VIP prefixes long enough for the backup to promote (transient
-        dual-master; see docs/single-ip-wan-carp.md section 3)."""
-        rx = self._observed_change
-        if rx is None:
-            return
-        self._observed_change = None
-        if not self.follow or not rx.yiaddr or rx.yiaddr == self._dhcp.yiaddr:
-            return
-        LOG.info("observed peer DHCP ACK for %s (we hold %s) -- following early to converge",
-                 rx.yiaddr, self._dhcp.yiaddr)
-        self._handle_changed_address(rx.yiaddr, rx, "OBSERVED", release_on_enforce=False)
+    def _on_changed_address(self, got, rx, phase, release_on_enforce):
+        """DhcpClient's changed-address hook -> the FollowPolicy decision
+        (late-bound through the attribute so tests can stub the policy)."""
+        return self._follow.on_changed_address(got, rx, phase, release_on_enforce)
 
     # ---- CARP role (master probe, transitions) ----
 
@@ -1180,10 +1208,9 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 LOG.info("manual ARP nudge requested (SIGUSR1)")
                 self._arp_nudge(force=True)
                 self._hb()   # publish the new nudge age right away for the status page
-            if self._observed_change is not None:
-                # A peer-ACK observation is pending -> follow now (rationale +
-                # the dual-master window it closes are in _check_observed_follow).
-                self._check_observed_follow()
+            # A pending peer-ACK observation follows now (rationale + the
+            # dual-master window it closes: FollowPolicy.check_observed).
+            self._follow.check_observed()
             # Link-return fast path: only while UNBOUND, poll carrier every few
             # seconds; a down->up edge means the WAN just came back, so stop waiting
             # and let _maintain_step re-DORA immediately (the bound path skips this).
@@ -1214,7 +1241,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 return False
             remaining -= chunk
             self._hb()
-            self._follow_watchdog()   # re-drive a follow whose apply stalled
+            self._follow.watchdog()   # re-drive a follow whose apply stalled
             self._poll_carp_role()    # backup->master? renew early + nudge now
             self._arp_nudge()
         return not self.stop
@@ -1230,7 +1257,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # eth-src matters for L2 debugging but only when it differs from the chaddr.
         ethsrc = f" eth-src={self.eth_src}" if self.eth_src != self.chaddr else ""
         LOG.info("lease-keeper active on %s: chaddr=%s%s request=%s",
-                 self.iface, self.chaddr, ethsrc, self.request_ip or "any")
+                 self.iface, self.chaddr, ethsrc, self._follow.target or "any")
         time.sleep(0.5)
         while not self.stop:
             # The keeper must NEVER die on a bad DHCP state: catch any unexpected
@@ -1264,7 +1291,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         if not self._dhcp.yiaddr:
             self._ensure_sniffer()  # a dead sniffer would silently fail every DORA
             self._hb()  # active but not holding yet -> publish bound=-
-            if self._dhcp.acquire(self.request_ip):
+            if self._dhcp.acquire(self._follow.target):
                 LOG.info("DHCP BOUND %s (lease=%ss, expires ~%s, server=%s, gw=%s, mask=%s)",
                          self._dhcp.yiaddr, self._dhcp.lease, _clock_at(self._dhcp.lease),
                          self._dhcp.server, self._dhcp.router or "?",
@@ -1408,7 +1435,7 @@ def _claim_once(k):
     if not k._start_sniffer():
         return 3
     time.sleep(0.5)
-    ok = k._dhcp.dora(k.request_ip)
+    ok = k._dhcp.dora(k._follow.target)
     LOG.info("DHCP claim %s -> %s", k.chaddr, k._dhcp.yiaddr if ok else "FAIL")
     if ok:
         k._dhcp.release()

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -408,13 +408,18 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
 
         return self.dora(request_ip)
 
-    def dora(self, request_ip=None):  # pylint: disable=too-many-return-statements
-        """Acquire a lease via the DHCP DORA handshake -- Discover, Offer,
-        Request, Ack. Returns True once BOUND, False on failure/NAK."""
+    def dora(self, request_ip=None):
+        """Acquire a lease via the DHCP DORA handshake: the SELECTING phase
+        (DISCOVER until an OFFER arrives) then the REQUESTING phase (REQUEST
+        the offer until the ACK lands). Returns True once BOUND, False on
+        failure/NAK."""
         self.xid = random.randint(1, 0xFFFFFFFF)
-        extra = [("requested_addr", request_ip)] if request_ip else []
+        return self._discover(request_ip) and self._request_offer(request_ip)
 
-        # DISCOVER until an OFFER arrives (or the attempts run out).
+    def _discover(self, request_ip):
+        """SELECTING: broadcast DISCOVER until a server OFFERs; record the
+        offered address and server. False on NAK/timeout/stop."""
+        extra = [("requested_addr", request_ip)] if request_ip else []
         for attempt in range(1, DORA_ATTEMPTS + 1):
             if self._should_stop():
                 return False
@@ -431,14 +436,16 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                 return False
             if rx:
                 self.yiaddr, self.server = rx.yiaddr, rx.server_id
-                break
+                return True
             # xid included so the exchange can be matched against a packet capture.
             LOG.info("no DHCP OFFER (attempt %d, xid 0x%08x)", attempt, self.xid)
             time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
-        else:
-            return False
+        return False
 
-        # REQUEST the offered address until the ACK lands.
+    def _request_offer(self, request_ip):
+        """REQUESTING: REQUEST the offered address until the ACK lands and we
+        are BOUND. False on NAK/timeout/stop; an ACK for a different address
+        goes through the on_changed_address policy hook."""
         for attempt in range(1, DORA_ATTEMPTS + 1):
             if self._should_stop():
                 return False
@@ -466,7 +473,14 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
         return False
 
-    def reboot(self, request_ip):  # pylint: disable=too-many-return-statements
+    # reboot() and renew() share _request_offer's REQUEST->ACK shape: they are
+    # the RFC 2131 REBOOTING and RENEWING/REBINDING states next to REQUESTING.
+    # They stay separate linear loops on purpose -- the three differ on nine
+    # axes (options, ciaddr, attempts, timeout, backoff, send-failure policy,
+    # expected address, changed-address phase, bind action), so a shared
+    # parametrized engine would turn each into config that is harder to audit
+    # against the RFC than the plain loop it replaces.
+    def reboot(self, request_ip):
         """INIT-REBOOT (RFC 2131 4.3.2): we already know the address we want
         (request_ip), so REQUEST it directly instead of a full DISCOVER -- one
         exchange, and a server that is reachable but refuses the address answers
@@ -506,6 +520,8 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                 time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
         return False
 
+    # One return per protocol gate (unbound/stop/send-fail/NAK/changed/ok);
+    # folding them into an attempt-helper trades readable gates for plumbing.
     def renew(self, rebind=False):  # pylint: disable=too-many-return-statements
         """REQUEST an extension of the held lease. Returns True on a fresh ACK,
         False on NAK/timeout/unbound (the caller escalates: RENEW -> REBIND ->
@@ -678,7 +694,7 @@ class ArpNudge:  # pylint: disable=too-many-instance-attributes
             LOG.debug("ARP reply parse error: %s", e)
 
 
-class Keeper:  # pylint: disable=too-many-instance-attributes,too-few-public-methods
+class Keeper:  # pylint: disable=too-many-instance-attributes
     """Policy and orchestration around the components: owns the packet sniffer
     (feeding DHCP replies to DhcpClient and ARP replies to ArpNudge), the
     follow/enforce decision for a changed address, the heartbeat, the CARP
@@ -1119,6 +1135,22 @@ class Keeper:  # pylint: disable=too-many-instance-attributes,too-few-public-met
         ArpNudge component; it owns the pacing, the master gate and the send."""
         self._nudge.maybe_nudge(self._dhcp.yiaddr, self._nudge_target(), force=force)
 
+    # ---- operator/signal API (set flags only; the loops act within a second) ----
+
+    def request_stop(self):
+        """Ask the daemon to exit at the next loop tick (SIGINT/SIGTERM)."""
+        self.stop = True
+
+    def trigger_nudge(self):
+        """Request an immediate ARP nudge (SIGUSR1 / configd action). Flag
+        only: no network I/O happens in signal context."""
+        self._nudge_now = True
+
+    def recheck_carp_role(self):
+        """Re-check the CARP role within a second (SIGUSR2 from the CARP
+        syshook) instead of waiting for the next ~30s poll."""
+        self._poll_role_now = True
+
     # ---- main loop / sleeps ----
 
     def _sleep(self, secs):
@@ -1154,7 +1186,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes,too-few-public-met
                 self._check_observed_follow()
             # Link-return fast path: only while UNBOUND, poll carrier every few
             # seconds; a down->up edge means the WAN just came back, so stop waiting
-            # and let _run_once re-DORA immediately (the bound path skips this).
+            # and let _maintain_step re-DORA immediately (the bound path skips this).
             if self._dhcp.yiaddr is None and slept % LINK_POLL_STEP == 0 and self._check_link_returned():
                 self._link_returned = True
                 return not self.stop
@@ -1205,7 +1237,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes,too-few-public-met
             # error, keep the heartbeat fresh so CARP does not falsely demote us,
             # and retry after a short backoff.
             try:
-                self._run_once()
+                self._maintain_step()
             except Exception:
                 LOG.exception("unexpected error in main loop -- recovering")
                 try:
@@ -1224,7 +1256,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes,too-few-public-met
         LOG.info("stopped")
         return 0
 
-    def _run_once(self):  # pylint: disable=too-many-branches,too-many-statements
+    def _maintain_step(self):
         """One iteration of the maintain loop. Returns to run() (which loops again)
         on every state transition; any exception it raises is caught by run() and
         retried, so a transient fault can never terminate the keeper."""
@@ -1326,10 +1358,8 @@ def acquire_pidfile(path):
             sys.exit(5)
 
 
-# main() drives the Keeper internals directly (signal flags, the --once path).
-# pylint: disable=protected-access
-def main():  # pylint: disable=too-many-branches,too-many-statements
-    """CLI entry point: parse args, wire up the Keeper and signals, run."""
+def _build_arg_parser():
+    """The daemon's CLI."""
     ap = argparse.ArgumentParser(description="Robust DHCP lease-keeper (chaddr decoupled from the iface MAC)")
     ap.add_argument("--iface", required=True)
     ap.add_argument("--chaddr", required=True)
@@ -1353,20 +1383,47 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
                          "unicast MACs (default off; only needed if replies aren't seen)")
     ap.add_argument("--once", action="store_true")
     ap.add_argument("--release-on-exit", action="store_true")
-    a = ap.parse_args()
+    return ap
 
+
+def _setup_logging(logfile):
+    """stderr plus a rotating file. DEBUG is always written (routine detail
+    like the renew/rebind plan): the volume is low, the log page hides DEBUG
+    by default, and its filter reveals it -- so "turning up the log level"
+    needs no daemon restart."""
     handlers: list[logging.Handler] = [logging.StreamHandler()]
-    if a.logfile:
+    if logfile:
         try:
-            handlers.append(RotatingFileHandler(a.logfile, maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUPS))
+            handlers.append(RotatingFileHandler(logfile, maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUPS))
         except Exception:
             pass
-    # Write DEBUG too (routine detail like the renew/rebind plan). The volume is
-    # low here, and the log page defaults to hiding DEBUG -- selecting a lower
-    # level in its filter reveals it, so "turning up the log level" needs no
-    # daemon restart.
     logging.basicConfig(level=logging.DEBUG, handlers=handlers,
                         format="%(asctime)s %(levelname)s %(message)s")
+
+
+# The one-shot mode drives the Keeper/DhcpClient internals directly.
+# pylint: disable=protected-access
+def _claim_once(k):
+    """--once mode: claim, report, release -- a wiring test, not service mode."""
+    if not k._start_sniffer():
+        return 3
+    time.sleep(0.5)
+    ok = k._dhcp.dora(k.request_ip)
+    LOG.info("DHCP claim %s -> %s", k.chaddr, k._dhcp.yiaddr if ok else "FAIL")
+    if ok:
+        k._dhcp.release()
+    try:
+        if k._sniffer:
+            k._sniffer.stop()
+    except Exception:
+        pass
+    return 0 if ok else 1
+
+
+def main():
+    """CLI entry point: parse args, wire up the Keeper and signals, run."""
+    a = _build_arg_parser().parse_args()
+    _setup_logging(a.logfile)
 
     if _SCAPY_IMPORT_ERROR is not None:
         LOG.critical("cannot import scapy -- the lease keeper cannot run: %s. "
@@ -1392,37 +1449,22 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
 
     def _sig(*_):
         LOG.info("signal received -- stopping")
-        k.stop = True
+        k.request_stop()
     signal.signal(signal.SIGINT, _sig)
     signal.signal(signal.SIGTERM, _sig)
 
     def _sig_arp_nudge(*_):
         # Operator-requested immediate ARP nudge (configd action / kill -USR1).
-        # Only sets a flag; the sleep loops service it within a second, so no
-        # network I/O happens inside the signal handler itself.
-        k._nudge_now = True
+        k.trigger_nudge()
     signal.signal(signal.SIGUSR1, _sig_arp_nudge)  # type: ignore[attr-defined]  # pylint: disable=no-member
 
     def _sig_carp(*_):
-        # CARP transition (rc.syshook.d/carp/50-carpvipdhcp sends SIGUSR2). Only
-        # sets a flag; the sleep loop re-checks the CARP role within a second.
-        k._poll_role_now = True
+        # CARP transition (rc.syshook.d/carp/50-carpvipdhcp sends SIGUSR2).
+        k.recheck_carp_role()
     signal.signal(signal.SIGUSR2, _sig_carp)  # type: ignore[attr-defined]  # pylint: disable=no-member
 
     if a.once:
-        if not k._start_sniffer():
-            return 3
-        time.sleep(0.5)
-        ok = k._dhcp.dora(a.request)
-        LOG.info("DHCP claim %s -> %s", k.chaddr, k._dhcp.yiaddr if ok else "FAIL")
-        if ok:
-            k._dhcp.release()
-        try:
-            if k._sniffer:
-                k._sniffer.stop()
-        except Exception:
-            pass
-        return 0 if ok else 1
+        return _claim_once(k)
 
     pf = acquire_pidfile(a.pidfile)
     try:

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -45,8 +45,8 @@ the carrier's guards see consistent state. The README's "Playing nicely with
 ISP access-network security" section is the full map.
 
 Usage:
-  lease-keeper.py --iface <if> --chaddr <mac> --request <ip>
-  lease-keeper.py ... --once            # one-shot claim+verify+release (test)
+  lease_keeper.py --iface <if> --chaddr <mac> --request <ip>
+  lease_keeper.py ... --once            # one-shot claim+verify+release (test)
 """
 import argparse
 import ipaddress

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -65,6 +65,7 @@ import sys
 import threading
 import time
 from collections import namedtuple
+from dataclasses import dataclass
 from logging.handlers import RotatingFileHandler
 from typing import Any
 
@@ -312,9 +313,26 @@ def _clock_at(offset):
     return time.strftime("%H:%M", time.localtime(time.time() + offset))
 
 
+@dataclass
+class Lease:
+    """The held DHCP binding: address, granting server, timing, and the
+    routing facts (options 3/1) the Parameter Request List asks for. During
+    a DORA it briefly holds the unconfirmed OFFER candidate; otherwise it is
+    the held (or last-held) binding. yiaddr None = unbound; expire() clears
+    only yiaddr, so the other fields survive as hints (logging, the
+    ARP-nudge target) until the next bind."""
+    yiaddr: str | None = None
+    server: str | None = None
+    lease_secs: int = DEFAULT_LEASE
+    t1_server: int | None = None   # server-provided renewal time (DHCP opt 58)
+    t2_server: int | None = None   # server-provided rebinding time (DHCP opt 59)
+    router: str | None = None      # default gateway (DHCP opt 3, fallback: server)
+    mask_bits: int | None = None   # subnet prefix length from opt 1
+
+
 class DhcpClient:  # pylint: disable=too-many-instance-attributes
-    """RFC 2131 client for one chaddr: owns the lease state (yiaddr, server,
-    lease/T1/T2, router, mask) and the stateful protocol sequences
+    """RFC 2131 client for one chaddr: owns the held binding (a Lease)
+    and the stateful protocol sequences
     (INIT-REBOOT / DORA / RENEW / REBIND / RELEASE) with their send/await
     machinery. It does NOT own the packet capture: the sniffer owner hands
     xid-matched replies to feed(). Policy stays with the caller through three
@@ -338,13 +356,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         self._on_changed = on_changed_address
 
         self.xid = _new_xid()
-        self.yiaddr = None
-        self.server = None
-        self.lease = DEFAULT_LEASE
-        self.t1_server = None          # server-provided renewal time (DHCP opt 58)
-        self.t2_server = None          # server-provided rebinding time (DHCP opt 59)
-        self.router = None             # default gateway (DHCP opt 3, fallback: server_id)
-        self.mask_bits = None          # subnet prefix length from opt 1 (for logging + follow)
+        self.binding = Lease()         # the held (or last-held) DHCP binding
         self._tried_reboot = False     # the first acquire tries INIT-REBOOT before a full DISCOVER
 
         self._rx = None                # latest DhcpReply snapshot (set via feed(), sniffer thread)
@@ -396,10 +408,10 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         -- the one place that knows which DhcpReply fields carry lease state.
         gateway + mask are what the Parameter Request List asks for; keep them for
         logging + the cross-subnet follow decision."""
-        self.lease = rx.lease or default_lease
-        self.t1_server, self.t2_server = rx.t1, rx.t2
-        self.router = rx.router or self.router
-        self.mask_bits = _mask_to_bits(rx.subnet_mask) or self.mask_bits
+        self.binding.lease_secs = rx.lease or default_lease
+        self.binding.t1_server, self.binding.t2_server = rx.t1, rx.t2
+        self.binding.router = rx.router or self.binding.router
+        self.binding.mask_bits = _mask_to_bits(rx.subnet_mask) or self.binding.mask_bits
 
     def adopt(self, rx):
         """Bind to the address in rx: the ACK that completes a DORA, or a
@@ -407,8 +419,8 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         on_changed_address hook calls this, so the lease state stays owned here
         while the decision stays with the caller). The server refreshes from
         the ACK's server-id, keeping the previous one when the ACK has none."""
-        self.yiaddr = rx.yiaddr
-        self.server = rx.server_id or self.server
+        self.binding.yiaddr = rx.yiaddr
+        self.binding.server = rx.server_id or self.binding.server
         self._absorb_reply(rx, DEFAULT_LEASE)
 
     def expire(self):
@@ -416,7 +428,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         grant the policy refused to keep): yiaddr clears so the next cycle
         re-acquires via DISCOVER; server/router stay as hints for logging and
         the caller's nudge target."""
-        self.yiaddr = None
+        self.binding.yiaddr = None
 
     def acquire(self, request_ip):
         """Get a lease. The first acquire after (re)start tries INIT-REBOOT (a
@@ -464,7 +476,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             if rx == "NAK":
                 return False
             if rx:
-                self.yiaddr, self.server = rx.yiaddr, rx.server_id
+                self.binding.yiaddr, self.binding.server = rx.yiaddr, rx.server_id
                 return True
             # xid included so the exchange can be matched against a packet capture.
             LOG.info("no DHCP OFFER (attempt %d, xid 0x%08x)", attempt, self.xid)
@@ -482,7 +494,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             try:
                 self._send_dhcp(
                     "request",
-                    [("server_id", self.server), ("requested_addr", self.yiaddr)],
+                    [("server_id", self.binding.server), ("requested_addr", self.binding.yiaddr)],
                 )
             except Exception as e:
                 LOG.error("DHCP REQUEST send failed: %s", e)
@@ -498,7 +510,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                 self.adopt(rx)
                 return True
             LOG.info("no DHCP ACK from %s for %s (attempt %d, xid 0x%08x)",
-                     self.server, self.yiaddr, attempt, self.xid)
+                     self.binding.server, self.binding.yiaddr, attempt, self.xid)
             time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
         return False
 
@@ -540,8 +552,9 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                 got = rx.yiaddr
                 if got and got != request_ip:
                     return self._on_changed(got, rx, PHASE_REBOOT, True)
-                self.yiaddr, self.server = request_ip, rx.server_id
-                self._absorb_reply(rx, DEFAULT_LEASE)
+                self.adopt(rx)
+                if not self.binding.yiaddr:
+                    self.binding.yiaddr = request_ip   # ACK without yiaddr: we asked for it
                 return True
             LOG.info("no DHCP ACK to INIT-REBOOT for %s (attempt %d, xid 0x%08x)",
                      request_ip, attempt, self.xid)
@@ -563,7 +576,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         # (via the `phase` it sets) relaxes the expected-server check in the
         # caller's on_changed_address hook, since at T2 any server may
         # legitimately answer.
-        yiaddr = self.yiaddr
+        yiaddr = self.binding.yiaddr
         if not yiaddr:
             return False   # nothing bound -> nothing to renew
 
@@ -583,13 +596,13 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                 return False   # NAK -> re-DORA
             if rx:
                 got = rx.yiaddr
-                if got and got != self.yiaddr:
+                if got and got != self.binding.yiaddr:
                     # Some dynamic servers change the address at renewal (ACK with a
                     # new yiaddr) instead of NAKing. Route it through the same
                     # follow / enforce decision (and hardening) as the initial DORA.
                     phase = PHASE_REBIND if rebind else PHASE_RENEW
                     return self._on_changed(got, rx, phase, False)
-                self._absorb_reply(rx, self.lease)
+                self._absorb_reply(rx, self.binding.lease_secs)
                 return True
         return False
 
@@ -598,7 +611,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         (yiaddr, server) pair (the enforce path releases an address it was
         granted but refuses to keep)."""
         if yiaddr is None:
-            yiaddr, server = self.yiaddr, self.server
+            yiaddr, server = self.binding.yiaddr, self.binding.server
         if not yiaddr:
             return
 
@@ -620,16 +633,16 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         Uses server-provided DHCP option 58/59 when present and sane, otherwise
         the RFC-suggested 0.5 / 0.875 of the lease time.
         """
-        lease = max(1, self.lease)
-        t1 = self.t1_server if self.t1_server else int(lease * T1_FACTOR)
-        t2 = self.t2_server if self.t2_server else int(lease * T2_FACTOR)
+        lease = max(1, self.binding.lease_secs)
+        t1 = self.binding.t1_server if self.binding.t1_server else int(lease * T1_FACTOR)
+        t2 = self.binding.t2_server if self.binding.t2_server else int(lease * T2_FACTOR)
         # Keep both timers inside the lease; only apply the MIN_T1 floor when the
         # lease is long enough to accommodate it (very short leases renew sooner).
         t1 = min(t1, lease)
         if lease > MIN_T1:
             t1 = max(MIN_T1, t1)
         t2 = min(max(t1 + REBIND_MARGIN, t2), lease)
-        src = "server" if (self.t1_server or self.t2_server) else "derived"
+        src = "server" if (self.binding.t1_server or self.binding.t2_server) else "derived"
         return t1, t2, src
 
 
@@ -790,9 +803,10 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
                           "(possible spoofed ACK from %s)", phase, self.target, got,
                           rx.server_id)
                 return False
-            if phase != PHASE_REBIND and rx.server_id and self._dhcp.server and rx.server_id != self._dhcp.server:
+            leased_from = self._dhcp.binding.server
+            if phase != PHASE_REBIND and rx.server_id and leased_from and rx.server_id != leased_from:
                 LOG.error("%s: ACK from unexpected server %s (leased from %s) -- not following",
-                          phase, rx.server_id, self._dhcp.server)
+                          phase, rx.server_id, leased_from)
                 return False
 
             waited = time.time() - self._last_follow_time()
@@ -808,7 +822,7 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
             # plain DHCP interface does. Needs the new subnet mask (opt 1) to set the
             # VIP prefix; without it we can only move the address, so warn instead.
             self._gw_args = []
-            old_router = self._dhcp.router
+            old_router = self._dhcp.binding.router
             if rx.router and old_router and rx.router != old_router:
                 bits = _mask_to_bits(rx.subnet_mask)
                 if bits:
@@ -899,10 +913,10 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
         if rx is None:
             return
         self._observed = None
-        if not self.follow or not rx.yiaddr or rx.yiaddr == self._dhcp.yiaddr:
+        if not self.follow or not rx.yiaddr or rx.yiaddr == self._dhcp.binding.yiaddr:
             return
         LOG.info("observed peer DHCP ACK for %s (we hold %s) -- following early to converge",
-                 rx.yiaddr, self._dhcp.yiaddr)
+                 rx.yiaddr, self._dhcp.binding.yiaddr)
         self.on_changed_address(rx.yiaddr, rx, PHASE_OBSERVED, release_on_enforce=False)
 
 
@@ -1027,7 +1041,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             self._on_dhcp_reply(p)
         elif p.haslayer(ARP):
             # Gateway answering our nudge (reachability stamp).
-            self._nudge.on_arp_reply(p, self._dhcp.yiaddr, self._nudge_target())
+            self._nudge.on_arp_reply(p, self._dhcp.binding.yiaddr, self._nudge_target())
 
     def _chaddr_matches(self, b):
         """True if the reply's BOOTP client hardware address is our chaddr (the
@@ -1063,10 +1077,10 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             # thread -- which routes it through the same follow hardening
             # (sane / same-class / expected-server / throttle) as a first-party
             # ACK and never acts on the sniffer thread.
-            if not self._follow.follow or not self._dhcp.yiaddr or not self._chaddr_matches(b):
+            if not self._follow.follow or not self._dhcp.binding.yiaddr or not self._chaddr_matches(b):
                 return
             rx = _parse_reply(p, b.yiaddr)
-            if (rx.mtype == ACK and rx.yiaddr and rx.yiaddr != self._dhcp.yiaddr
+            if (rx.mtype == ACK and rx.yiaddr and rx.yiaddr != self._dhcp.binding.yiaddr
                     and _sane_ipv4(rx.yiaddr)):
                 self._follow.observe(rx)
                 self._wake.set()   # wake the maintain-loop sleep now, don't wait for the tick
@@ -1096,8 +1110,8 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             gw = self._nudge_target()
             if gw:
                 extra += f" gw={gw}"
-        self._write_hb(f"{int(time.time())} bound={self._dhcp.yiaddr or '-'} "
-                       f"lease={self._dhcp.lease} t1={t1} t2={t2} src={src}{extra}\n")
+        self._write_hb(f"{int(time.time())} bound={self._dhcp.binding.yiaddr or '-'} "
+                       f"lease={self._dhcp.binding.lease_secs} t1={t1} t2={t2} src={src}{extra}\n")
 
     def _hb_mismatch(self, got, want):
         # Write a clear marker into the heartbeat file so a supervisor/human sees the mismatch.
@@ -1198,12 +1212,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
     def _nudge_target(self):
         """The gateway whose ARP cache the nudge maintains: DHCP option 3 from
         the last ACK, falling back to the leasing server's address."""
-        return self._dhcp.router or self._dhcp.server
+        return self._dhcp.binding.router or self._dhcp.binding.server
 
     def _arp_nudge(self, force=False):
         """Hand the current lease binding (leased address, nudge target) to the
         ArpNudge component; it owns the pacing, the master gate and the send."""
-        self._nudge.maybe_nudge(self._dhcp.yiaddr, self._nudge_target(), force=force)
+        self._nudge.maybe_nudge(self._dhcp.binding.yiaddr, self._nudge_target(), force=force)
 
     # ---- operator/signal API (set flags only; the loops act within a second) ----
 
@@ -1259,7 +1273,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             # Link-return fast path: only while UNBOUND, poll carrier every few
             # seconds; a down->up edge means the WAN just came back, so stop waiting
             # and let _maintain_step re-DORA immediately (the bound path skips this).
-            if self._dhcp.yiaddr is None and slept % LINK_POLL_STEP == 0 and self._check_link_returned():
+            if self._dhcp.binding.yiaddr is None and slept % LINK_POLL_STEP == 0 and self._check_link_returned():
                 self._link_returned = True
                 return not self._stop
 
@@ -1335,14 +1349,15 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         on every state transition; any exception it raises is caught by run() and
         retried, so a transient fault can never terminate the keeper."""
         # Acquire a lease if we do not hold one.
-        if not self._dhcp.yiaddr:
+        b = self._dhcp.binding
+        if not b.yiaddr:
             self._ensure_sniffer()  # a dead sniffer would silently fail every DORA
             self._hb()  # active but not holding yet -> publish bound=-
             if self._dhcp.acquire(self._follow.target):
                 LOG.info("DHCP BOUND %s (lease=%ss, expires ~%s, server=%s, gw=%s, mask=%s)",
-                         self._dhcp.yiaddr, self._dhcp.lease, _clock_at(self._dhcp.lease),
-                         self._dhcp.server, self._dhcp.router or "?",
-                         f"/{self._dhcp.mask_bits}" if self._dhcp.mask_bits else "none")
+                         b.yiaddr, b.lease_secs, _clock_at(b.lease_secs),
+                         b.server, b.router or "?",
+                         f"/{b.mask_bits}" if b.mask_bits else "none")
                 self._hb()
                 self._arp_nudge(force=True)
                 self.redora_wait = REDORA_MIN
@@ -1365,12 +1380,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # "RENEW ok" already carries the lease + expiry. Raise the keeper's log
         # level to see it.
         LOG.debug("DHCP lease %ds; renew at T1=%ds (~%s), rebind by T2=%ds (~%s) (timing source: %s)",
-                  self._dhcp.lease, t1, _clock_at(t1), t2, _clock_at(t2), src)
+                  b.lease_secs, t1, _clock_at(t1), t2, _clock_at(t2), src)
         if not self._hold_lease(t1):
             return
         if self._dhcp.renew():
             LOG.info("DHCP RENEW ok %s (lease=%ss, expires ~%s)",
-                     self._dhcp.yiaddr, self._dhcp.lease, _clock_at(self._dhcp.lease))
+                     b.yiaddr, b.lease_secs, _clock_at(b.lease_secs))
             self._hb()
             self._arp_nudge(force=True)
             return
@@ -1393,7 +1408,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 break
         if ok:
             LOG.info("DHCP REBIND ok %s (lease=%ss, expires ~%s)",
-                     self._dhcp.yiaddr, self._dhcp.lease, _clock_at(self._dhcp.lease))
+                     b.yiaddr, b.lease_secs, _clock_at(b.lease_secs))
             self._hb()
             self._arp_nudge(force=True)
             return
@@ -1483,7 +1498,7 @@ def _claim_once(k):
         return 3
     time.sleep(SNIFFER_WARMUP)
     ok = k._dhcp.dora(k._follow.target)
-    LOG.info("DHCP claim %s -> %s", k.chaddr, k._dhcp.yiaddr if ok else "FAIL")
+    LOG.info("DHCP claim %s -> %s", k.chaddr, k._dhcp.binding.yiaddr if ok else "FAIL")
     if ok:
         k._dhcp.release()
     k._stop_sniffer()

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -35,7 +35,7 @@ Security posture (this daemon parses untrusted WAN traffic as root):
     the keeper needs are extracted -- no dissection of the rest (untrusted input).
   * Follow mode never rewrites the CARP VIP from a single ACK: the new address
     is validated (plausibility, routability class, expected server) and
-    rate-throttled against flap/spoof storms (see _handle_changed_address).
+    rate-throttled against flap/spoof storms (see FollowPolicy.on_changed_address).
   * A parse error in the sniffer callback is dropped (debug-logged).
 
 Cooperating with ISP access-network policing (DHCP snooping, Dynamic ARP
@@ -83,8 +83,8 @@ except Exception as _scapy_exc:   # ImportError, or scapy's own import-time fail
     # Bind the names so the module still loads (main() exits with the captured
     # error before any of them is used). Typed Any so type checkers do not
     # flag every scapy call site as calling None.
-    _missing: Any = None                                # pylint: disable=invalid-name
-    ARP = Ether = IP = UDP = BOOTP = DHCP = AsyncSniffer = sendp = _missing  # pylint: disable=invalid-name
+    _MISSING: Any = None
+    ARP = Ether = IP = UDP = BOOTP = DHCP = AsyncSniffer = sendp = _MISSING  # pylint: disable=invalid-name
 
 LOG = logging.getLogger("lease-keeper")
 
@@ -261,7 +261,8 @@ def _same_ip_class(a, b):
 
 
 def _fs_safe(s):
-    """Filesystem-safe token (same charset as the keeper id)."""
+    """Filesystem-safe token (keeperconf.keeper_id mirrors this charset for
+    the configd scripts)."""
     return re.sub(r"[^A-Za-z0-9]", "_", s or "")
 
 
@@ -278,6 +279,14 @@ def _jittered(base):
 def mac2raw(m):
     """Colon/dash-separated MAC string -> 6 raw bytes (BOOTP chaddr)."""
     return bytes.fromhex(m.replace(":", "").replace("-", ""))
+
+
+def _atomic_write(path, content):
+    """Write via tmp + rename so a crash mid-write cannot leave a partial file."""
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(content)
+    os.replace(tmp, path)
 
 
 def _clock_at(offset):
@@ -298,18 +307,20 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
     release_on_enforce) -> bool for an ACK whose address differs from the
     expected one (True = the caller validated and adopted it, see adopt())."""
 
-    def __init__(self, iface, chaddr, eth_src, id_opts,  # pylint: disable=R0913,R0917
+    def __init__(self, iface, chaddr, eth_src, id_opts, *,  # pylint: disable=too-many-arguments
                  should_stop, ensure_sniffer, on_changed_address):
         self.iface = iface
         self.chaddr = chaddr
         self.chraw = mac2raw(chaddr)
         self.eth_src = eth_src
+
         # Optional DHCP request options (empty -> not sent); added to every
         # DISCOVER/REQUEST/RENEW so the server sees a consistent client identity.
         self._id_opts = id_opts
         self._should_stop = should_stop
         self._ensure_sniffer = ensure_sniffer
         self._on_changed = on_changed_address
+
         self.xid = random.randint(1, 0xFFFFFFFF)
         self.yiaddr = None
         self.server = None
@@ -319,6 +330,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         self.router = None             # default gateway (DHCP opt 3, fallback: server_id)
         self.mask_bits = None          # subnet prefix length from opt 1 (for logging + follow)
         self._tried_reboot = False     # the first acquire tries INIT-REBOOT before a full DISCOVER
+
         self._rx = None                # latest DhcpReply snapshot (set via feed(), sniffer thread)
         self._ev = threading.Event()
 
@@ -348,6 +360,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         while time.time() < end and not self._should_stop():
             self._ev.clear()
             self._ev.wait(min(1.0, max(0.05, end - time.time())))
+
             rx = self._rx
             if rx and rx.mtype == want:
                 return rx
@@ -619,6 +632,7 @@ class ArpNudge:  # pylint: disable=too-many-instance-attributes
         # Interval floor so a typo cannot flood the segment; 0 = disabled.
         self.interval = max(ARP_NUDGE_MIN, interval) if interval else 0
         self._is_master = is_master    # callable -> True/False/None (None = probe failed)
+
         self.last_nudge = 0.0          # epoch of the last sent nudge (0 = never)
         # Reachability: the sniffer stamps last_reply when the gateway answers
         # a nudge (a lone atomic float write); the status page surfaces its age.
@@ -636,6 +650,7 @@ class ArpNudge:  # pylint: disable=too-many-instance-attributes
             return
         if self._is_master() is not True:
             return
+
         if not gateway:
             # Enabled but no target: without this warning the nudge would be a
             # silent no-op and the operator would believe they are protected.
@@ -709,13 +724,16 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
         self.follow = follow
         self._dhcp = dhcp
         self._hb_mismatch = hb_mismatch
+
         self._followed_ip = None       # last address we asked configd to follow to
         self._follow_from = None       # address we followed FROM (for the retry watchdog)
         self._fired_at = 0.0           # when we last dispatched follow_update (retry deadline)
         self._gw_args = []             # extra follow_update args on a cross-subnet move: [old_gw, new_gw, bits]
+
         # Throttle state, keyed by chaddr so it survives the follow-induced
         # restart (the target-keyed runtime paths change on every follow).
         self._state_file = f"/var/run/carpvipdhcp-follow-{_fs_safe(chaddr)}"
+
         # A changed ISP address first seen in the PEER's ACK (both HA nodes run
         # an identical keeper on the same shared chaddr). The sniffer thread
         # records it via observe() -- a lone atomic ref-assign -- and the main
@@ -733,10 +751,7 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
 
     def _record_follow(self):
         try:
-            tmp = self._state_file + ".tmp"
-            with open(tmp, "w", encoding="utf-8") as f:
-                f.write(str(int(time.time())))
-            os.replace(tmp, self._state_file)
+            _atomic_write(self._state_file, str(int(time.time())))
         except OSError as e:
             LOG.warning("could not persist follow timestamp: %s", e)
 
@@ -883,7 +898,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
     operator actions. The lease lives in DhcpClient; the changed-address
     decision and the target address live in FollowPolicy."""
 
-    def __init__(self, iface, chaddr, request_ip=None, eth_src=None,  # pylint: disable=R0913,R0917
+    def __init__(self, iface, chaddr, request_ip=None, eth_src=None, *,  # pylint: disable=too-many-arguments
                  hbfile=None, release_on_exit=False, vhid=None,
                  follow=False, vendor_class=None, client_id=None, hostname=None,
                  arp_nudge=0, arp_listen_promisc=False):
@@ -893,11 +908,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self.hbfile = hbfile
         self.release_on_exit = release_on_exit
         self.vhid = str(vhid) if vhid else None
+
         # ARP nudge component: owns the pacing and reachability state; the
         # keeper supplies the lease binding per nudge (_arp_nudge) and the
-        # CARP-role probe (late-bound so tests can stub _probe_carp_master).
-        self._nudge = ArpNudge(iface, self.chaddr, arp_nudge,
-                               lambda: self._probe_carp_master())  # pylint: disable=unnecessary-lambda
+        # CARP-role probe (via the _carp_master_probe shim).
+        self._nudge = ArpNudge(iface, self.chaddr, arp_nudge, self._carp_master_probe)
+
         # Promiscuous ARP capture: off by default (the CARP master already
         # accepts the VIP MAC, so the unicast reply reaches a normal socket).
         # Opt-in fallback for NICs that drop non-primary unicast MACs.
@@ -906,6 +922,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._nudge_now = False        # operator asked for an immediate nudge (SIGUSR1)
         self._poll_role_now = False    # a CARP transition fired -> re-check role now (SIGUSR2)
         self._renew_asap = False       # renew at the next _hold_lease tick instead of waiting for T1
+
         # Optional DHCP request options (empty -> not sent); built once and added to
         # every DISCOVER/REQUEST/RENEW so the server sees a consistent client identity.
         # ISP interplay: satisfies servers that only lease to a known vendor-class
@@ -918,26 +935,29 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             id_opts.append(("client_id", client_id.encode()))
         if hostname:
             id_opts.append(("hostname", hostname))
+
         # DHCP client component: owns the lease state and the protocol sequences;
         # the keeper owns the sniffer (feeding it xid-matched replies) and the
-        # policy hooks. should_stop/ensure_sniffer are late-bound lambdas so
-        # tests can stub the keeper attributes after construction.
+        # policy hooks.
         self._dhcp = DhcpClient(
             iface, self.chaddr, self.eth_src, id_opts,
-            should_stop=lambda: self.stop,
-            ensure_sniffer=lambda: self._ensure_sniffer(),  # pylint: disable=unnecessary-lambda
+            should_stop=lambda: self._stop,
+            ensure_sniffer=self._ensure_sniffer,
             on_changed_address=self._on_changed_address)
+
         # Follow/enforce policy component: owns the target address and the
         # follow bookkeeping; drives the client via adopt()/release()/expire().
         self._follow = FollowPolicy(request_ip, follow, self.chaddr, self._dhcp,
                                     self._hb_mismatch)
+
         self.redora_wait = REDORA_MIN
         # Link-return fast path (only while UNBOUND): a carrier down->up edge resets
         # the backoff and re-DORAs at once, like dhclient's link-up -> state_reboot.
         self._link_up = None           # last carrier state seen (None = unknown / not probed)
         self._link_kick_at = 0.0       # epoch of the last link-return kick (debounce)
         self._link_returned = False    # set by _sleep_interruptible on a carrier return while unbound
-        self.stop = False
+
+        self._stop = False
         # General early-wake for the maintain-loop sleep (_sleep_interruptible): lets it
         # return before the 1s tick when there is pending work. Currently the
         # sniffer sets it on an observed address change so the follow fires in
@@ -948,13 +968,17 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._sniffer = None
 
     # ---- sniffer (resilient) ----
-    def _start_sniffer(self):
+    def _stop_sniffer(self):
+        """Best-effort capture stop (scapy may raise if it never ran)."""
         try:
             if self._sniffer:
-                try:
-                    self._sniffer.stop()
-                except Exception:
-                    pass
+                self._sniffer.stop()
+        except Exception:
+            pass
+
+    def _start_sniffer(self):
+        try:
+            self._stop_sniffer()
             # Non-promiscuous by default: the BOOTP broadcast flag makes the
             # server broadcast OFFER/ACK, and the gateway's unicast ARP reply to a
             # nudge reaches us because the CARP master already accepts the VIP's
@@ -1036,14 +1060,10 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
     # ---- heartbeat / status file ----
 
     def _write_hb(self, content):
-        # Write atomically (temp + rename) so a crash mid-write can't leave a partial file.
         if not self.hbfile:
             return
-        tmp = f"{self.hbfile}.tmp"
         try:
-            with open(tmp, "w", encoding="utf-8") as f:
-                f.write(content)
-            os.replace(tmp, self.hbfile)
+            _atomic_write(self.hbfile, content)
         except Exception as e:
             # The heartbeat drives CARP gating, so a write failure is worth surfacing.
             LOG.warning("heartbeat write failed (%s): %s", self.hbfile, e)
@@ -1052,7 +1072,8 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         t1, t2, src = self._dhcp.timing()
         # Publish nudge state so the status page can show it: nudge=<epoch of the
         # last sent nudge, 0 = never>, arpok=<epoch of the gateway's last ARP reply,
-        # 0 = none seen> and the current target gateway (if known).
+        # 0 = none seen> and the current target gateway (if known). status.py's
+        # _HB_TOKENS table is the reader -- keep the tokens in lockstep.
         extra = ""
         if self._nudge.interval:
             extra = f" nudge={int(self._nudge.last_nudge)} arpok={int(self._nudge.last_reply)}"
@@ -1067,8 +1088,8 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._write_hb(f"{int(time.time())} MISMATCH got={got} want={want}\n")
 
     def _on_changed_address(self, got, rx, phase, release_on_enforce):
-        """DhcpClient's changed-address hook -> the FollowPolicy decision
-        (late-bound through the attribute so tests can stub the policy)."""
+        """DhcpClient's changed-address hook -> the FollowPolicy decision. A
+        shim because the client is constructed before the policy exists."""
         return self._follow.on_changed_address(got, rx, phase, release_on_enforce)
 
     # ---- CARP role (master probe, transitions) ----
@@ -1094,6 +1115,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         if out is None:
             return None
         return f"carp: MASTER vhid {self.vhid} " in out
+
+    def _carp_master_probe(self):
+        """ArpNudge's is_master hook -> the CARP probe (late-bound through the
+        attribute so tests can stub _probe_carp_master)."""
+        return self._probe_carp_master()
 
     def _iface_link_up(self):
         """Interface carrier from ifconfig: True on 'status: active', False on a
@@ -1167,7 +1193,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
 
     def request_stop(self):
         """Ask the daemon to exit at the next loop tick (SIGINT/SIGTERM)."""
-        self.stop = True
+        self._stop = True
 
     def trigger_nudge(self):
         """Request an immediate ARP nudge (SIGUSR1 / configd action). Flag
@@ -1183,7 +1209,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
 
     def _sleep(self, secs):
         slept = 0
-        while slept < secs and not self.stop:
+        while slept < secs and not self._stop:
             time.sleep(1)
             slept += 1
         return slept
@@ -1193,13 +1219,14 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         operator-requested immediate nudge (SIGUSR1) and a CARP-transition re-check
         (SIGUSR2) so both act within a second instead of at the next heartbeat tick."""
         slept = 0
-        while slept < secs and not self.stop:
+        while slept < secs and not self._stop:
             if self._poll_role_now:
                 self._poll_role_now = False
                 # A CARP transition just fired (kernel -> devd -> rc.syshook.d/carp
                 # -> SIGUSR2); re-check the role now so a backup->master keeper
                 # nudges + renews immediately instead of at the next ~30s poll.
                 self._poll_carp_role()
+
             if self._nudge_now:
                 self._nudge_now = False
                 # Operator actions are rare and intentional -- always log them,
@@ -1208,21 +1235,24 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 LOG.info("manual ARP nudge requested (SIGUSR1)")
                 self._arp_nudge(force=True)
                 self._hb()   # publish the new nudge age right away for the status page
+
             # A pending peer-ACK observation follows now (rationale + the
             # dual-master window it closes: FollowPolicy.check_observed).
             self._follow.check_observed()
+
             # Link-return fast path: only while UNBOUND, poll carrier every few
             # seconds; a down->up edge means the WAN just came back, so stop waiting
             # and let _maintain_step re-DORA immediately (the bound path skips this).
             if self._dhcp.yiaddr is None and slept % LINK_POLL_STEP == 0 and self._check_link_returned():
                 self._link_returned = True
-                return not self.stop
+                return not self._stop
+
             # Event-driven sleep: return at once when the sniffer signals a fresh
             # observation, otherwise time out after ~1s to run the periodic checks.
             if self._wake.wait(1.0):
                 self._wake.clear()
             slept += 1
-        return not self.stop
+        return not self._stop
 
     def _hold_lease(self, secs):
         """Sleep up to secs while holding a lease, rewriting the heartbeat every
@@ -1230,36 +1260,40 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         the CARP demotion hook only sees heartbeat freshness). Returns False early
         on stop."""
         remaining = secs
-        while remaining > 0 and not self.stop:
+        while remaining > 0 and not self._stop:
             if self._renew_asap:
                 # Return as if T1 elapsed: the caller renews right away, which
                 # re-teaches upstream DHCP-snooping state after a master change.
                 self._renew_asap = False
-                return not self.stop
+                return not self._stop
+
             chunk = min(HB_REFRESH, remaining)
             if not self._sleep_interruptible(chunk):
                 return False
             remaining -= chunk
+
             self._hb()
             self._follow.watchdog()   # re-drive a follow whose apply stalled
             self._poll_carp_role()    # backup->master? renew early + nudge now
             self._arp_nudge()
-        return not self.stop
+        return not self._stop
 
     def run(self):
         """The daemon main loop: sniffer up, then maintain the lease until
         stopped. Never raises; returns the process exit code."""
         # Start the packet sniffer, retrying forever: a keeper must self-heal, not
         # die, if the interface is briefly unavailable at startup.
-        while not self.stop and not self._start_sniffer():
+        while not self._stop and not self._start_sniffer():
             LOG.warning("sniffer start failed -- retrying in %ds", SNIFFER_RETRY)
             self._sleep(SNIFFER_RETRY)
+
         # eth-src matters for L2 debugging but only when it differs from the chaddr.
         ethsrc = f" eth-src={self.eth_src}" if self.eth_src != self.chaddr else ""
         LOG.info("lease-keeper active on %s: chaddr=%s%s request=%s",
                  self.iface, self.chaddr, ethsrc, self._follow.target or "any")
         time.sleep(0.5)
-        while not self.stop:
+
+        while not self._stop:
             # The keeper must NEVER die on a bad DHCP state: catch any unexpected
             # error, keep the heartbeat fresh so CARP does not falsely demote us,
             # and retry after a short backoff.
@@ -1272,14 +1306,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 except Exception:
                     pass
                 self._sleep(LOOP_ERROR_BACKOFF)
+
         # shutdown
         if self.release_on_exit:
             self._dhcp.release()
-        try:
-            if self._sniffer:
-                self._sniffer.stop()
-        except Exception:
-            pass
+        self._stop_sniffer()
         LOG.info("stopped")
         return 0
 
@@ -1331,7 +1362,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
 
         elapsed = t1
         ok = False
-        while elapsed < t2 and not self.stop:
+        while elapsed < t2 and not self._stop:
             # Jitter the REBIND retransmit cadence: both nodes hit T2 together
             # (identical lease timers), so an un-jittered step would broadcast
             # REBIND in lockstep. Overshooting t2 slightly is harmless (the guard
@@ -1439,12 +1470,9 @@ def _claim_once(k):
     LOG.info("DHCP claim %s -> %s", k.chaddr, k._dhcp.yiaddr if ok else "FAIL")
     if ok:
         k._dhcp.release()
-    try:
-        if k._sniffer:
-            k._sniffer.stop()
-    except Exception:
-        pass
+    k._stop_sniffer()
     return 0 if ok else 1
+# pylint: enable=protected-access
 
 
 def main():

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/logparse.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/logparse.py
@@ -11,6 +11,8 @@ import json
 import os
 import re
 
+from keeperconf import keeper_lines
+
 LOG_GLOB = "/var/log/carpvipdhcp-*.log"
 CONFFILE = "/usr/local/etc/carpvipdhcp/keeper.conf"
 MAX_PER_FILE = 500
@@ -20,15 +22,7 @@ LINE_RE = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})(?:,\d+)?\s+(\w+)\s
 def keeper_meta():
     """Map the filesystem-safe keeper id to {ip, vhid} via keeper.conf."""
     meta = {}
-    try:
-        lines = open(CONFFILE).read().splitlines()
-    except OSError:
-        return meta
-    for line in lines:
-        line = line.strip()
-        if not line or line.startswith("#") or "|" not in line:
-            continue
-        parts = line.split("|")
+    for parts in keeper_lines(CONFFILE):
         request = parts[0]
         vhid = parts[4] if len(parts) > 4 else ""
         meta[re.sub(r"[^A-Za-z0-9]", "_", request)] = {"ip": request, "vhid": vhid}
@@ -36,6 +30,7 @@ def keeper_meta():
 
 
 def main():
+    """Emit the merged, newest-first JSON array of parsed log records."""
     meta = keeper_meta()
     records = []
     for path in sorted(glob.glob(LOG_GLOB)):
@@ -45,7 +40,8 @@ def main():
         keeper = info.get("ip", kid)
         vhid = info.get("vhid", "")
         try:
-            lines = open(path, errors="replace").read().splitlines()[-MAX_PER_FILE:]
+            with open(path, encoding="utf-8", errors="replace") as f:
+                lines = f.read().splitlines()[-MAX_PER_FILE:]
         except OSError:
             continue
         for line in lines:

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/logparse.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/logparse.py
@@ -11,10 +11,9 @@ import json
 import os
 import re
 
-from keeperconf import keeper_lines
+from keeperconf import CONFFILE, keeper_id, keeper_lines
 
 LOG_GLOB = "/var/log/carpvipdhcp-*.log"
-CONFFILE = "/usr/local/etc/carpvipdhcp/keeper.conf"
 MAX_PER_FILE = 500
 LINE_RE = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})(?:,\d+)?\s+(\w+)\s+(.*)$")
 
@@ -25,7 +24,7 @@ def keeper_meta():
     for parts in keeper_lines(CONFFILE):
         request = parts[0]
         vhid = parts[4] if len(parts) > 4 else ""
-        meta[re.sub(r"[^A-Za-z0-9]", "_", request)] = {"ip": request, "vhid": vhid}
+        meta[keeper_id(request)] = {"ip": request, "vhid": vhid}
     return meta
 
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/logparse.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/logparse.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python3
 """Parse the per-keeper daemon logs into structured JSON records (root, via configd).
 
-Each lease-keeper.py log line looks like:
+Each lease_keeper.py log line looks like:
     2026-07-06 12:34:56,789 INFO some message
 Output: a JSON array of {timestamp, keeper, vhid, level, message}, newest first,
 which the Diagnostics API feeds to a searchable/sortable bootgrid.

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
@@ -18,9 +18,8 @@ import subprocess
 import time
 import xml.etree.ElementTree as ET
 
-from keeperconf import keeper_lines
+from keeperconf import CONFFILE, keeper_id, keeper_lines
 
-CONFFILE = "/usr/local/etc/carpvipdhcp/keeper.conf"
 CONFIG_XML = "/conf/config.xml"
 RUN_DIR = "/var/run"
 
@@ -29,11 +28,6 @@ RUN_DIR = "/var/run"
 # intervals). Older = stale -> the GUI shows it as unconfirmed.
 ARP_CONFIRM_INTERVALS = 3
 ARP_CONFIRM_FLOOR = 90
-
-
-def keeper_id(request_ip):
-    """Filesystem-safe keeper id (same charset as the daemon uses)."""
-    return re.sub(r"[^A-Za-z0-9]", "_", request_ip)
 
 
 def pid_alive(path):
@@ -107,6 +101,7 @@ def parse_heartbeat(path):
         result["hb_age"] = int(time.time()) - result["hb_epoch"]
     except ValueError:
         return result
+
     for part in parts[1:]:
         if part == "MISMATCH":
             result["mismatch"] = True

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
@@ -151,7 +151,7 @@ def iface_names():
     return names
 
 
-def read_keepers(states, names):  # pylint: disable=too-many-locals
+def read_keepers(states, names):
     """One status entry per keeper.conf line: config, process, CARP role and
     heartbeat fields, plus the derived arp_confirmed freshness flag."""
     keepers = []

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
@@ -18,6 +18,8 @@ import subprocess
 import time
 import xml.etree.ElementTree as ET
 
+from keeperconf import keeper_lines
+
 CONFFILE = "/usr/local/etc/carpvipdhcp/keeper.conf"
 CONFIG_XML = "/conf/config.xml"
 RUN_DIR = "/var/run"
@@ -30,12 +32,15 @@ ARP_CONFIRM_FLOOR = 90
 
 
 def keeper_id(request_ip):
+    """Filesystem-safe keeper id (same charset as the daemon uses)."""
     return re.sub(r"[^A-Za-z0-9]", "_", request_ip)
 
 
 def pid_alive(path):
+    """The live pid recorded in the pidfile, or None (absent/stale/foreign)."""
     try:
-        pid = int(open(path).read().strip())
+        with open(path, encoding="utf-8") as f:
+            pid = int(f.read().strip())
         os.kill(pid, 0)
         return pid
     except (OSError, ValueError):
@@ -56,13 +61,42 @@ def _int_token(value):
         return None
 
 
+def _epoch_pair(value):
+    """(epoch, age) for the nudge=/arpok= tokens; a 0 epoch means 'never yet'
+    and a garbled value parses to nothing -- age stays None either way."""
+    try:
+        return _epoch_and_age(value)
+    except ValueError:
+        return None, None
+
+
+# Heartbeat token dispatch: token -> (result fields, value parser). The parser
+# returns one value per field. Tokens are data, not logic -- adding one is a
+# table row, in lockstep with what lease_keeper.py's _hb()/_hb_mismatch() emit.
+_HB_TOKENS = {
+    "bound": (("bound",), lambda v: (None if v == "-" else v,)),
+    "lease": (("lease",), lambda v: (_int_token(v),)),
+    "t1": (("t1",), lambda v: (_int_token(v),)),
+    "t2": (("t2",), lambda v: (_int_token(v),)),
+    "src": (("timing_source",), lambda v: (v,)),
+    "nudge": (("nudge_epoch", "nudge_age"), _epoch_pair),
+    "arpok": (("arp_reply_epoch", "arp_reply_age"), _epoch_pair),
+    "gw": (("gw",), lambda v: (v,)),
+    "got": (("mismatch_got",), lambda v: (v,)),
+    "want": (("mismatch_want",), lambda v: (v,)),
+}
+
+
 def parse_heartbeat(path):
+    """Parse one heartbeat file into the per-keeper status fields (all None /
+    False when the file is absent or unreadable)."""
     result = {"bound": None, "lease": None, "t1": None, "t2": None, "timing_source": None,
               "mismatch": False, "mismatch_got": None, "mismatch_want": None,
               "hb_epoch": None, "hb_age": None, "nudge_epoch": None, "nudge_age": None, "gw": None,
               "arp_reply_epoch": None, "arp_reply_age": None}
     try:
-        raw = open(path).read().strip()
+        with open(path, encoding="utf-8") as f:
+            raw = f.read().strip()
     except OSError:
         return result
     parts = raw.split()
@@ -74,37 +108,14 @@ def parse_heartbeat(path):
     except ValueError:
         return result
     for part in parts[1:]:
-        if part.startswith("bound="):
-            value = part.split("=", 1)[1]
-            result["bound"] = None if value == "-" else value
-        elif part.startswith("lease="):
-            result["lease"] = _int_token(part.split("=", 1)[1])
-        elif part.startswith("t1="):
-            result["t1"] = _int_token(part.split("=", 1)[1])
-        elif part.startswith("t2="):
-            result["t2"] = _int_token(part.split("=", 1)[1])
-        elif part.startswith("src="):
-            result["timing_source"] = part.split("=", 1)[1]
-        elif part.startswith("nudge="):
-            # nudge=0 means "enabled but never sent yet" -> age stays None.
-            try:
-                result["nudge_epoch"], result["nudge_age"] = _epoch_and_age(part.split("=", 1)[1])
-            except ValueError:
-                pass
-        elif part.startswith("arpok="):
-            # arpok=0 means "no gateway ARP reply seen yet" -> age stays None.
-            try:
-                result["arp_reply_epoch"], result["arp_reply_age"] = _epoch_and_age(part.split("=", 1)[1])
-            except ValueError:
-                pass
-        elif part.startswith("gw="):
-            result["gw"] = part.split("=", 1)[1]
-        elif part == "MISMATCH":
+        if part == "MISMATCH":
             result["mismatch"] = True
-        elif part.startswith("got="):
-            result["mismatch_got"] = part.split("=", 1)[1]
-        elif part.startswith("want="):
-            result["mismatch_want"] = part.split("=", 1)[1]
+            continue
+        token, sep, value = part.partition("=")
+        spec = _HB_TOKENS.get(token) if sep else None
+        if spec:
+            fields, parse = spec
+            result.update(zip(fields, parse(value)))
     return result
 
 
@@ -140,17 +151,11 @@ def iface_names():
     return names
 
 
-def read_keepers(states, names):
+def read_keepers(states, names):  # pylint: disable=too-many-locals
+    """One status entry per keeper.conf line: config, process, CARP role and
+    heartbeat fields, plus the derived arp_confirmed freshness flag."""
     keepers = []
-    try:
-        lines = open(CONFFILE).read().splitlines()
-    except OSError:
-        return keepers
-    for line in lines:
-        line = line.strip()
-        if not line or line.startswith("#") or "|" not in line:
-            continue
-        parts = line.split("|")
+    for parts in keeper_lines(CONFFILE):
         if len(parts) < 4:
             continue
         # keeper.conf field order (keep in lockstep with the template + rc.d readers):
@@ -163,7 +168,7 @@ def read_keepers(states, names):
         if len(parts) > 9:
             arp_nudge = _int_token(parts[9]) or 0
         kid = keeper_id(request)
-        pid = pid_alive("%s/carpvipdhcp-%s.pid" % (RUN_DIR, kid))
+        pid = pid_alive(f"{RUN_DIR}/carpvipdhcp-{kid}.pid")
         entry = {
             "request": request,
             "iface": iface,
@@ -177,7 +182,7 @@ def read_keepers(states, names):
             "running": pid is not None,
             "pid": pid,
         }
-        entry.update(parse_heartbeat("%s/carpvipdhcp-%s.hb" % (RUN_DIR, kid)))
+        entry.update(parse_heartbeat(f"{RUN_DIR}/carpvipdhcp-{kid}.hb"))
         age = entry.get("arp_reply_age")
         entry["arp_confirmed"] = (
             age is not None and age <= max(ARP_CONFIRM_FLOOR, arp_nudge * ARP_CONFIRM_INTERVALS))
@@ -186,6 +191,7 @@ def read_keepers(states, names):
 
 
 def carp_demotion():
+    """The kernel CARP demotion counter, or None when unreadable."""
     try:
         out = subprocess.check_output(["/sbin/sysctl", "-n", "net.inet.carp.demotion"])
         return int(out.strip())
@@ -194,6 +200,7 @@ def carp_demotion():
 
 
 def main():
+    """Emit the status JSON document on stdout."""
     print(json.dumps({
         "carp_demotion": carp_demotion(),
         "keepers": read_keepers(carp_states(), iface_names()),

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
@@ -6,7 +6,7 @@ pidfile and heartbeat file. Output:
 
     {"carp_demotion": <int|null>, "keepers": [ {per-keeper status}, ... ]}
 
-The heartbeat file is written by lease-keeper.py in one of two forms:
+The heartbeat file is written by lease_keeper.py in one of two forms:
     <epoch> bound=<ip> lease=<seconds> t1=<seconds> t2=<seconds> src=<server|derived>
             [nudge=<epoch|0> arpok=<epoch|0> [gw=<ip>]]
     <epoch> MISMATCH got=<ip> want=<ip>

--- a/net/os-carp-vip-dhcp/src/opnsense/service/templates/OPNsense/CarpVipDhcp/keeper.conf
+++ b/net/os-carp-vip-dhcp/src/opnsense/service/templates/OPNsense/CarpVipDhcp/keeper.conf
@@ -1,5 +1,5 @@
 {#
-    Rendered keeper table for lease-keeper.py (one line per enabled keeper).
+    Rendered keeper table for lease_keeper.py (one line per enabled keeper).
 
     Format per line:  REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE|ARP_LISTEN_PROMISC
     Everything is derived from each keeper's referenced CARP VirtualIP: we look

--- a/net/os-carp-vip-dhcp/tests/conftest.py
+++ b/net/os-carp-vip-dhcp/tests/conftest.py
@@ -9,6 +9,7 @@ import importlib.util
 import os
 import sys
 import types
+from typing import Any
 
 import pytest
 
@@ -21,22 +22,23 @@ sys.path.insert(0, SCRIPT_DIR)
 def _stub_scapy():
     if "scapy.all" in sys.modules:
         return
-    scapy = types.ModuleType("scapy")
-    allmod = types.ModuleType("scapy.all")
+    # Typed Any: module attributes are assigned dynamically below.
+    scapy: Any = types.ModuleType("scapy")
+    allmod: Any = types.ModuleType("scapy.all")
 
-    class _Sniffer:
-        def __init__(self, *args, **kwargs):
+    class _Sniffer:  # pylint: disable=too-few-public-methods
+        def __init__(self, *_args, **_kwargs):
             self.thread = types.SimpleNamespace(is_alive=lambda: True)
 
         def start(self):
-            pass
+            """No-op (no capture in unit tests)."""
 
         def stop(self):
-            pass
+            """No-op."""
 
-    class _Layer:
+    class _Layer:  # pylint: disable=too-few-public-methods
         """Composable no-op protocol layer: Ether(...) / IP(...) / ... works."""
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *_args, **_kwargs):
             pass
 
         def __truediv__(self, other):
@@ -59,6 +61,7 @@ _stub_scapy()
 def _load(filename, modname):
     path = os.path.join(SCRIPT_DIR, filename)
     spec = importlib.util.spec_from_file_location(modname, path)
+    assert spec and spec.loader, path
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/net/os-carp-vip-dhcp/tests/conftest.py
+++ b/net/os-carp-vip-dhcp/tests/conftest.py
@@ -26,7 +26,7 @@ def _stub_scapy():
     scapy: Any = types.ModuleType("scapy")
     allmod: Any = types.ModuleType("scapy.all")
 
-    class _Sniffer:  # pylint: disable=too-few-public-methods
+    class _Sniffer:
         def __init__(self, *_args, **_kwargs):
             self.thread = types.SimpleNamespace(is_alive=lambda: True)
 

--- a/net/os-carp-vip-dhcp/tests/conftest.py
+++ b/net/os-carp-vip-dhcp/tests/conftest.py
@@ -1,6 +1,6 @@
 """Pytest bootstrap: make the plugin's configd scripts importable and stub scapy.
 
-lease-keeper.py imports scapy at module load, but the daemon logic under test
+lease_keeper.py imports scapy at module load, but the daemon logic under test
 never touches the network, so a lightweight stub lets the suite run without the
 dependency (and without root or a live interface). status.py / logparse.py are
 plain-stdlib and import directly once their directory is on sys.path.
@@ -66,5 +66,5 @@ def _load(filename, modname):
 
 @pytest.fixture(scope="session")
 def lk():
-    """The lease-keeper daemon module (loaded via importlib -- hyphenated name)."""
-    return _load("lease-keeper.py", "lease_keeper")
+    """The lease_keeper daemon module (loaded via importlib so scapy stays stubbed)."""
+    return _load("lease_keeper.py", "lease_keeper")

--- a/net/os-carp-vip-dhcp/tests/conftest.py
+++ b/net/os-carp-vip-dhcp/tests/conftest.py
@@ -63,6 +63,9 @@ def _load(filename, modname):
     spec = importlib.util.spec_from_file_location(modname, path)
     assert spec and spec.loader, path
     module = importlib.util.module_from_spec(spec)
+    # Register before exec: dataclasses (and anything else that resolves
+    # annotations) looks the module up in sys.modules by __module__.
+    sys.modules[modname] = module
     spec.loader.exec_module(module)
     return module
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -224,7 +224,7 @@ def _ack(lk, yiaddr, server="100.64.4.1"):
 class _DhcpPkt:
     """Minimal stand-in for a scapy DHCP reply: p[BOOTP].xid/op/yiaddr and
     p[DHCP].options, with haslayer() so _on_dhcp_reply parses it."""
-    def __init__(self, lk, xid, options, yiaddr="100.64.4.7",
+    def __init__(self, lk, xid, options, yiaddr="100.64.4.7",  # pylint: disable=R0913,R0917
                  chaddr=b"\x00\x00\x5e\x00\x01\xfe", op=None, giaddr="0.0.0.0"):
         self._lk = lk
         self._bootp = types.SimpleNamespace(xid=xid, op=(lk.BOOTREPLY if op is None else op),

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1,4 +1,8 @@
-"""Unit tests for the lease-keeper daemon's pure helpers and follow decision."""
+"""Unit tests for the lease-keeper daemon's pure helpers and follow decision.
+
+Tests reach into private state/methods by design, and use comments over
+per-test docstrings."""
+# pylint: disable=protected-access, missing-function-docstring
 import os
 import time
 import types
@@ -26,18 +30,30 @@ def test_fs_safe(lk):
     assert lk._fs_safe("100.64.4.7") == "100_64_4_7"
 
 
+def _client(lk, id_opts=None, on_changed=None):
+    """A bare DhcpClient with stub hooks and a captured send list -- the
+    protocol tests need no Keeper."""
+    c = lk.DhcpClient("eth0", "00:00:5e:00:01:fe", "00:00:5e:00:01:fe", id_opts or [],
+                      should_stop=lambda: False,
+                      ensure_sniffer=lambda: None,
+                      on_changed_address=on_changed or (lambda *a: False))
+    c.sent = []
+    c._send_dhcp = lambda mtype, extra, ciaddr="0.0.0.0": c.sent.append((mtype, extra, ciaddr))
+    return c
+
+
 def test_timing_derived(lk):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
-    keeper._dhcp.lease = 1800
-    assert keeper._dhcp.timing() == (900, 1575, "derived")
+    c = _client(lk)
+    c.lease = 1800
+    assert c.timing() == (900, 1575, "derived")
 
 
 def test_timing_honours_server(lk):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
-    keeper._dhcp.lease = 1800
-    keeper._dhcp.t1_server = 600
-    keeper._dhcp.t2_server = 1200
-    assert keeper._dhcp.timing() == (600, 1200, "server")
+    c = _client(lk)
+    c.lease = 1800
+    c.t1_server = 600
+    c.t2_server = 1200
+    assert c.timing() == (600, 1200, "server")
 
 
 def test_redora_max_bounded(lk):
@@ -51,48 +67,75 @@ def test_dhcpreply_giaddr_defaults_none(lk):
     assert rx.giaddr is None
 
 
-def _reboot_keeper(lk):
-    k = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
-    k._ensure_sniffer = lambda: None
-    k.sent = []
-    k._dhcp._send_dhcp = lambda mtype, extra, ciaddr="0.0.0.0": k.sent.append((mtype, extra, ciaddr))
-    return k
-
-
 def test_reboot_request_shape_and_bind(lk):
-    k = _reboot_keeper(lk)
-    k._dhcp._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
+    c = _client(lk)
+    c._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
         lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, None)
-    assert k._dhcp.reboot("100.64.4.7") is True
-    assert k._dhcp.yiaddr == "100.64.4.7" and k._dhcp.server == "100.64.4.1"
-    mtype, extra, ciaddr = k.sent[0]
+    assert c.reboot("100.64.4.7") is True
+    assert c.yiaddr == "100.64.4.7" and c.server == "100.64.4.1"
+    mtype, extra, ciaddr = c.sent[0]
     assert mtype == "request" and ciaddr == "0.0.0.0"          # INIT-REBOOT: ciaddr stays 0
     assert ("requested_addr", "100.64.4.7") in extra           # option 50 = our known address
     assert not any(o[0] == "server_id" for o in extra if isinstance(o, tuple))  # RFC 4.3.2: no server-id
 
 
 def test_reboot_nak_falls_through(lk):
-    k = _reboot_keeper(lk)
-    k._dhcp._wait_for_dhcp_reply = lambda want, timeout: "NAK"
-    assert k._dhcp.reboot("100.64.4.7") is False
-    assert k._dhcp.yiaddr is None
+    c = _client(lk)
+    c._wait_for_dhcp_reply = lambda want, timeout: "NAK"
+    assert c.reboot("100.64.4.7") is False
+    assert c.yiaddr is None
 
 
 def test_reboot_skipped_without_request_ip(lk):
-    k = lk.Keeper("eth0", "00:00:5e:00:01:fe", None, hbfile=None)
-    assert k._dhcp.reboot(None) is False  # no known address -> nothing to reboot-request
+    c = _client(lk)
+    assert c.reboot(None) is False  # no known address -> nothing to reboot-request
 
 
 def test_acquire_reboot_first_then_dora(lk):
-    k = _reboot_keeper(lk)
+    c = _client(lk)
     calls = []
-    k._dhcp.reboot = lambda rip: (calls.append("reboot"), False)[1]
-    k._dhcp.dora = lambda rip=None: (calls.append("dora"), True)[1]
-    assert k._dhcp.acquire("100.64.4.7") is True
+    c.reboot = lambda rip: (calls.append("reboot"), False)[1]
+    c.dora = lambda rip=None: (calls.append("dora"), True)[1]
+    assert c.acquire("100.64.4.7") is True
     assert calls == ["reboot", "dora"]      # first acquire: INIT-REBOOT then DISCOVER fallback
     calls.clear()
-    assert k._dhcp.acquire("100.64.4.7") is True
+    assert c.acquire("100.64.4.7") is True
     assert calls == ["dora"]                # subsequent acquires: DISCOVER only
+
+
+def test_adopt_binds_and_refreshes_server(lk):
+    c = _client(lk)
+    c.server = "100.64.4.1"                                    # from the OFFER
+    ack = lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.2", 1800, None, None,
+                       "100.64.4.1", None, "255.255.255.0")
+    c.adopt(ack)
+    assert c.yiaddr == "100.64.4.7"
+    assert c.server == "100.64.4.2"          # ACK's server-id wins...
+    assert c.lease == 1800 and c.mask_bits == 24
+    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.8", None, 900, None, None, None))
+    assert c.server == "100.64.4.2"          # ...and is kept when the ACK has none
+
+
+def test_expire_unbinds_but_keeps_hints(lk):
+    c = _client(lk)
+    c.yiaddr, c.server, c.router = "100.64.4.7", "100.64.4.1", "100.64.4.254"
+    c.expire()
+    assert c.yiaddr is None                            # unbound -> the run loop re-acquires
+    assert c.server == "100.64.4.1" and c.router == "100.64.4.254"   # hints survive
+
+
+def test_renew_requires_binding(lk):
+    c = _client(lk)
+    assert c.renew() is False    # unbound -> nothing to renew
+    assert c.sent == []          # and nothing went on the wire
+
+
+def test_feed_wakes_the_waiting_sequence(lk):
+    c = _client(lk)
+    rx = lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, None)
+    c.feed(rx)
+    assert c._rx is rx
+    assert c._ev.is_set()        # the waiting _wait_for_dhcp_reply returns at once
 
 
 def test_fmt_reply_readable(lk):
@@ -259,7 +302,7 @@ def test_follow_throttled_within_interval(lk, tmp_path):
     assert keeper._handle_changed_address("100.64.4.61", _ack(lk, "100.64.4.61"), "DORA", True) is False
 
 
-def test_enforce_mismatch_refused(lk, tmp_path):
+def test_enforce_mismatch_refused(lk):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, follow=False)
     keeper._dhcp.server = "100.64.4.1"
     keeper._dhcp.yiaddr = "100.64.4.7"
@@ -319,7 +362,7 @@ def test_observed_ignores_non_ack(lk, tmp_path):
     assert keeper._observed_change is None
 
 
-def test_observed_ignored_when_not_follow(lk, tmp_path):
+def test_observed_ignored_when_not_follow(lk):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, follow=False)
     keeper._dhcp.server = "100.64.4.1"
     keeper._dhcp.yiaddr = "100.64.4.7"
@@ -405,6 +448,23 @@ def _nudge_keeper(lk, arp_nudge=240, hbfile=None, **kwargs):
     keeper._dhcp.server = "100.64.4.1"
     keeper._probe_carp_master = lambda: True   # the real probe needs ifconfig
     return keeper
+
+
+def test_arp_nudge_component_direct(lk):
+    # ArpNudge alone (no Keeper): interval floor at construction, the injected
+    # master probe gates every send, and the reachability stamp starts at 0.
+    role = {"master": True}
+    n = lk.ArpNudge("eth0", "00:00:5e:00:01:fe", 1, lambda: role["master"])
+    assert n.interval == lk.ARP_NUDGE_MIN     # floored: a typo cannot flood the segment
+    assert n.last_reply == 0.0
+
+    n.maybe_nudge("100.64.4.7", "100.64.4.1")
+    first = n.last_nudge
+    assert first > 0                          # master + due -> sent
+
+    role["master"] = False
+    n.maybe_nudge("100.64.4.7", "100.64.4.1", force=True)
+    assert n.last_nudge == first              # backup: never nudge, even forced
 
 
 def test_nudge_off_by_default(lk):
@@ -640,7 +700,7 @@ def test_sniffer_filter_captures_arp_and_honours_promisc(lk, monkeypatch):
     captured = {}
 
     class _Cap:
-        def __init__(self, *a, **k):
+        def __init__(self, *_a, **k):
             captured.update(k)
             self.thread = types.SimpleNamespace(is_alive=lambda: True)
 
@@ -708,11 +768,11 @@ def test_follow_update_action_arity():
         "conf", "actions.d", "actions_carpvipdhcp.conf")
     params = None
     in_section = False
-    with open(conf) as fh:
+    with open(conf, encoding="utf-8") as fh:
         for raw in fh:
             line = raw.strip()
             if line.startswith("[") and line.endswith("]"):
-                in_section = (line == "[follow_update]")
+                in_section = line == "[follow_update]"
             elif in_section and line.startswith("parameters:"):
                 params = line.split(":", 1)[1]
                 break
@@ -722,15 +782,10 @@ def test_follow_update_action_arity():
 
 # ---- RFC 2131/2132 compliance ----
 
-def _plain_keeper(lk):
-    return lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
-
-
 def test_dhcp_options_include_param_req_list(lk):
     # Every DISCOVER/REQUEST must carry the Parameter Request List (RFC 2132 §9.8)
     # so the server returns the subnet mask (1) + router (3) follow-mode needs.
-    keeper = _plain_keeper(lk)
-    opts = lk._dhcp_options("discover", [("requested_addr", "100.64.4.7")], keeper._dhcp._id_opts)
+    opts = lk._dhcp_options("discover", [("requested_addr", "100.64.4.7")], [])
     assert opts[0] == ("message-type", "discover")
     assert ("param_req_list", lk.PARAM_REQ_LIST) in opts
     assert 1 in lk.PARAM_REQ_LIST and 3 in lk.PARAM_REQ_LIST
@@ -741,34 +796,31 @@ def test_dhcp_options_include_param_req_list(lk):
 def test_absorb_reply_captures_gw_and_mask(lk):
     # The PRL asks for opt 3 (router) + opt 1 (mask); _absorb_reply keeps both so
     # the BOUND log can surface them (and follow mode can use the mask).
-    keeper = _plain_keeper(lk)
+    c = _client(lk)
     rx = lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None,
                       "100.64.4.1", None, "255.255.255.0")
-    keeper._dhcp._absorb_reply(rx, lk.DEFAULT_LEASE)
-    assert keeper._dhcp.router == "100.64.4.1"
-    assert keeper._dhcp.mask_bits == 24
+    c._absorb_reply(rx, lk.DEFAULT_LEASE)
+    assert c.router == "100.64.4.1"
+    assert c.mask_bits == 24
 
 
 def test_renew_omits_server_id_and_requested_addr(lk):
     # RFC 2131 §4.3.2: a RENEWING/REBINDING REQUEST MUST NOT carry server_id or
     # requested_addr, and ciaddr MUST be the client's address.
-    keeper = _plain_keeper(lk)
-    keeper._dhcp.server, keeper._dhcp.yiaddr, keeper._dhcp.lease = "100.64.4.1", "100.64.4.7", 1800
-    sent = []
-    keeper._ensure_sniffer = lambda: None
-    keeper._dhcp._send_dhcp = lambda mtype, extra, ciaddr="0.0.0.0": sent.append((mtype, extra, ciaddr))
-    keeper._dhcp._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
-        lk.ACK, keeper._dhcp.yiaddr, keeper._dhcp.server, 1800, None, None, None)
-    assert keeper._dhcp.renew() is True            # RENEW (T1)
-    assert keeper._dhcp.renew(rebind=True) is True  # REBIND (T2)
-    assert sent, "renew sent nothing"
-    for mtype, extra, ciaddr in sent:
+    c = _client(lk)
+    c.server, c.yiaddr, c.lease = "100.64.4.1", "100.64.4.7", 1800
+    c._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
+        lk.ACK, c.yiaddr, c.server, 1800, None, None, None)
+    assert c.renew() is True            # RENEW (T1)
+    assert c.renew(rebind=True) is True  # REBIND (T2)
+    assert c.sent, "renew sent nothing"
+    for mtype, extra, ciaddr in c.sent:
         assert mtype == "request"
         assert ciaddr == "100.64.4.7"          # ciaddr MUST be the client's address
         # assert on the ACTUAL assembled option list, not the stubbed extras
         # (which are always empty here) -- so a regression that re-added
         # server_id to renew's opts would fail this.
-        wire = [o for o in lk._dhcp_options(mtype, extra, keeper._dhcp._id_opts) if isinstance(o, tuple)]
+        wire = [o for o in lk._dhcp_options(mtype, extra, c._id_opts) if isinstance(o, tuple)]
         assert all(o[0] != "server_id" for o in wire)
         assert all(o[0] != "requested_addr" for o in wire)
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -150,8 +150,14 @@ def test_fmt_reply_readable(lk):
     assert "NAK" in s2 and "giaddr=100.64.4.9" in s2 and "no free leases" in s2
 
 
+def _keeper(lk, **kw):
+    """A Keeper on the canonical test identity (iface/vMAC/VIP), hbfile off."""
+    kw.setdefault("hbfile", None)
+    return lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", **kw)
+
+
 def _link_keeper(lk):
-    return lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    return _keeper(lk)
 
 
 def test_iface_link_up_parsing(lk, monkeypatch):
@@ -206,7 +212,7 @@ def test_check_link_returned_debounce(lk, monkeypatch):
 
 
 def _follow_keeper(lk, tmp_path):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, follow=True)
+    keeper = _keeper(lk, follow=True)
     keeper._follow._state_file = str(tmp_path / "follow_state")
     keeper._dhcp.server = "100.64.4.1"
     keeper._dhcp.yiaddr = "100.64.4.7"
@@ -224,7 +230,7 @@ def _ack(lk, yiaddr, server="100.64.4.1"):
 class _DhcpPkt:
     """Minimal stand-in for a scapy DHCP reply: p[BOOTP].xid/op/yiaddr and
     p[DHCP].options, with haslayer() so _on_dhcp_reply parses it."""
-    def __init__(self, lk, xid, options, yiaddr="100.64.4.7",  # pylint: disable=R0913,R0917
+    def __init__(self, lk, xid, options, *, yiaddr="100.64.4.7",  # pylint: disable=too-many-arguments
                  chaddr=b"\x00\x00\x5e\x00\x01\xfe", op=None, giaddr="0.0.0.0"):
         self._lk = lk
         self._bootp = types.SimpleNamespace(xid=xid, op=(lk.BOOTREPLY if op is None else op),
@@ -255,7 +261,7 @@ def test_parse_reply_extracts_fields_and_relay(lk):
 
 
 def test_on_dhcp_reply_captures_option56_message(lk):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    keeper = _keeper(lk)
     pkt = _DhcpPkt(lk, keeper._dhcp.xid, [("message-type", lk.NAK), ("server_id", "100.64.4.1"),
                                           ("message", "pool exhausted"), "end"])
     keeper._on_dhcp_reply(pkt)
@@ -268,7 +274,7 @@ def test_on_dhcp_reply_captures_option56_message(lk):
     (None, "DHCPNAK received"),                        # no reason -> the NAK is still logged
 ])
 def test_dhcpnak_logs_reason(lk, caplog, message, expect):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    keeper = _keeper(lk)
     keeper._dhcp._rx = lk.DhcpReply(lk.NAK, None, "100.64.4.1", None, None, None, None, message)
     with caplog.at_level("WARNING", logger="lease-keeper"):
         assert keeper._dhcp._wait_for_dhcp_reply(lk.ACK, 0.2) == "NAK"
@@ -303,7 +309,7 @@ def test_follow_throttled_within_interval(lk, tmp_path):
 
 
 def test_enforce_mismatch_refused(lk):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, follow=False)
+    keeper = _keeper(lk, follow=False)
     keeper._dhcp.server = "100.64.4.1"
     keeper._dhcp.yiaddr = "100.64.4.7"
     released = []
@@ -316,7 +322,7 @@ def test_enforce_mismatch_refused(lk):
 # ---- observed peer ACK: converge follow from the peer's exchange (single-ip s.3) ----
 
 def _observe_keeper(lk, tmp_path):
-    # Same fixture as _follow_keeper (server / yiaddr / _follow_state / fired +
+    # Same fixture as _follow_keeper (server / yiaddr / _state_file / fired +
     # _follow_update stubs), plus a known in-flight xid so a peer ACK (different
     # xid) takes the observed path.
     keeper = _follow_keeper(lk, tmp_path)
@@ -363,7 +369,7 @@ def test_observed_ignores_non_ack(lk, tmp_path):
 
 
 def test_observed_ignored_when_not_follow(lk):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, follow=False)
+    keeper = _keeper(lk, follow=False)
     keeper._dhcp.server = "100.64.4.1"
     keeper._dhcp.yiaddr = "100.64.4.7"
     keeper._dhcp.xid = 0x11111111
@@ -381,7 +387,7 @@ def test_own_xid_reply_uses_first_party_path(lk, tmp_path):
 
 
 def test_observed_latest_wins(lk, tmp_path):
-    # Two peer ACKs in quick succession (the sniffer overwrites _observed_change):
+    # Two peer ACKs in quick succession (the sniffer overwrites _observed):
     # the handler acts on the LATEST address -- the older one is superseded (the
     # shared lease is now the newer address), so dropping it is correct.
     keeper = _observe_keeper(lk, tmp_path)
@@ -404,7 +410,7 @@ def test_observed_same_address_after_follow_is_dropped(lk, tmp_path):
     assert keeper._follow._observed is None
 
 
-def test_check_observed_follow_drives_hardened_follow(lk, tmp_path):
+def test_check_observed_drives_hardened_follow(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
     keeper._follow._observed = _ack(lk, "100.64.4.60")
     keeper._follow.check_observed()
@@ -413,7 +419,7 @@ def test_check_observed_follow_drives_hardened_follow(lk, tmp_path):
     assert keeper._follow._observed is None
 
 
-def test_check_observed_follow_rejects_wrong_server(lk, tmp_path):
+def test_check_observed_rejects_wrong_server(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
     keeper._follow._observed = _ack(lk, "100.64.4.60", server="100.64.4.9")  # not our server
     keeper._follow.check_observed()
@@ -429,21 +435,19 @@ def test_observed_serviced_by_maintain_loop(lk, tmp_path):
 
 
 def test_id_opts_empty_by_default(lk):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    keeper = _keeper(lk)
     assert keeper._dhcp._id_opts == []
 
 
 def test_id_opts_built_from_args(lk):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None,
-                       vendor_class="MSFT 5.0", client_id="keeper-1", hostname="vip")
+    keeper = _keeper(lk, vendor_class="MSFT 5.0", client_id="keeper-1", hostname="vip")
     assert ("vendor_class_id", "MSFT 5.0") in keeper._dhcp._id_opts
     assert ("client_id", b"keeper-1") in keeper._dhcp._id_opts
     assert ("hostname", "vip") in keeper._dhcp._id_opts
 
 
 def _nudge_keeper(lk, arp_nudge=240, hbfile=None, **kwargs):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7",
-                       hbfile=hbfile, arp_nudge=arp_nudge, **kwargs)
+    keeper = _keeper(lk, hbfile=hbfile, arp_nudge=arp_nudge, **kwargs)
     keeper._dhcp.yiaddr = "100.64.4.7"
     keeper._dhcp.server = "100.64.4.1"
     keeper._probe_carp_master = lambda: True   # the real probe needs ifconfig
@@ -468,14 +472,14 @@ def test_arp_nudge_component_direct(lk):
 
 
 def test_nudge_off_by_default(lk):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    keeper = _keeper(lk)
     assert keeper._nudge.interval == 0
     keeper._arp_nudge(force=True)   # must be a no-op, not an error
     assert keeper._nudge.last_nudge == 0.0
 
 
 def test_nudge_interval_floor(lk):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, arp_nudge=1)
+    keeper = _keeper(lk, arp_nudge=1)
     assert keeper._nudge.interval == lk.ARP_NUDGE_MIN
 
 
@@ -517,15 +521,14 @@ def test_nudge_gated_to_carp_master(lk):
 
 
 def test_probe_carp_master_true_without_vhid(lk):
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
+    keeper = _keeper(lk)
     assert keeper._probe_carp_master() is True
 
 
 def test_probe_failure_skips_nudge(lk, monkeypatch):
     # A failed probe reports None, and the nudge fails closed on anything but
     # a confirmed MASTER.
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None,
-                       vhid=199, arp_nudge=240)
+    keeper = _keeper(lk, vhid=199, arp_nudge=240)
     keeper._dhcp.yiaddr = "100.64.4.7"
     keeper._dhcp.server = "100.64.4.1"
 
@@ -711,8 +714,7 @@ def test_sniffer_filter_captures_arp_and_honours_promisc(lk, monkeypatch):
             pass
 
     monkeypatch.setattr(lk, "AsyncSniffer", _Cap)
-    keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None,
-                       arp_listen_promisc=True)
+    keeper = _keeper(lk, arp_listen_promisc=True)
     assert keeper._start_sniffer() is True
     assert "arp" in captured["filter"]        # ARP replies now reach the parser
     assert "port 67" in captured["filter"]     # ...alongside DHCP, unchanged
@@ -759,7 +761,7 @@ def test_follow_no_gateway_change_no_extra_args(lk, tmp_path):
 def test_follow_update_action_arity():
     """The configd [follow_update] action must accept as many params as the
     daemon can send: _fire_follow_update passes old_ip + new_ip plus
-    _follow_gw_args ([old_gw, new_gw, bits] on a cross-subnet move) = 5. configd
+    _gw_args ([old_gw, new_gw, bits] on a cross-subnet move) = 5. configd
     raises "Parameter mismatch" when more args than %s tokens are passed, so a
     narrower template would silently break every cross-subnet follow via
     configctl (a boundary the direct-call tests above never cross)."""

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -28,16 +28,16 @@ def test_fs_safe(lk):
 
 def test_timing_derived(lk):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
-    keeper.lease = 1800
-    assert keeper._timing() == (900, 1575, "derived")
+    keeper._dhcp.lease = 1800
+    assert keeper._dhcp.timing() == (900, 1575, "derived")
 
 
 def test_timing_honours_server(lk):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
-    keeper.lease = 1800
-    keeper.t1_server = 600
-    keeper.t2_server = 1200
-    assert keeper._timing() == (600, 1200, "server")
+    keeper._dhcp.lease = 1800
+    keeper._dhcp.t1_server = 600
+    keeper._dhcp.t2_server = 1200
+    assert keeper._dhcp.timing() == (600, 1200, "server")
 
 
 def test_redora_max_bounded(lk):
@@ -55,16 +55,16 @@ def _reboot_keeper(lk):
     k = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
     k._ensure_sniffer = lambda: None
     k.sent = []
-    k._send_dhcp = lambda mtype, extra, ciaddr="0.0.0.0": k.sent.append((mtype, extra, ciaddr))
+    k._dhcp._send_dhcp = lambda mtype, extra, ciaddr="0.0.0.0": k.sent.append((mtype, extra, ciaddr))
     return k
 
 
 def test_reboot_request_shape_and_bind(lk):
     k = _reboot_keeper(lk)
-    k._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
+    k._dhcp._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
         lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, None)
-    assert k.reboot() is True
-    assert k.yiaddr == "100.64.4.7" and k.server == "100.64.4.1"
+    assert k._dhcp.reboot("100.64.4.7") is True
+    assert k._dhcp.yiaddr == "100.64.4.7" and k._dhcp.server == "100.64.4.1"
     mtype, extra, ciaddr = k.sent[0]
     assert mtype == "request" and ciaddr == "0.0.0.0"          # INIT-REBOOT: ciaddr stays 0
     assert ("requested_addr", "100.64.4.7") in extra           # option 50 = our known address
@@ -73,25 +73,25 @@ def test_reboot_request_shape_and_bind(lk):
 
 def test_reboot_nak_falls_through(lk):
     k = _reboot_keeper(lk)
-    k._wait_for_dhcp_reply = lambda want, timeout: "NAK"
-    assert k.reboot() is False
-    assert k.yiaddr is None
+    k._dhcp._wait_for_dhcp_reply = lambda want, timeout: "NAK"
+    assert k._dhcp.reboot("100.64.4.7") is False
+    assert k._dhcp.yiaddr is None
 
 
 def test_reboot_skipped_without_request_ip(lk):
     k = lk.Keeper("eth0", "00:00:5e:00:01:fe", None, hbfile=None)
-    assert k.reboot() is False        # no known address -> nothing to reboot-request
+    assert k._dhcp.reboot(None) is False  # no known address -> nothing to reboot-request
 
 
 def test_acquire_reboot_first_then_dora(lk):
     k = _reboot_keeper(lk)
     calls = []
-    k.reboot = lambda: (calls.append("reboot"), False)[1]
-    k.dora = lambda: (calls.append("dora"), True)[1]
-    assert k._acquire() is True
+    k._dhcp.reboot = lambda rip: (calls.append("reboot"), False)[1]
+    k._dhcp.dora = lambda rip=None: (calls.append("dora"), True)[1]
+    assert k._dhcp.acquire("100.64.4.7") is True
     assert calls == ["reboot", "dora"]      # first acquire: INIT-REBOOT then DISCOVER fallback
     calls.clear()
-    assert k._acquire() is True
+    assert k._dhcp.acquire("100.64.4.7") is True
     assert calls == ["dora"]                # subsequent acquires: DISCOVER only
 
 
@@ -165,12 +165,12 @@ def test_check_link_returned_debounce(lk, monkeypatch):
 def _follow_keeper(lk, tmp_path):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, follow=True)
     keeper._follow_state = str(tmp_path / "follow_state")
-    keeper.server = "100.64.4.1"
-    keeper.yiaddr = "100.64.4.7"
+    keeper._dhcp.server = "100.64.4.1"
+    keeper._dhcp.yiaddr = "100.64.4.7"
     keeper.fired = []
     keeper._follow_update = keeper.fired.append
     keeper._hb_mismatch = lambda got: None
-    keeper.release = lambda: None
+    keeper._dhcp.release = lambda *a: None
     return keeper
 
 
@@ -213,10 +213,10 @@ def test_parse_reply_extracts_fields_and_relay(lk):
 
 def test_on_dhcp_reply_captures_option56_message(lk):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
-    pkt = _DhcpPkt(lk, keeper.xid, [("message-type", lk.NAK), ("server_id", "100.64.4.1"),
-                                    ("message", "pool exhausted"), "end"])
+    pkt = _DhcpPkt(lk, keeper._dhcp.xid, [("message-type", lk.NAK), ("server_id", "100.64.4.1"),
+                                          ("message", "pool exhausted"), "end"])
     keeper._on_dhcp_reply(pkt)
-    assert keeper._rx.message == "pool exhausted"
+    assert keeper._dhcp._rx.message == "pool exhausted"
 
 
 @pytest.mark.parametrize("message, expect", [
@@ -226,9 +226,9 @@ def test_on_dhcp_reply_captures_option56_message(lk):
 ])
 def test_dhcpnak_logs_reason(lk, caplog, message, expect):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
-    keeper._rx = lk.DhcpReply(lk.NAK, None, "100.64.4.1", None, None, None, None, message)
+    keeper._dhcp._rx = lk.DhcpReply(lk.NAK, None, "100.64.4.1", None, None, None, None, message)
     with caplog.at_level("WARNING", logger="lease-keeper"):
-        assert keeper._wait_for_dhcp_reply(lk.ACK, 0.2) == "NAK"
+        assert keeper._dhcp._wait_for_dhcp_reply(lk.ACK, 0.2) == "NAK"
     assert any(expect in r.getMessage() for r in caplog.records)
 
 
@@ -261,10 +261,13 @@ def test_follow_throttled_within_interval(lk, tmp_path):
 
 def test_enforce_mismatch_refused(lk, tmp_path):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, follow=False)
-    keeper.server = "100.64.4.1"
-    keeper.yiaddr = "100.64.4.7"
-    keeper.release = lambda: None
+    keeper._dhcp.server = "100.64.4.1"
+    keeper._dhcp.yiaddr = "100.64.4.7"
+    released = []
+    keeper._dhcp.release = lambda *a: released.append(a)
     assert keeper._handle_changed_address("100.64.4.60", _ack(lk, "100.64.4.60"), "DORA", True) is False
+    assert released == [("100.64.4.60", "100.64.4.1")]  # the refused grant is released...
+    assert keeper._dhcp.yiaddr is None                  # ...and not held (run loop re-acquires)
 
 
 # ---- observed peer ACK: converge follow from the peer's exchange (single-ip s.3) ----
@@ -274,7 +277,7 @@ def _observe_keeper(lk, tmp_path):
     # _follow_update stubs), plus a known in-flight xid so a peer ACK (different
     # xid) takes the observed path.
     keeper = _follow_keeper(lk, tmp_path)
-    keeper.xid = 0x11111111
+    keeper._dhcp.xid = 0x11111111
     return keeper
 
 
@@ -291,7 +294,7 @@ def test_observed_peer_ack_records_change_and_wakes(lk, tmp_path):
     keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60"))
     assert keeper._observed_change is not None
     assert keeper._observed_change.yiaddr == "100.64.4.60"
-    assert keeper._rx is None          # the first-party slot is untouched
+    assert keeper._dhcp._rx is None          # the first-party slot is untouched
     assert keeper._wake.is_set()       # ...and the maintain-loop sleep is woken at once
 
 
@@ -318,20 +321,20 @@ def test_observed_ignores_non_ack(lk, tmp_path):
 
 def test_observed_ignored_when_not_follow(lk, tmp_path):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, follow=False)
-    keeper.server = "100.64.4.1"
-    keeper.yiaddr = "100.64.4.7"
-    keeper.xid = 0x11111111
+    keeper._dhcp.server = "100.64.4.1"
+    keeper._dhcp.yiaddr = "100.64.4.7"
+    keeper._dhcp.xid = 0x11111111
     keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60"))
     assert keeper._observed_change is None
 
 
 def test_own_xid_reply_uses_first_party_path(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
-    keeper._on_dhcp_reply(_DhcpPkt(lk, keeper.xid,
+    keeper._on_dhcp_reply(_DhcpPkt(lk, keeper._dhcp.xid,
                                    [("message-type", lk.ACK), ("server_id", "100.64.4.1"), "end"],
                                    yiaddr="100.64.4.60"))
     assert keeper._observed_change is None            # not the observed path
-    assert keeper._rx is not None and keeper._rx.yiaddr == "100.64.4.60"
+    assert keeper._dhcp._rx is not None and keeper._dhcp._rx.yiaddr == "100.64.4.60"
 
 
 def test_observed_latest_wins(lk, tmp_path):
@@ -351,7 +354,7 @@ def test_observed_same_address_after_follow_is_dropped(lk, tmp_path):
     # After we've followed to the new address, a lingering observation for that
     # same address is a no-op (the == self.yiaddr guard), never a double-follow.
     keeper = _observe_keeper(lk, tmp_path)
-    keeper.yiaddr = "100.64.4.61"                 # we already hold the new address
+    keeper._dhcp.yiaddr = "100.64.4.61"                 # we already hold the new address
     keeper._observed_change = _ack(lk, "100.64.4.61")
     keeper._check_observed_follow()
     assert keeper.fired == []                     # no redundant follow
@@ -384,22 +387,22 @@ def test_observed_serviced_by_maintain_loop(lk, tmp_path):
 
 def test_id_opts_empty_by_default(lk):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None)
-    assert keeper._id_opts == []
+    assert keeper._dhcp._id_opts == []
 
 
 def test_id_opts_built_from_args(lk):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None,
                        vendor_class="MSFT 5.0", client_id="keeper-1", hostname="vip")
-    assert ("vendor_class_id", "MSFT 5.0") in keeper._id_opts
-    assert ("client_id", b"keeper-1") in keeper._id_opts
-    assert ("hostname", "vip") in keeper._id_opts
+    assert ("vendor_class_id", "MSFT 5.0") in keeper._dhcp._id_opts
+    assert ("client_id", b"keeper-1") in keeper._dhcp._id_opts
+    assert ("hostname", "vip") in keeper._dhcp._id_opts
 
 
 def _nudge_keeper(lk, arp_nudge=240, hbfile=None, **kwargs):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7",
                        hbfile=hbfile, arp_nudge=arp_nudge, **kwargs)
-    keeper.yiaddr = "100.64.4.7"
-    keeper.server = "100.64.4.1"
+    keeper._dhcp.yiaddr = "100.64.4.7"
+    keeper._dhcp.server = "100.64.4.1"
     keeper._probe_carp_master = lambda: True   # the real probe needs ifconfig
     return keeper
 
@@ -429,19 +432,19 @@ def test_nudge_respects_interval_and_force(lk):
 
 def test_nudge_requires_gateway_and_lease(lk):
     keeper = _nudge_keeper(lk)
-    keeper.server = None            # no router option and no server_id -> no target
+    keeper._dhcp.server = None            # no router option and no server_id -> no target
     keeper._arp_nudge(force=True)
     assert keeper._nudge.last_nudge == 0.0
-    keeper.server = "100.64.4.1"
-    keeper.yiaddr = None            # not bound -> no source address
+    keeper._dhcp.server = "100.64.4.1"
+    keeper._dhcp.yiaddr = None            # not bound -> no source address
     keeper._arp_nudge(force=True)
     assert keeper._nudge.last_nudge == 0.0
 
 
 def test_nudge_works_from_router_option_alone(lk):
     keeper = _nudge_keeper(lk)
-    keeper.server = None
-    keeper.router = "100.64.4.254"   # DHCP option 3 alone is a valid target
+    keeper._dhcp.server = None
+    keeper._dhcp.router = "100.64.4.254"   # DHCP option 3 alone is a valid target
     keeper._arp_nudge(force=True)
     assert keeper._nudge.last_nudge > 0
 
@@ -463,8 +466,8 @@ def test_probe_failure_skips_nudge(lk, monkeypatch):
     # a confirmed MASTER.
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None,
                        vhid=199, arp_nudge=240)
-    keeper.yiaddr = "100.64.4.7"
-    keeper.server = "100.64.4.1"
+    keeper._dhcp.yiaddr = "100.64.4.7"
+    keeper._dhcp.server = "100.64.4.1"
 
     def boom(*a, **k):
         raise OSError("ifconfig unavailable")
@@ -477,7 +480,7 @@ def test_probe_failure_skips_nudge(lk, monkeypatch):
 def test_hb_nudge_tokens_present(lk, tmp_path):
     hb = tmp_path / "hb"
     keeper = _nudge_keeper(lk, hbfile=str(hb))
-    keeper.router = "100.64.4.1"
+    keeper._dhcp.router = "100.64.4.1"
     keeper._nudge.last_nudge = 1783350000.0
     keeper._nudge.last_reply = 1783350050.0
     keeper._hb()
@@ -490,7 +493,7 @@ def test_hb_nudge_tokens_present(lk, tmp_path):
 def test_hb_nudge_zeros_when_never_and_no_target(lk, tmp_path):
     hb = tmp_path / "hb"
     keeper = _nudge_keeper(lk, hbfile=str(hb))
-    keeper.server = None             # enabled, but no target and nothing sent yet
+    keeper._dhcp.server = None             # enabled, but no target and nothing sent yet
     keeper._hb()
     content = hb.read_text()
     assert " nudge=0" in content
@@ -583,7 +586,7 @@ def test_sigusr2_flag_rechecks_carp_role_within_a_second(lk):
 
 def test_nudge_missing_gateway_warns_once(lk, caplog):
     keeper = _nudge_keeper(lk)
-    keeper.server = None             # enabled + bound, but no target
+    keeper._dhcp.server = None             # enabled + bound, but no target
     with caplog.at_level("WARNING", logger="lease-keeper"):
         keeper._arp_nudge(force=True)
         keeper._arp_nudge(force=True)
@@ -609,7 +612,7 @@ class _ArpPkt:
 
 def test_arp_reply_ignores_unrelated(lk):
     keeper = _nudge_keeper(lk)
-    keeper.router = "100.64.4.254"
+    keeper._dhcp.router = "100.64.4.254"
     keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.9", "100.64.4.7"))    # wrong sender
     keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.254", "100.64.4.99"))  # wrong target IP
     keeper._on_sniff(_ArpPkt(lk, 1, "100.64.4.254", "100.64.4.7"))   # a request, not a reply
@@ -620,7 +623,7 @@ def test_arp_reply_stamps_reachability_and_logs(lk, caplog):
     # A matching is-at reply from the nudge target, dispatched through the
     # sniffer path, stamps the reachability epoch and logs at DEBUG.
     keeper = _nudge_keeper(lk)
-    keeper.router = "100.64.4.1"
+    keeper._dhcp.router = "100.64.4.1"
     with caplog.at_level("DEBUG", logger="lease-keeper"):
         keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
     assert keeper._nudge.last_reply > 0
@@ -664,7 +667,7 @@ def _ack_gw(lk, yiaddr, router, server="100.64.4.1", mask=None):
 
 def test_follow_across_subnet_with_mask(lk, tmp_path, caplog):
     keeper = _follow_keeper(lk, tmp_path)
-    keeper.router = "100.64.4.1"
+    keeper._dhcp.router = "100.64.4.1"
     with caplog.at_level("WARNING", logger="lease-keeper"):
         assert keeper._handle_changed_address(
             "100.64.5.60", _ack_gw(lk, "100.64.5.60", "100.64.5.1", mask="255.255.255.0"),
@@ -676,7 +679,7 @@ def test_follow_across_subnet_with_mask(lk, tmp_path, caplog):
 
 def test_follow_gateway_change_without_mask_warns(lk, tmp_path, caplog):
     keeper = _follow_keeper(lk, tmp_path)
-    keeper.router = "100.64.4.1"
+    keeper._dhcp.router = "100.64.4.1"
     with caplog.at_level("ERROR", logger="lease-keeper"):   # no mask in the ACK
         keeper._handle_changed_address(
             "100.64.5.60", _ack_gw(lk, "100.64.5.60", "100.64.5.1"), "DORA", True)
@@ -687,7 +690,7 @@ def test_follow_gateway_change_without_mask_warns(lk, tmp_path, caplog):
 
 def test_follow_no_gateway_change_no_extra_args(lk, tmp_path):
     keeper = _follow_keeper(lk, tmp_path)
-    keeper.router = "100.64.4.1"
+    keeper._dhcp.router = "100.64.4.1"
     keeper._handle_changed_address(          # same gateway -> no cross-subnet extras
         "100.64.4.60", _ack_gw(lk, "100.64.4.60", "100.64.4.1"), "DORA", True)
     assert keeper._follow_gw_args == []
@@ -727,7 +730,7 @@ def test_dhcp_options_include_param_req_list(lk):
     # Every DISCOVER/REQUEST must carry the Parameter Request List (RFC 2132 §9.8)
     # so the server returns the subnet mask (1) + router (3) follow-mode needs.
     keeper = _plain_keeper(lk)
-    opts = lk._dhcp_options("discover", [("requested_addr", "100.64.4.7")], keeper._id_opts)
+    opts = lk._dhcp_options("discover", [("requested_addr", "100.64.4.7")], keeper._dhcp._id_opts)
     assert opts[0] == ("message-type", "discover")
     assert ("param_req_list", lk.PARAM_REQ_LIST) in opts
     assert 1 in lk.PARAM_REQ_LIST and 3 in lk.PARAM_REQ_LIST
@@ -741,23 +744,23 @@ def test_absorb_reply_captures_gw_and_mask(lk):
     keeper = _plain_keeper(lk)
     rx = lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None,
                       "100.64.4.1", None, "255.255.255.0")
-    keeper._absorb_reply(rx, lk.DEFAULT_LEASE)
-    assert keeper.router == "100.64.4.1"
-    assert keeper.mask_bits == 24
+    keeper._dhcp._absorb_reply(rx, lk.DEFAULT_LEASE)
+    assert keeper._dhcp.router == "100.64.4.1"
+    assert keeper._dhcp.mask_bits == 24
 
 
 def test_renew_omits_server_id_and_requested_addr(lk):
     # RFC 2131 §4.3.2: a RENEWING/REBINDING REQUEST MUST NOT carry server_id or
     # requested_addr, and ciaddr MUST be the client's address.
     keeper = _plain_keeper(lk)
-    keeper.server, keeper.yiaddr, keeper.lease = "100.64.4.1", "100.64.4.7", 1800
+    keeper._dhcp.server, keeper._dhcp.yiaddr, keeper._dhcp.lease = "100.64.4.1", "100.64.4.7", 1800
     sent = []
     keeper._ensure_sniffer = lambda: None
-    keeper._send_dhcp = lambda mtype, extra, ciaddr="0.0.0.0": sent.append((mtype, extra, ciaddr))
-    keeper._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
-        lk.ACK, keeper.yiaddr, keeper.server, 1800, None, None, None)
-    assert keeper.renew() is True            # RENEW (T1)
-    assert keeper.renew(rebind=True) is True  # REBIND (T2)
+    keeper._dhcp._send_dhcp = lambda mtype, extra, ciaddr="0.0.0.0": sent.append((mtype, extra, ciaddr))
+    keeper._dhcp._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
+        lk.ACK, keeper._dhcp.yiaddr, keeper._dhcp.server, 1800, None, None, None)
+    assert keeper._dhcp.renew() is True            # RENEW (T1)
+    assert keeper._dhcp.renew(rebind=True) is True  # REBIND (T2)
     assert sent, "renew sent nothing"
     for mtype, extra, ciaddr in sent:
         assert mtype == "request"
@@ -765,7 +768,7 @@ def test_renew_omits_server_id_and_requested_addr(lk):
         # assert on the ACTUAL assembled option list, not the stubbed extras
         # (which are always empty here) -- so a regression that re-added
         # server_id to renew's opts would fail this.
-        wire = [o for o in lk._dhcp_options(mtype, extra, keeper._id_opts) if isinstance(o, tuple)]
+        wire = [o for o in lk._dhcp_options(mtype, extra, keeper._dhcp._id_opts) if isinstance(o, tuple)]
         assert all(o[0] != "server_id" for o in wire)
         assert all(o[0] != "requested_addr" for o in wire)
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -44,15 +44,15 @@ def _client(lk, id_opts=None, on_changed=None):
 
 def test_timing_derived(lk):
     c = _client(lk)
-    c.lease = 1800
+    c.binding.lease_secs = 1800
     assert c.timing() == (900, 1575, "derived")
 
 
 def test_timing_honours_server(lk):
     c = _client(lk)
-    c.lease = 1800
-    c.t1_server = 600
-    c.t2_server = 1200
+    c.binding.lease_secs = 1800
+    c.binding.t1_server = 600
+    c.binding.t2_server = 1200
     assert c.timing() == (600, 1200, "server")
 
 
@@ -72,7 +72,7 @@ def test_reboot_request_shape_and_bind(lk):
     c._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
         lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, None)
     assert c.reboot("100.64.4.7") is True
-    assert c.yiaddr == "100.64.4.7" and c.server == "100.64.4.1"
+    assert c.binding.yiaddr == "100.64.4.7" and c.binding.server == "100.64.4.1"
     mtype, extra, ciaddr = c.sent[0]
     assert mtype == "request" and ciaddr == "0.0.0.0"          # INIT-REBOOT: ciaddr stays 0
     assert ("requested_addr", "100.64.4.7") in extra           # option 50 = our known address
@@ -83,7 +83,7 @@ def test_reboot_nak_falls_through(lk):
     c = _client(lk)
     c._wait_for_dhcp_reply = lambda want, timeout: "NAK"
     assert c.reboot("100.64.4.7") is False
-    assert c.yiaddr is None
+    assert c.binding.yiaddr is None
 
 
 def test_reboot_skipped_without_request_ip(lk):
@@ -100,28 +100,28 @@ def test_acquire_reboot_first_then_dora(lk):
     assert calls == ["reboot", "dora"]      # first acquire: INIT-REBOOT then DISCOVER fallback
     calls.clear()
     assert c.acquire("100.64.4.7") is True
-    assert calls == ["dora"]                # subsequent acquires: DISCOVER only
+    assert calls == ["dora"]   # subsequent acquires: DISCOVER only
 
 
 def test_adopt_binds_and_refreshes_server(lk):
     c = _client(lk)
-    c.server = "100.64.4.1"                                    # from the OFFER
+    c.binding.server = "100.64.4.1"   # from the OFFER
     ack = lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.2", 1800, None, None,
                        "100.64.4.1", None, "255.255.255.0")
     c.adopt(ack)
-    assert c.yiaddr == "100.64.4.7"
-    assert c.server == "100.64.4.2"          # ACK's server-id wins...
-    assert c.lease == 1800 and c.mask_bits == 24
+    assert c.binding.yiaddr == "100.64.4.7"
+    assert c.binding.server == "100.64.4.2"          # ACK's server-id wins...
+    assert c.binding.lease_secs == 1800 and c.binding.mask_bits == 24
     c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.8", None, 900, None, None, None))
-    assert c.server == "100.64.4.2"          # ...and is kept when the ACK has none
+    assert c.binding.server == "100.64.4.2"          # ...and is kept when the ACK has none
 
 
 def test_expire_unbinds_but_keeps_hints(lk):
     c = _client(lk)
-    c.yiaddr, c.server, c.router = "100.64.4.7", "100.64.4.1", "100.64.4.254"
+    c.binding.yiaddr, c.binding.server, c.binding.router = "100.64.4.7", "100.64.4.1", "100.64.4.254"
     c.expire()
-    assert c.yiaddr is None                            # unbound -> the run loop re-acquires
-    assert c.server == "100.64.4.1" and c.router == "100.64.4.254"   # hints survive
+    assert c.binding.yiaddr is None   # unbound -> the run loop re-acquires
+    assert c.binding.server == "100.64.4.1" and c.binding.router == "100.64.4.254"   # hints survive
 
 
 def test_renew_requires_binding(lk):
@@ -205,17 +205,17 @@ def test_check_link_returned_debounce(lk, monkeypatch):
     k = _link_keeper(lk)
     monkeypatch.setattr(lk.time, "time", lambda: 1000.0)
     k._iface_link_up = lambda: True
-    k._link_up = False                       # pretend we saw the link go down
+    k._link_up = False   # pretend we saw the link go down
     assert k._check_link_returned() is True   # first down->up fires (kick_at was 0.0)
-    k._link_up = False                       # another down at the same instant
+    k._link_up = False   # another down at the same instant
     assert k._check_link_returned() is False  # debounced (now - kick_at = 0 < LINK_KICK_DEBOUNCE)
 
 
 def _follow_keeper(lk, tmp_path):
     keeper = _keeper(lk, follow=True)
     keeper._follow._state_file = str(tmp_path / "follow_state")
-    keeper._dhcp.server = "100.64.4.1"
-    keeper._dhcp.yiaddr = "100.64.4.7"
+    keeper._dhcp.binding.server = "100.64.4.1"
+    keeper._dhcp.binding.yiaddr = "100.64.4.7"
     keeper.fired = []
     keeper._follow._follow_update = keeper.fired.append
     keeper._follow._hb_mismatch = lambda got, want: None
@@ -270,8 +270,8 @@ def test_on_dhcp_reply_captures_option56_message(lk):
 
 @pytest.mark.parametrize("message, expect", [
     ("lease not available", "lease not available"),   # option-56 text surfaced
-    (b"bad chaddr", "bad chaddr"),                     # a bytes reason is decoded
-    (None, "DHCPNAK received"),                        # no reason -> the NAK is still logged
+    (b"bad chaddr", "bad chaddr"),   # a bytes reason is decoded
+    (None, "DHCPNAK received"),   # no reason -> the NAK is still logged
 ])
 def test_dhcpnak_logs_reason(lk, caplog, message, expect):
     keeper = _keeper(lk)
@@ -310,13 +310,13 @@ def test_follow_throttled_within_interval(lk, tmp_path):
 
 def test_enforce_mismatch_refused(lk):
     keeper = _keeper(lk, follow=False)
-    keeper._dhcp.server = "100.64.4.1"
-    keeper._dhcp.yiaddr = "100.64.4.7"
+    keeper._dhcp.binding.server = "100.64.4.1"
+    keeper._dhcp.binding.yiaddr = "100.64.4.7"
     released = []
     keeper._dhcp.release = lambda *a: released.append(a)
     assert keeper._follow.on_changed_address("100.64.4.60", _ack(lk, "100.64.4.60"), "DORA", True) is False
     assert released == [("100.64.4.60", "100.64.4.1")]  # the refused grant is released...
-    assert keeper._dhcp.yiaddr is None                  # ...and not held (run loop re-acquires)
+    assert keeper._dhcp.binding.yiaddr is None   # ...and not held (run loop re-acquires)
 
 
 # ---- observed peer ACK: converge follow from the peer's exchange (single-ip s.3) ----
@@ -370,8 +370,8 @@ def test_observed_ignores_non_ack(lk, tmp_path):
 
 def test_observed_ignored_when_not_follow(lk):
     keeper = _keeper(lk, follow=False)
-    keeper._dhcp.server = "100.64.4.1"
-    keeper._dhcp.yiaddr = "100.64.4.7"
+    keeper._dhcp.binding.server = "100.64.4.1"
+    keeper._dhcp.binding.yiaddr = "100.64.4.7"
     keeper._dhcp.xid = 0x11111111
     keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60"))
     assert keeper._follow._observed is None
@@ -382,7 +382,7 @@ def test_own_xid_reply_uses_first_party_path(lk, tmp_path):
     keeper._on_dhcp_reply(_DhcpPkt(lk, keeper._dhcp.xid,
                                    [("message-type", lk.ACK), ("server_id", "100.64.4.1"), "end"],
                                    yiaddr="100.64.4.60"))
-    assert keeper._follow._observed is None            # not the observed path
+    assert keeper._follow._observed is None   # not the observed path
     assert keeper._dhcp._rx is not None and keeper._dhcp._rx.yiaddr == "100.64.4.60"
 
 
@@ -401,12 +401,12 @@ def test_observed_latest_wins(lk, tmp_path):
 
 def test_observed_same_address_after_follow_is_dropped(lk, tmp_path):
     # After we've followed to the new address, a lingering observation for that
-    # same address is a no-op (the == self.yiaddr guard), never a double-follow.
+    # same address is a no-op (the == binding.yiaddr guard), never a double-follow.
     keeper = _observe_keeper(lk, tmp_path)
-    keeper._dhcp.yiaddr = "100.64.4.61"                 # we already hold the new address
+    keeper._dhcp.binding.yiaddr = "100.64.4.61"   # we already hold the new address
     keeper._follow._observed = _ack(lk, "100.64.4.61")
     keeper._follow.check_observed()
-    assert keeper.fired == []                     # no redundant follow
+    assert keeper.fired == []   # no redundant follow
     assert keeper._follow._observed is None
 
 
@@ -429,7 +429,7 @@ def test_check_observed_rejects_wrong_server(lk, tmp_path):
 def test_observed_serviced_by_maintain_loop(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
     keeper._follow._observed = _ack(lk, "100.64.4.60")
-    keeper._wake.set()                 # as the sniffer would -> loop returns at once
+    keeper._wake.set()   # as the sniffer would -> loop returns at once
     keeper._sleep_interruptible(1)
     assert keeper.fired == ["100.64.4.60"]
 
@@ -448,8 +448,8 @@ def test_id_opts_built_from_args(lk):
 
 def _nudge_keeper(lk, arp_nudge=240, hbfile=None, **kwargs):
     keeper = _keeper(lk, hbfile=hbfile, arp_nudge=arp_nudge, **kwargs)
-    keeper._dhcp.yiaddr = "100.64.4.7"
-    keeper._dhcp.server = "100.64.4.1"
+    keeper._dhcp.binding.yiaddr = "100.64.4.7"
+    keeper._dhcp.binding.server = "100.64.4.1"
     keeper._probe_carp_master = lambda: True   # the real probe needs ifconfig
     return keeper
 
@@ -464,11 +464,11 @@ def test_arp_nudge_component_direct(lk):
 
     n.maybe_nudge("100.64.4.7", "100.64.4.1")
     first = n.last_nudge
-    assert first > 0                          # master + due -> sent
+    assert first > 0   # master + due -> sent
 
     role["master"] = False
     n.maybe_nudge("100.64.4.7", "100.64.4.1", force=True)
-    assert n.last_nudge == first              # backup: never nudge, even forced
+    assert n.last_nudge == first   # backup: never nudge, even forced
 
 
 def test_nudge_off_by_default(lk):
@@ -488,7 +488,7 @@ def test_nudge_respects_interval_and_force(lk):
     keeper._arp_nudge()
     first = keeper._nudge.last_nudge
     assert first > 0
-    keeper._arp_nudge()             # within the interval -> skipped
+    keeper._arp_nudge()   # within the interval -> skipped
     assert keeper._nudge.last_nudge == first
     keeper._arp_nudge(force=True)   # forced (BOUND/RENEW/REBIND) -> sent
     assert keeper._nudge.last_nudge > first
@@ -496,19 +496,19 @@ def test_nudge_respects_interval_and_force(lk):
 
 def test_nudge_requires_gateway_and_lease(lk):
     keeper = _nudge_keeper(lk)
-    keeper._dhcp.server = None            # no router option and no server_id -> no target
+    keeper._dhcp.binding.server = None   # no router option and no server_id -> no target
     keeper._arp_nudge(force=True)
     assert keeper._nudge.last_nudge == 0.0
-    keeper._dhcp.server = "100.64.4.1"
-    keeper._dhcp.yiaddr = None            # not bound -> no source address
+    keeper._dhcp.binding.server = "100.64.4.1"
+    keeper._dhcp.binding.yiaddr = None   # not bound -> no source address
     keeper._arp_nudge(force=True)
     assert keeper._nudge.last_nudge == 0.0
 
 
 def test_nudge_works_from_router_option_alone(lk):
     keeper = _nudge_keeper(lk)
-    keeper._dhcp.server = None
-    keeper._dhcp.router = "100.64.4.254"   # DHCP option 3 alone is a valid target
+    keeper._dhcp.binding.server = None
+    keeper._dhcp.binding.router = "100.64.4.254"   # DHCP option 3 alone is a valid target
     keeper._arp_nudge(force=True)
     assert keeper._nudge.last_nudge > 0
 
@@ -529,8 +529,8 @@ def test_probe_failure_skips_nudge(lk, monkeypatch):
     # A failed probe reports None, and the nudge fails closed on anything but
     # a confirmed MASTER.
     keeper = _keeper(lk, vhid=199, arp_nudge=240)
-    keeper._dhcp.yiaddr = "100.64.4.7"
-    keeper._dhcp.server = "100.64.4.1"
+    keeper._dhcp.binding.yiaddr = "100.64.4.7"
+    keeper._dhcp.binding.server = "100.64.4.1"
 
     def boom(*a, **k):
         raise OSError("ifconfig unavailable")
@@ -543,7 +543,7 @@ def test_probe_failure_skips_nudge(lk, monkeypatch):
 def test_hb_nudge_tokens_present(lk, tmp_path):
     hb = tmp_path / "hb"
     keeper = _nudge_keeper(lk, hbfile=str(hb))
-    keeper._dhcp.router = "100.64.4.1"
+    keeper._dhcp.binding.router = "100.64.4.1"
     keeper._nudge.last_nudge = 1783350000.0
     keeper._nudge.last_reply = 1783350050.0
     keeper._hb()
@@ -556,7 +556,7 @@ def test_hb_nudge_tokens_present(lk, tmp_path):
 def test_hb_nudge_zeros_when_never_and_no_target(lk, tmp_path):
     hb = tmp_path / "hb"
     keeper = _nudge_keeper(lk, hbfile=str(hb))
-    keeper._dhcp.server = None             # enabled, but no target and nothing sent yet
+    keeper._dhcp.binding.server = None   # enabled, but no target and nothing sent yet
     keeper._hb()
     content = hb.read_text()
     assert " nudge=0" in content
@@ -577,15 +577,15 @@ def test_master_transition_renews_early_and_nudges(lk):
     keeper = _nudge_keeper(lk, vhid=199)
     states = iter([True, False, True, True, True])
     keeper._probe_carp_master = lambda: next(states)
-    keeper._poll_carp_role()             # master from the start -> no transition
+    keeper._poll_carp_role()   # master from the start -> no transition
     assert keeper._renew_asap is False
     assert keeper._nudge.last_nudge == 0.0
-    keeper._poll_carp_role()             # backup -> remembers the role
-    keeper._poll_carp_role()             # backup -> master (the forced nudge probes again)
+    keeper._poll_carp_role()   # backup -> remembers the role
+    keeper._poll_carp_role()   # backup -> master (the forced nudge probes again)
     assert keeper._renew_asap is True
     first = keeper._nudge.last_nudge
     assert first > 0
-    keeper._poll_carp_role()             # still master -> nothing new
+    keeper._poll_carp_role()   # still master -> nothing new
     assert keeper._nudge.last_nudge == first
 
 
@@ -621,7 +621,7 @@ def test_hold_returns_early_for_asap_renew(lk):
 
 def test_sigusr1_flag_services_nudge_within_a_second(lk, caplog):
     keeper = _nudge_keeper(lk)
-    keeper._nudge_now = True             # what the SIGUSR1 handler sets
+    keeper._nudge_now = True   # what the SIGUSR1 handler sets
     with caplog.at_level("INFO", logger="lease-keeper"):
         keeper._sleep_interruptible(1)
     assert keeper._nudge_now is False
@@ -634,14 +634,14 @@ def test_sigusr2_flag_rechecks_carp_role_within_a_second(lk):
     keeper = _nudge_keeper(lk, vhid=199)
     calls = {"n": 0}
 
-    def probe():                          # backup on the first probe, master after
+    def probe():   # backup on the first probe, master after
         calls["n"] += 1
         return calls["n"] > 1
     keeper._probe_carp_master = probe
-    keeper._poll_carp_role()              # first observation: records backup
+    keeper._poll_carp_role()   # first observation: records backup
     assert keeper._renew_asap is False
     keeper._poll_role_now = True          # what the SIGUSR2 handler sets on a CARP event
-    keeper._sleep_interruptible(1)                # services the flag -> re-check -> transition
+    keeper._sleep_interruptible(1)   # services the flag -> re-check -> transition
     assert keeper._poll_role_now is False
     assert keeper._renew_asap is True     # backup->master: renew early
     assert keeper._nudge.last_nudge > 0         # and nudge immediately
@@ -649,7 +649,7 @@ def test_sigusr2_flag_rechecks_carp_role_within_a_second(lk):
 
 def test_nudge_missing_gateway_warns_once(lk, caplog):
     keeper = _nudge_keeper(lk)
-    keeper._dhcp.server = None             # enabled + bound, but no target
+    keeper._dhcp.binding.server = None   # enabled + bound, but no target
     with caplog.at_level("WARNING", logger="lease-keeper"):
         keeper._arp_nudge(force=True)
         keeper._arp_nudge(force=True)
@@ -675,7 +675,7 @@ class _ArpPkt:
 
 def test_arp_reply_ignores_unrelated(lk):
     keeper = _nudge_keeper(lk)
-    keeper._dhcp.router = "100.64.4.254"
+    keeper._dhcp.binding.router = "100.64.4.254"
     keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.9", "100.64.4.7"))    # wrong sender
     keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.254", "100.64.4.99"))  # wrong target IP
     keeper._on_sniff(_ArpPkt(lk, 1, "100.64.4.254", "100.64.4.7"))   # a request, not a reply
@@ -686,7 +686,7 @@ def test_arp_reply_stamps_reachability_and_logs(lk, caplog):
     # A matching is-at reply from the nudge target, dispatched through the
     # sniffer path, stamps the reachability epoch and logs at DEBUG.
     keeper = _nudge_keeper(lk)
-    keeper._dhcp.router = "100.64.4.1"
+    keeper._dhcp.binding.router = "100.64.4.1"
     with caplog.at_level("DEBUG", logger="lease-keeper"):
         keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
     assert keeper._nudge.last_reply > 0
@@ -696,7 +696,7 @@ def test_arp_reply_stamps_reachability_and_logs(lk, caplog):
 def test_sniffer_filter_is_static(lk):
     # A fixed BPF boundary: DHCP + ARP replies (nudge reachability), no lease dependence.
     assert "port 67 or port 68" in lk.SNIFFER_FILTER      # DHCP clause
-    assert "arp[6:2] = 2" in lk.SNIFFER_FILTER            # reachability clause
+    assert "arp[6:2] = 2" in lk.SNIFFER_FILTER   # reachability clause
 
 
 def test_sniffer_filter_captures_arp_and_honours_promisc(lk, monkeypatch):
@@ -729,7 +729,7 @@ def _ack_gw(lk, yiaddr, router, server="100.64.4.1", mask=None):
 
 def test_follow_across_subnet_with_mask(lk, tmp_path, caplog):
     keeper = _follow_keeper(lk, tmp_path)
-    keeper._dhcp.router = "100.64.4.1"
+    keeper._dhcp.binding.router = "100.64.4.1"
     with caplog.at_level("WARNING", logger="lease-keeper"):
         assert keeper._follow.on_changed_address(
             "100.64.5.60", _ack_gw(lk, "100.64.5.60", "100.64.5.1", mask="255.255.255.0"),
@@ -741,7 +741,7 @@ def test_follow_across_subnet_with_mask(lk, tmp_path, caplog):
 
 def test_follow_gateway_change_without_mask_warns(lk, tmp_path, caplog):
     keeper = _follow_keeper(lk, tmp_path)
-    keeper._dhcp.router = "100.64.4.1"
+    keeper._dhcp.binding.router = "100.64.4.1"
     with caplog.at_level("ERROR", logger="lease-keeper"):   # no mask in the ACK
         keeper._follow.on_changed_address(
             "100.64.5.60", _ack_gw(lk, "100.64.5.60", "100.64.5.1"), "DORA", True)
@@ -752,7 +752,7 @@ def test_follow_gateway_change_without_mask_warns(lk, tmp_path, caplog):
 
 def test_follow_no_gateway_change_no_extra_args(lk, tmp_path):
     keeper = _follow_keeper(lk, tmp_path)
-    keeper._dhcp.router = "100.64.4.1"
+    keeper._dhcp.binding.router = "100.64.4.1"
     keeper._follow.on_changed_address(          # same gateway -> no cross-subnet extras
         "100.64.4.60", _ack_gw(lk, "100.64.4.60", "100.64.4.1"), "DORA", True)
     assert keeper._follow._gw_args == []
@@ -802,18 +802,18 @@ def test_absorb_reply_captures_gw_and_mask(lk):
     rx = lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None,
                       "100.64.4.1", None, "255.255.255.0")
     c._absorb_reply(rx, lk.DEFAULT_LEASE)
-    assert c.router == "100.64.4.1"
-    assert c.mask_bits == 24
+    assert c.binding.router == "100.64.4.1"
+    assert c.binding.mask_bits == 24
 
 
 def test_renew_omits_server_id_and_requested_addr(lk):
     # RFC 2131 §4.3.2: a RENEWING/REBINDING REQUEST MUST NOT carry server_id or
     # requested_addr, and ciaddr MUST be the client's address.
     c = _client(lk)
-    c.server, c.yiaddr, c.lease = "100.64.4.1", "100.64.4.7", 1800
+    c.binding.server, c.binding.yiaddr, c.binding.lease_secs = "100.64.4.1", "100.64.4.7", 1800
     c._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
-        lk.ACK, c.yiaddr, c.server, 1800, None, None, None)
-    assert c.renew() is True            # RENEW (T1)
+        lk.ACK, c.binding.yiaddr, c.binding.server, 1800, None, None, None)
+    assert c.renew() is True   # RENEW (T1)
     assert c.renew(rebind=True) is True  # REBIND (T2)
     assert c.sent, "renew sent nothing"
     for mtype, extra, ciaddr in c.sent:

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1,4 +1,4 @@
-"""Unit tests for the lease-keeper daemon's pure helpers and follow decision.
+"""Unit tests for the lease_keeper daemon's pure helpers and follow decision.
 
 Tests reach into private state/methods by design, and use comments over
 per-test docstrings."""

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -207,12 +207,12 @@ def test_check_link_returned_debounce(lk, monkeypatch):
 
 def _follow_keeper(lk, tmp_path):
     keeper = lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", hbfile=None, follow=True)
-    keeper._follow_state = str(tmp_path / "follow_state")
+    keeper._follow._state_file = str(tmp_path / "follow_state")
     keeper._dhcp.server = "100.64.4.1"
     keeper._dhcp.yiaddr = "100.64.4.7"
     keeper.fired = []
-    keeper._follow_update = keeper.fired.append
-    keeper._hb_mismatch = lambda got: None
+    keeper._follow._follow_update = keeper.fired.append
+    keeper._follow._hb_mismatch = lambda got, want: None
     keeper._dhcp.release = lambda *a: None
     return keeper
 
@@ -277,29 +277,29 @@ def test_dhcpnak_logs_reason(lk, caplog, message, expect):
 
 def test_follow_accepts_same_class(lk, tmp_path):
     keeper = _follow_keeper(lk, tmp_path)
-    assert keeper._handle_changed_address("100.64.4.60", _ack(lk, "100.64.4.60"), "DORA", True) is True
+    assert keeper._follow.on_changed_address("100.64.4.60", _ack(lk, "100.64.4.60"), "DORA", True) is True
     assert keeper.fired == ["100.64.4.60"]
-    assert keeper.request_ip == "100.64.4.60"
+    assert keeper._follow.target == "100.64.4.60"
 
 
 def test_follow_rejects_wrong_server(lk, tmp_path):
     keeper = _follow_keeper(lk, tmp_path)
     reply = _ack(lk, "100.64.4.60", server="100.64.4.9")
-    assert keeper._handle_changed_address("100.64.4.60", reply, "DORA", True) is False
+    assert keeper._follow.on_changed_address("100.64.4.60", reply, "DORA", True) is False
     assert keeper.fired == []
 
 
 def test_follow_rejects_cross_class(lk, tmp_path):
     keeper = _follow_keeper(lk, tmp_path)
-    assert keeper._handle_changed_address("8.8.8.8", _ack(lk, "8.8.8.8"), "DORA", True) is False
+    assert keeper._follow.on_changed_address("8.8.8.8", _ack(lk, "8.8.8.8"), "DORA", True) is False
     assert keeper.fired == []
 
 
 def test_follow_throttled_within_interval(lk, tmp_path):
     keeper = _follow_keeper(lk, tmp_path)
-    assert keeper._handle_changed_address("100.64.4.60", _ack(lk, "100.64.4.60"), "DORA", True) is True
+    assert keeper._follow.on_changed_address("100.64.4.60", _ack(lk, "100.64.4.60"), "DORA", True) is True
     # A second follow inside MIN_FOLLOW_INTERVAL is deferred.
-    assert keeper._handle_changed_address("100.64.4.61", _ack(lk, "100.64.4.61"), "DORA", True) is False
+    assert keeper._follow.on_changed_address("100.64.4.61", _ack(lk, "100.64.4.61"), "DORA", True) is False
 
 
 def test_enforce_mismatch_refused(lk):
@@ -308,7 +308,7 @@ def test_enforce_mismatch_refused(lk):
     keeper._dhcp.yiaddr = "100.64.4.7"
     released = []
     keeper._dhcp.release = lambda *a: released.append(a)
-    assert keeper._handle_changed_address("100.64.4.60", _ack(lk, "100.64.4.60"), "DORA", True) is False
+    assert keeper._follow.on_changed_address("100.64.4.60", _ack(lk, "100.64.4.60"), "DORA", True) is False
     assert released == [("100.64.4.60", "100.64.4.1")]  # the refused grant is released...
     assert keeper._dhcp.yiaddr is None                  # ...and not held (run loop re-acquires)
 
@@ -335,8 +335,8 @@ def test_observed_peer_ack_records_change_and_wakes(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
     assert not keeper._wake.is_set()
     keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60"))
-    assert keeper._observed_change is not None
-    assert keeper._observed_change.yiaddr == "100.64.4.60"
+    assert keeper._follow._observed is not None
+    assert keeper._follow._observed.yiaddr == "100.64.4.60"
     assert keeper._dhcp._rx is None          # the first-party slot is untouched
     assert keeper._wake.is_set()       # ...and the maintain-loop sleep is woken at once
 
@@ -344,14 +344,14 @@ def test_observed_peer_ack_records_change_and_wakes(lk, tmp_path):
 def test_ignored_observation_does_not_wake(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
     keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.7"))     # same address -> no change
-    assert keeper._observed_change is None
+    assert keeper._follow._observed is None
     assert not keeper._wake.is_set()
 
 
 def test_observed_ignores_wrong_chaddr(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
     keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60", chaddr=b"\xaa\xbb\xcc\xdd\xee\xff"))
-    assert keeper._observed_change is None
+    assert keeper._follow._observed is None
 
 
 def test_observed_ignores_non_ack(lk, tmp_path):
@@ -359,7 +359,7 @@ def test_observed_ignores_non_ack(lk, tmp_path):
     keeper._on_dhcp_reply(_DhcpPkt(lk, 0x22222222,
                                    [("message-type", lk.OFFER), ("server_id", "100.64.4.1"), "end"],
                                    yiaddr="100.64.4.60"))
-    assert keeper._observed_change is None
+    assert keeper._follow._observed is None
 
 
 def test_observed_ignored_when_not_follow(lk):
@@ -368,7 +368,7 @@ def test_observed_ignored_when_not_follow(lk):
     keeper._dhcp.yiaddr = "100.64.4.7"
     keeper._dhcp.xid = 0x11111111
     keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60"))
-    assert keeper._observed_change is None
+    assert keeper._follow._observed is None
 
 
 def test_own_xid_reply_uses_first_party_path(lk, tmp_path):
@@ -376,7 +376,7 @@ def test_own_xid_reply_uses_first_party_path(lk, tmp_path):
     keeper._on_dhcp_reply(_DhcpPkt(lk, keeper._dhcp.xid,
                                    [("message-type", lk.ACK), ("server_id", "100.64.4.1"), "end"],
                                    yiaddr="100.64.4.60"))
-    assert keeper._observed_change is None            # not the observed path
+    assert keeper._follow._observed is None            # not the observed path
     assert keeper._dhcp._rx is not None and keeper._dhcp._rx.yiaddr == "100.64.4.60"
 
 
@@ -387,10 +387,10 @@ def test_observed_latest_wins(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
     keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60"))
     keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.61"))
-    assert keeper._observed_change.yiaddr == "100.64.4.61"
-    keeper._check_observed_follow()
+    assert keeper._follow._observed.yiaddr == "100.64.4.61"
+    keeper._follow.check_observed()
     assert keeper.fired == ["100.64.4.61"]
-    assert keeper._observed_change is None
+    assert keeper._follow._observed is None
 
 
 def test_observed_same_address_after_follow_is_dropped(lk, tmp_path):
@@ -398,31 +398,31 @@ def test_observed_same_address_after_follow_is_dropped(lk, tmp_path):
     # same address is a no-op (the == self.yiaddr guard), never a double-follow.
     keeper = _observe_keeper(lk, tmp_path)
     keeper._dhcp.yiaddr = "100.64.4.61"                 # we already hold the new address
-    keeper._observed_change = _ack(lk, "100.64.4.61")
-    keeper._check_observed_follow()
+    keeper._follow._observed = _ack(lk, "100.64.4.61")
+    keeper._follow.check_observed()
     assert keeper.fired == []                     # no redundant follow
-    assert keeper._observed_change is None
+    assert keeper._follow._observed is None
 
 
 def test_check_observed_follow_drives_hardened_follow(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
-    keeper._observed_change = _ack(lk, "100.64.4.60")
-    keeper._check_observed_follow()
+    keeper._follow._observed = _ack(lk, "100.64.4.60")
+    keeper._follow.check_observed()
     assert keeper.fired == ["100.64.4.60"]
-    assert keeper.request_ip == "100.64.4.60"
-    assert keeper._observed_change is None
+    assert keeper._follow.target == "100.64.4.60"
+    assert keeper._follow._observed is None
 
 
 def test_check_observed_follow_rejects_wrong_server(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
-    keeper._observed_change = _ack(lk, "100.64.4.60", server="100.64.4.9")  # not our server
-    keeper._check_observed_follow()
+    keeper._follow._observed = _ack(lk, "100.64.4.60", server="100.64.4.9")  # not our server
+    keeper._follow.check_observed()
     assert keeper.fired == []          # same hardening as a first-party ACK
 
 
 def test_observed_serviced_by_maintain_loop(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
-    keeper._observed_change = _ack(lk, "100.64.4.60")
+    keeper._follow._observed = _ack(lk, "100.64.4.60")
     keeper._wake.set()                 # as the sniffer would -> loop returns at once
     keeper._sleep_interruptible(1)
     assert keeper.fired == ["100.64.4.60"]
@@ -729,11 +729,11 @@ def test_follow_across_subnet_with_mask(lk, tmp_path, caplog):
     keeper = _follow_keeper(lk, tmp_path)
     keeper._dhcp.router = "100.64.4.1"
     with caplog.at_level("WARNING", logger="lease-keeper"):
-        assert keeper._handle_changed_address(
+        assert keeper._follow.on_changed_address(
             "100.64.5.60", _ack_gw(lk, "100.64.5.60", "100.64.5.1", mask="255.255.255.0"),
             "DORA", True) is True
     # gateway + prefix are handed to follow_update so outbound follows the new subnet
-    assert keeper._follow_gw_args == ["100.64.4.1", "100.64.5.1", "24"]
+    assert keeper._follow._gw_args == ["100.64.4.1", "100.64.5.1", "24"]
     assert any("following across the subnet" in r.getMessage() for r in caplog.records)
 
 
@@ -741,19 +741,19 @@ def test_follow_gateway_change_without_mask_warns(lk, tmp_path, caplog):
     keeper = _follow_keeper(lk, tmp_path)
     keeper._dhcp.router = "100.64.4.1"
     with caplog.at_level("ERROR", logger="lease-keeper"):   # no mask in the ACK
-        keeper._handle_changed_address(
+        keeper._follow.on_changed_address(
             "100.64.5.60", _ack_gw(lk, "100.64.5.60", "100.64.5.1"), "DORA", True)
     # without a mask we can't set the prefix: address-only follow + a fix-by-hand warning
-    assert keeper._follow_gw_args == []
+    assert keeper._follow._gw_args == []
     assert any("carried no subnet mask" in r.getMessage() for r in caplog.records)
 
 
 def test_follow_no_gateway_change_no_extra_args(lk, tmp_path):
     keeper = _follow_keeper(lk, tmp_path)
     keeper._dhcp.router = "100.64.4.1"
-    keeper._handle_changed_address(          # same gateway -> no cross-subnet extras
+    keeper._follow.on_changed_address(          # same gateway -> no cross-subnet extras
         "100.64.4.60", _ack_gw(lk, "100.64.4.60", "100.64.4.1"), "DORA", True)
-    assert keeper._follow_gw_args == []
+    assert keeper._follow._gw_args == []
 
 
 def test_follow_update_action_arity():

--- a/net/os-carp-vip-dhcp/tests/test_logparse.py
+++ b/net/os-carp-vip-dhcp/tests/test_logparse.py
@@ -1,5 +1,6 @@
-"""Unit tests for logparse.py log-line parsing."""
-import logparse
+"""Unit tests for logparse.py log-line parsing (comments over docstrings)."""
+# pylint: disable=missing-function-docstring
+import logparse  # sys.path via conftest  # type: ignore  # pylint: disable=import-error
 
 
 def test_line_re_matches_standard_line():

--- a/net/os-carp-vip-dhcp/tests/test_status.py
+++ b/net/os-carp-vip-dhcp/tests/test_status.py
@@ -1,7 +1,8 @@
-"""Unit tests for status.py heartbeat / keeper-id parsing."""
+"""Unit tests for status.py heartbeat / keeper-id parsing (comments over docstrings)."""
+# pylint: disable=missing-function-docstring
 import time
 
-import status
+import status  # sys.path via conftest  # type: ignore  # pylint: disable=import-error
 
 
 def test_keeper_id():
@@ -84,10 +85,10 @@ def test_read_keepers_arp_nudge_field(tmp_path, monkeypatch):
     assert keepers[1]["arp_nudge"] == 0
 
 
-def _write_hb(path, arpok_age, now, arp_nudge=240):
+def _write_hb(path, arpok_age, now):
     path.write_text(
-        "%d bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived nudge=%d arpok=%d gw=100.64.4.1\n"
-        % (now, now - 5, now - arpok_age))
+        f"{now} bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived"
+        f" nudge={now - 5} arpok={now - arpok_age} gw=100.64.4.1\n")
 
 
 def test_read_keepers_arp_confirmed_fresh_and_stale(tmp_path, monkeypatch):
@@ -102,8 +103,8 @@ def test_read_keepers_arp_confirmed_fresh_and_stale(tmp_path, monkeypatch):
     _write_hb(tmp_path / "carpvipdhcp-100_64_4_7.hb", 5, now)       # 5s ago -> fresh
     _write_hb(tmp_path / "carpvipdhcp-100_64_4_8.hb", 5000, now)    # 5000s ago -> stale
     (tmp_path / "carpvipdhcp-100_64_4_9.hb").write_text(
-        "%d bound=100.64.4.9 lease=1800 t1=900 t2=1575 src=derived nudge=%d arpok=0 gw=100.64.4.1\n"
-        % (now, now - 5))                                          # arpok=0 -> never
+        f"{now} bound=100.64.4.9 lease=1800 t1=900 t2=1575 src=derived"
+        f" nudge={now - 5} arpok=0 gw=100.64.4.1\n")                                          # arpok=0 -> never
     by_ip = {k["request"]: k for k in status.read_keepers({}, {})}
     assert by_ip["100.64.4.7"]["arp_confirmed"] is True
     assert by_ip["100.64.4.8"]["arp_confirmed"] is False

--- a/net/os-carp-vip-dhcp/tests/test_status.py
+++ b/net/os-carp-vip-dhcp/tests/test_status.py
@@ -104,7 +104,7 @@ def test_read_keepers_arp_confirmed_fresh_and_stale(tmp_path, monkeypatch):
     _write_hb(tmp_path / "carpvipdhcp-100_64_4_8.hb", 5000, now)    # 5000s ago -> stale
     (tmp_path / "carpvipdhcp-100_64_4_9.hb").write_text(
         f"{now} bound=100.64.4.9 lease=1800 t1=900 t2=1575 src=derived"
-        f" nudge={now - 5} arpok=0 gw=100.64.4.1\n")                                          # arpok=0 -> never
+        f" nudge={now - 5} arpok=0 gw=100.64.4.1\n")   # arpok=0 -> never
     by_ip = {k["request"]: k for k in status.read_keepers({}, {})}
     assert by_ip["100.64.4.7"]["arp_confirmed"] is True
     assert by_ip["100.64.4.8"]["arp_confirmed"] is False


### PR DESCRIPTION
## What

This PR completes the Keeper restructuring started in 1.8.1 (wire codec) and 1.8.2 (ArpNudge), and brings the whole plugin to a clean lint/type-check baseline. It grew beyond the original DhcpClient scope during review; the commits tell the story in order.

### Components (behaviour preserved)

- `DhcpClient` owns the lease state and the protocol sequences (INIT-REBOOT, DORA as its two RFC phases `_discover`/`_request_offer`, RENEW, REBIND, RELEASE) plus send/await and lease timing. Keeper feeds it xid-matched replies via `feed()`; policy hooks are injected. `adopt()`/`expire()` name the bind and unbind transitions.
- `FollowPolicy` owns the changed-address decision (follow AND enforce arms), the target address (the old `request_ip` had two owners: follow rewrote it, acquire read it), the persisted throttle, the configd dispatch with retry watchdog, and the peer-ACK observation handoff.
- `Lease` groups the client's seven lease fields into one binding value (address, server, duration, T1/T2, routing facts), so the held binding reads and logs as a whole. yiaddr None still means unbound; expire() clears only the address so the routing hints survive to the next bind. The INIT-REBOOT bind now routes through `adopt()` too, so one place defines the bind and the server-fallback rule.
- `Keeper` is orchestration only: sniffer owner, heartbeat, CARP role watch, acquire pacing (backoff + link-return fast path), and a public signal API (`request_stop`/`trigger_nudge`/`recheck_carp_role`) so the handlers no longer poke private flags. Down from ~44 mutable attributes at the start of this series to 21, each remaining domain with one owner.

### Daemon rename

`lease-keeper.py` becomes `lease_keeper.py` (upstream uses plain or underscored script names; the dash was this plugin's own deviation). The rc.d wrapper's pgrep matches both spellings so a stop/restart during the package upgrade still finds a daemon started under the old path.

### Lint and type-check baseline

- pyright: 0 errors. pylint: 10.00/10 including a useless-suppression audit. flake8 clean at the documented 120 columns.
- A repo-root `.pylintrc` carries ONLY project-wide conventions (120 columns, the recurring short wire names); every deviation from the strict defaults is an inline pragma at its site, with the considered alternative noted where one was rejected.
- Real fixes over suppressions where a better form existed: table-driven heartbeat token parse in status.py, a shared `keeperconf.py` (conf path, keeper-id transform, line parser) for the configd scripts instead of three copies, `_atomic_write`/`_stop_sniffer` helpers instead of repeated idioms, dora split into its RFC phases instead of a return-count pragma, main() split into parser/logging/once-mode.
- Named wire constants (ETHER_BROADCAST, IPV4_BROADCAST, the DHCP port pair; the BPF filter derives from them).

### Review passes

Three /simplify rounds ran over the series. The important catch: the enforce path had lost its unbind in the extraction (DORA's OFFER phase records a tentative yiaddr; refusing the grant must drop it or the run loop would renew a released address) -- fixed via `expire()` and locked by a test asserting both the release arguments and the unbind.

## Testing

- 86 unit tests (direct component tests for DhcpClient/ArpNudge via a bare-construction helper, plus the Keeper-level integration tests), flake8/pylint/pyright as above.
- Lab, isolated fake-DHCP bench: link-return suite 8/8 and ARP-nudge wire suite 6/6, re-run on the heads along the way.
- Lab, real-WAN HA bench: full follow suite through configd 4/4 (same-subnet, cross-subnet with prefix rewrite, idempotent retry, arity canary) on the FollowPolicy-bearing code.
- The final-head battery result is posted as a PR comment when it completes.

Version bump 1.8.2 to 1.8.3 (refactor, behaviour preserved). Note for the reviewer: given the daemon-file rename is packaging-visible, say the word if you would rather ship this as 1.9.0.

