### PR TITLE
net/os-carp-vip-dhcp: follow runs the post-address-change notifications; two follow_update bugs (1.8.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,13 @@ When **Follow dynamic DHCP address** is on (default) and the server assigns a di
 1. In the keeper, set **Sync firewall alias** to a name (e.g. `wan_carp_vip`). The plugin creates a Host alias of that name and keeps it equal to the VIP's current address.
 2. Point your **outbound NAT** translation address — and any rule that must follow — at that **alias** instead of a literal IP. On a follow, the plugin updates the alias and reapplies the filter (state-preserving), so rules track the new address.
 
+A follow also runs the system's **newwanip hooks** for the VIP's interface, so consumers such as dynamic DNS and VPN endpoints learn the new address the same way they would after a native lease change.
+
 The alias is created/updated automatically and never deleted (it may be referenced elsewhere).
 
 **Inbound is different:** a **port-forward cannot follow** a dynamic address — the upstream only routes inbound to the address it has reserved. Follow keeps *outbound* online; inbound services need a stable reserved address.
 
-A **cross-subnet** renumber is the one case follow can't fully handle: it rewrites the VIP *address* but not the interface prefix or System → Gateways, so if the ISP also moves the gateway you must update those by hand (the keeper logs a loud warning when it sees the gateway change).
+A **cross-subnet** renumber is handled too: when the ACK moves the gateway, the plugin also updates the VIP prefix and the WAN gateway from the ACK's subnet mask and gateway, and reapplies routing. The one gap left is an ACK that changes the gateway **without** carrying a subnet mask — then only the address moves and the keeper logs a loud warning to fix the interface prefix and System → Gateways by hand.
 
 **HA note:** firewall aliases are covered by OPNsense HA config sync, so an alias update propagates to the backup too. The CARP VIP itself is intentionally *not* synced (`advskew` differs per node).
 

--- a/README.md
+++ b/README.md
@@ -136,13 +136,14 @@ When **Follow dynamic DHCP address** is on (default) and the server assigns a di
 1. In the keeper, set **Sync firewall alias** to a name (e.g. `wan_carp_vip`). The plugin creates a Host alias of that name and keeps it equal to the VIP's current address.
 2. Point your **outbound NAT** translation address — and any rule that must follow — at that **alias** instead of a literal IP. On a follow, the plugin updates the alias and reapplies the filter (state-preserving), so rules track the new address.
 
-A follow also runs the system's **newwanip hooks** for the VIP's interface, so consumers such as dynamic DNS and VPN endpoints learn the new address the same way they would after a native lease change.
 
 The alias is created/updated automatically and never deleted (it may be referenced elsewhere).
 
+A follow also runs the system's **newwanip hooks** for the VIP's interface, so consumers such as dynamic DNS and VPN endpoints learn the new address the same way they would after a native lease change.
+
 **Inbound is different:** a **port-forward cannot follow** a dynamic address — the upstream only routes inbound to the address it has reserved. Follow keeps *outbound* online; inbound services need a stable reserved address.
 
-A **cross-subnet** renumber is handled too: when the ACK moves the gateway, the plugin also updates the VIP prefix and the WAN gateway from the ACK's subnet mask and gateway, and reapplies routing. The one gap left is an ACK that changes the gateway **without** carrying a subnet mask — then only the address moves and the keeper logs a loud warning to fix the interface prefix and System → Gateways by hand.
+A **cross-subnet** renumber is handled too: when the ACK moves the gateway, the plugin also updates the VIP prefix and the WAN gateway from the ACK's subnet mask and gateway, and reapplies routing. The one gap left is an ACK that changes the gateway **without** carrying a subnet mask: then only the address moves, and the keeper logs a loud warning to fix the interface prefix and System > Gateways by hand.
 
 **HA note:** firewall aliases are covered by OPNsense HA config sync, so an alias update propagates to the backup too. The CARP VIP itself is intentionally *not* synced (`advskew` differs per node).
 

--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.8.3
+PLUGIN_VERSION=         1.8.4
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
@@ -14,6 +14,16 @@
  * new prefix length: the VIP's subnet_bits and the WAN gateway are updated too
  * and routing is reapplied, so outbound keeps working (parity with a plain DHCP
  * interface). Same-subnet moves omit those args and touch only the address.
+ *
+ * After the move the registered newwanip plugin hooks run for the VIP's
+ * interface (dynamic DNS, VPN endpoints, ...), completing the parity: those
+ * consumers learn about the new address just as they would after a native
+ * lease change. "newwanip" is a historical name: the chain is per-interface
+ * and the consumers self-select on the interface argument, so firing it is
+ * correct wherever the VIP lives (native DHCP on a non-WAN interface fires
+ * the same chain). Deliberately NOT rc.newwanip: on a dhcp-configured
+ * interface that would re-run interface_configure and disturb the native
+ * lease; the hook chain is the part the consumers need.
  */
 
 require_once("config.inc");
@@ -246,6 +256,20 @@ if ($rc !== 0) {
     // Non-fatal: the address has followed and CARP is advertising it; only the
     // firewall alias mirror lags. Surface it so `sync_aliases` can be re-run.
     fwrite(STDERR, "manage_alias failed (rc={$rc}): " . implode(' | ', $out) . "\n");
+}
+
+// Parity with a native address change: run the newwanip hooks for the VIP's
+// interface now that the VIP, routing, keepers and alias all agree (see the
+// header for why this is the hook chain and not rc.newwanip). Non-fatal: the
+// address has followed either way.
+if ($old_vip_iface !== '') {
+    // Marker BEFORE the hooks: a hook that hangs or gets the action killed
+    // must not hide that the chain was reached.
+    openlog('carpvipdhcp', LOG_ODELAY, LOG_USER);
+    syslog(LOG_NOTICE, "running newwanip hooks for {$old_vip_iface} after follow {$old_ip} -> {$new_ip}");
+    require_once("plugins.inc");
+    plugins_configure('newwanip', false, array($old_vip_iface));
+    syslog(LOG_NOTICE, "newwanip hooks for {$old_vip_iface} completed");
 }
 
 $msg = "updated CARP VIP {$old_ip} -> {$new_ip}";

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
@@ -151,6 +151,9 @@ if (!$vip_changed && !$keeper_changed && !$gw_changed) {
     foreach ($config['virtualip']['vip'] ?? [] as $vip) {
         if (($vip['mode'] ?? '') === 'carp' && ($vip['subnet'] ?? '') === $new_ip) {
             $already_migrated = true;
+            // The retry must also run the notification tail below (a crashed
+            // original may have died before it), so learn the interface here.
+            $old_vip_iface = $vip['interface'] ?? '';
             break;
         }
     }
@@ -202,6 +205,11 @@ if ($gw_changed) {
     } else {
         exec('/usr/local/sbin/configctl interface routes configure 2>&1');
     }
+    // The gateway moved: retarget its monitor too, or dpinger keeps probing
+    // the OLD gateway and flags it down (core's post-address-change sequence
+    // fires monitor alongside newwanip when the gateway changes).
+    require_once("plugins.inc");
+    plugins_configure('monitor');
 }
 
 // Re-render keeper.conf, then WAIT until it actually reflects new_ip before

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
@@ -86,6 +86,14 @@ $vip_changed = false;
 $keeper_changed = false;
 $old_vip_iface = '';
 
+// A single VIP deserializes as one associative array, not a list of one
+// (the same quirk the keeper section below handles). Normalize to a list so
+// the loops here and the already-migrated re-check see actual VIP entries;
+// write_config serializes a one-element list back to identical XML.
+if (isset($config['virtualip']['vip']['mode'])) {
+    $config['virtualip']['vip'] = [$config['virtualip']['vip']];
+}
+
 // 1. Rewrite the CARP VIP whose current subnet is old_ip.
 if (isset($config['virtualip']['vip']) && is_array($config['virtualip']['vip'])) {
     foreach ($config['virtualip']['vip'] as $idx => $vip) {

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
@@ -226,6 +226,15 @@ if (!$rendered_ok) {
     exit(1);
 }
 
+// Release the follow lock BEFORE starting daemons: PHP file descriptors are
+// not close-on-exec, so a keeper started below would inherit the lock fd and
+// hold the lock for its whole lifetime -- silently skipping every later
+// follow on this node. The section the lock protects (config write,
+// reconfigure, template render) is complete and consistent here; the restart
+// tail below is idempotent, so a racing late runner converges harmlessly.
+flock($lockfh, LOCK_UN);
+fclose($lockfh);
+
 // Replace only the keeper that just changed address, not every keeper on the
 // node. The daemon is keyed by a filesystem-safe id derived from its request IP,
 // so a follow renames it old_id -> new_id. We must stop old_id and start new_id

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/follow_update.php
@@ -111,20 +111,15 @@ if (isset($config['virtualip']['vip']) && is_array($config['virtualip']['vip']))
 // 2. Update every keeper that referenced the old address. Use direct assignment
 // (not a &reference to the subtree) so write_config serializes the change.
 if (isset($config['OPNsense']['CarpVipDhcp']['keepers']['keeper'])) {
+    // Same single-entry quirk as the VIPs above; normalize to a list once.
     $keepers = $config['OPNsense']['CarpVipDhcp']['keepers']['keeper'];
     if (isset($keepers['carpVip']) || isset($keepers['@attributes'])) {
-        // single keeper (associative)
-        if (($keepers['carpVip'] ?? '') === $old_ip) {
-            $config['OPNsense']['CarpVipDhcp']['keepers']['keeper']['carpVip'] = $new_ip;
+        $config['OPNsense']['CarpVipDhcp']['keepers']['keeper'] = [$keepers];
+    }
+    foreach ($config['OPNsense']['CarpVipDhcp']['keepers']['keeper'] as $k => $entry) {
+        if (($entry['carpVip'] ?? '') === $old_ip) {
+            $config['OPNsense']['CarpVipDhcp']['keepers']['keeper'][$k]['carpVip'] = $new_ip;
             $keeper_changed = true;
-        }
-    } else {
-        // list of keepers
-        foreach ($keepers as $k => $entry) {
-            if (($entry['carpVip'] ?? '') === $old_ip) {
-                $config['OPNsense']['CarpVipDhcp']['keepers']['keeper'][$k]['carpVip'] = $new_ip;
-                $keeper_changed = true;
-            }
         }
     }
 }
@@ -282,6 +277,8 @@ if ($rc !== 0) {
 if ($old_vip_iface !== '') {
     // Marker BEFORE the hooks: a hook that hangs or gets the action killed
     // must not hide that the chain was reached.
+    // The stable 'carpvipdhcp' ident is a greppable contract (the lab
+    // regression suite asserts the marker); log_msg would ident differently.
     openlog('carpvipdhcp', LOG_ODELAY, LOG_USER);
     syslog(LOG_NOTICE, "running newwanip hooks for {$old_vip_iface} after follow {$old_ip} -> {$new_ip}");
     require_once("plugins.inc");

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -4,6 +4,7 @@ Tests reach into private state/methods by design, and use comments over
 per-test docstrings."""
 # pylint: disable=protected-access, missing-function-docstring
 import os
+import re
 import time
 import types
 
@@ -769,8 +770,8 @@ def test_follow_update_fires_newwanip_hooks():
     with open(php, encoding="utf-8") as fh:
         src = fh.read()
     assert "plugins_configure('newwanip'" in src
-    assert "rc.newwanip" not in src.replace("NOT rc.newwanip", "").replace(
-        "not rc.newwanip", "")   # mentioned only as the documented non-choice
+    code = re.sub(r"/\*.*?\*/|//[^\n]*", "", src, flags=re.S)   # comments may discuss it
+    assert "rc.newwanip" not in code
 
 
 def test_follow_update_action_arity():

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -758,6 +758,21 @@ def test_follow_no_gateway_change_no_extra_args(lk, tmp_path):
     assert keeper._follow._gw_args == []
 
 
+def test_follow_update_fires_newwanip_hooks():
+    """A follow must run the newwanip plugin hooks for the VIP's interface
+    (dynamic DNS, VPN endpoints learn the new address -- the parity promise),
+    and must NOT invoke rc.newwanip, which would re-run interface_configure
+    and disturb a dhcp-configured WAN's native lease."""
+    php = os.path.join(
+        os.path.dirname(__file__), "..", "src", "opnsense", "scripts",
+        "OPNsense", "CarpVipDhcp", "follow_update.php")
+    with open(php, encoding="utf-8") as fh:
+        src = fh.read()
+    assert "plugins_configure('newwanip'" in src
+    assert "rc.newwanip" not in src.replace("NOT rc.newwanip", "").replace(
+        "not rc.newwanip", "")   # mentioned only as the documented non-choice
+
+
 def test_follow_update_action_arity():
     """The configd [follow_update] action must accept as many params as the
     daemon can send: _fire_follow_update passes old_ip + new_ip plus


### PR DESCRIPTION
## What

Closes the parity gap after a follow, and fixes two real follow_update bugs the lab bench surfaced while validating it.

### The feature: post-follow notifications

- After a follow (VIP, routing, keepers and alias all consistent), follow_update now runs the registered **newwanip plugin hooks** for the VIP's interface, so consumers such as dynamic DNS and VPN endpoints learn the new address exactly as they would after a native lease change. "newwanip" is a historical per-interface name: the consumers self-select on the interface argument, so this is correct wherever the VIP lives.
- Deliberately the hook chain and NOT rc.newwanip: on a dhcp-configured interface that would re-run interface_configure and disturb the native lease. A contract test pins both choices (hook call present, rc.newwanip never invoked).
- On a **cross-subnet** follow the **monitor hook** fires too: without it dpinger kept probing the OLD gateway and would flag it down. And the idempotent repair retry now also runs the notification tail (previously the interface was only learned in the rewrite path, so a follow whose original run crashed before the hooks left consumers unnotified forever).
- Syslog markers before and after the hook run (stable ident, greppable; the lab suite asserts it).

### Bug: the follow lock outlived the run

PHP file descriptors are not close-on-exec, so the keeper daemon started at the end of follow_update inherited the lock fd and held the follow lock for its whole lifetime. Every later follow on the node was silently skipped ("another follow_update is already running"). The lock now releases explicitly once the protected section (config write, reconfigure, template render) is complete; the restart tail is idempotent. Surfaced by a back-to-back run on the bench seconds after a clean exit.

### Bug: single-VIP config shape

One configured VIP deserializes as a single associative array, not a list of one. The VIP rewrite loop and the already-migrated re-check then iterated its FIELDS and silently no-opped (exit 0, config untouched): on a single-VIP node every follow did nothing. Normalized to a list up front (write_config serializes a one-element list back to identical XML); the keeper section now uses the same idiom instead of its bespoke branch.

### Docs

The landing page still described cross-subnet follow as unhandled ("update prefix and gateway by hand"), contradicting the implementation since the 1.6 line. Corrected, and the dynamic-address section documents the new hook behaviour.

## Testing

- 87 unit tests (new contract test for the hook/no-rc.newwanip choices), flake8/pylint 10.00/pyright 0 unchanged, php -l clean on the bench.
- Real-WAN HA bench, follow suite through configd: **5/5** including a new check that asserts the newwanip marker in the system log after the cross-subnet follow.
- The bench work also hardened the suite itself: the real-WAN bridge carries live ISP DHCP, and the old lock bug had been masking a race where the freshly started keeper followed the VIP away mid-test; the suite now cuts the clone's carrier for the config-level scenarios.

Version bump 1.8.3 to 1.8.4.