### PR TITLE
net/os-carp-vip-dhcp: hold the DHCP acquire while the link is down (1.8.5)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.8.4
+PLUGIN_VERSION=         1.8.5
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -111,7 +111,7 @@ RENEW_TIMEOUT = 3          # wait for an ACK during renew
 ATTEMPT_BACKOFF_CAP = 8    # max wait between acquire attempts
 SEND_RETRY_DELAY = 2       # wait after a failed packet send before retrying
 REBIND_POLL_STEP = 10      # how often to re-try RENEW during the REBIND window
-REDORA_MIN = 10            # initial wait after a failed acquire
+REDORA_MIN = 10            # initial wait after a failed acquire; also the hold-poll cadence while no carrier
 # Caps worst-case re-acquire lag at ~45s even if the link-return fast path (below)
 # is missed; the backoff doubles 10 -> 20 -> 40 -> 45.
 REDORA_MAX = 45            # max exponential-backoff wait after a failed acquire
@@ -1154,8 +1154,9 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
     def _iface_link_up(self):
         """Interface carrier from ifconfig: True on 'status: active', False on a
         present-but-inactive status (no carrier / no link), None when it cannot be
-        read (probe failed, or the NIC reports no status line). Used only by the
-        unbound link-return fast path; a None result never disturbs the backoff."""
+        read (probe failed, or the NIC reports no status line). Used by the
+        unbound link-return fast path and the acquire carrier gate; a None
+        result never disturbs the backoff and never holds an acquire."""
         out = self._ifconfig()
         if out is None:
             return None
@@ -1348,31 +1349,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         """One iteration of the maintain loop. Returns to run() (which loops again)
         on every state transition; any exception it raises is caught by run() and
         retried, so a transient fault can never terminate the keeper."""
-        # Acquire a lease if we do not hold one.
         b = self._dhcp.binding
         if not b.yiaddr:
-            self._ensure_sniffer()  # a dead sniffer would silently fail every DORA
-            self._hb()  # active but not holding yet -> publish bound=-
-            if self._dhcp.acquire(self._follow.target):
-                LOG.info("DHCP BOUND %s (lease=%ss, expires ~%s, server=%s, gw=%s, mask=%s)",
-                         b.yiaddr, b.lease_secs, _clock_at(b.lease_secs),
-                         b.server, b.router or "?",
-                         f"/{b.mask_bits}" if b.mask_bits else "none")
-                self._hb()
-                self._arp_nudge(force=True)
-                self.redora_wait = REDORA_MIN
-            else:
-                LOG.warning("DHCP acquire (DISCOVER/REQUEST) failed -- retrying in %ds", self.redora_wait)
-                self._link_returned = False
-                self._sleep_interruptible(_jittered(self.redora_wait))
-                if self._link_returned:
-                    # WAN carrier returned mid-backoff: re-acquire now instead of
-                    # waiting out the next backoff (matches native dhclient).
-                    LOG.info("WAN link returned while unbound -- re-acquiring now")
-                    self.redora_wait = REDORA_MIN
-                else:
-                    self.redora_wait = min(self.redora_wait * 2, REDORA_MAX)
+            self._acquire_step()
             return
+
         # Maintain: wait until T1, then RENEW; bail early on stop.
         t1, t2, src = self._dhcp.timing()
         # The renew/rebind plan is verbose and identical every cycle for a stable
@@ -1415,6 +1396,53 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
 
         LOG.error("DHCP lease expired -- re-acquiring (back to DISCOVER)")
         self._dhcp.expire()
+
+    def _acquire_step(self):
+        """The unbound arm of the maintain loop: hold while there is no
+        carrier, otherwise try one acquire with the jittered re-DORA backoff;
+        the link-return fast path cuts either wait short."""
+        self._ensure_sniffer()  # a dead sniffer would silently fail every DORA
+        self._hb()  # active but not holding yet -> publish bound=-
+
+        # No point broadcasting DISCOVERs on a dead link (native dhclient
+        # does not either): wait for the carrier instead of burning DORA
+        # attempts. The unbound sleep polls the link and the link-return
+        # fast path resumes within seconds of it coming back. Fail open:
+        # only a confirmed "no carrier" (False) holds the acquire; an
+        # unreadable probe (None) never blocks it.
+        if self._iface_link_up() is False:
+            if self._link_up is not False:   # log once per down-episode
+                LOG.info("no carrier on %s -- waiting for the link before the DHCP acquire",
+                         self.iface)
+            self._link_up = False
+            self._link_returned = False
+            self._sleep_interruptible(REDORA_MIN)
+            if self._link_returned:
+                LOG.info("WAN link returned while unbound -- re-acquiring now")
+                self.redora_wait = REDORA_MIN
+            return
+
+        b = self._dhcp.binding
+        if self._dhcp.acquire(self._follow.target):
+            self._link_up = True   # a completed DORA proves carrier
+            LOG.info("DHCP BOUND %s (lease=%ss, expires ~%s, server=%s, gw=%s, mask=%s)",
+                     b.yiaddr, b.lease_secs, _clock_at(b.lease_secs),
+                     b.server, b.router or "?",
+                     f"/{b.mask_bits}" if b.mask_bits else "none")
+            self._hb()
+            self._arp_nudge(force=True)
+            self.redora_wait = REDORA_MIN
+        else:
+            LOG.warning("DHCP acquire (DISCOVER/REQUEST) failed -- retrying in %ds", self.redora_wait)
+            self._link_returned = False
+            self._sleep_interruptible(_jittered(self.redora_wait))
+            if self._link_returned:
+                # WAN carrier returned mid-backoff: re-acquire now instead of
+                # waiting out the next backoff (matches native dhclient).
+                LOG.info("WAN link returned while unbound -- re-acquiring now")
+                self.redora_wait = REDORA_MIN
+            else:
+                self.redora_wait = min(self.redora_wait * 2, REDORA_MAX)
 
 
 def acquire_pidfile(path):

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -202,6 +202,65 @@ def test_check_link_returned_edge(lk):
     assert k._check_link_returned() is False
 
 
+def _gate_keeper(lk, carrier):
+    """Unbound keeper with a stubbed carrier probe and recorded acquire calls."""
+    k = _keeper(lk)
+    k._ensure_sniffer = lambda: None
+    k.acquired = []
+    k._dhcp.acquire = lambda rip: (k.acquired.append(rip), False)[1]
+    k._iface_link_up = lambda: carrier
+    k._sleep_interruptible = lambda secs: True
+    return k
+
+
+def test_maintain_holds_acquire_without_carrier(lk, caplog):
+    k = _gate_keeper(lk, carrier=False)
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        k._maintain_step()
+        k._maintain_step()
+    assert k.acquired == []                  # no DISCOVER burned on a dead link
+    assert k._link_up is False
+    # one INFO per down-episode, not per loop pass
+    waits = [r for r in caplog.records if "no carrier" in r.getMessage()]
+    assert len(waits) == 1
+
+
+def test_maintain_acquire_fails_open_on_unreadable_carrier(lk):
+    k = _gate_keeper(lk, carrier=None)
+    k._maintain_step()
+    assert k.acquired == ["100.64.4.7"]      # None never blocks the acquire
+
+
+def test_maintain_acquires_with_carrier(lk):
+    k = _gate_keeper(lk, carrier=True)
+    k._maintain_step()
+    assert k.acquired == ["100.64.4.7"]
+
+
+def test_bound_marks_carrier_up(lk):
+    # A completed DORA proves carrier: the last-carrier-state invariant stays
+    # honest so the next down-episode always logs its hold line.
+    k = _gate_keeper(lk, carrier=True)
+    k._link_up = False                       # stale from an earlier down-episode
+    k._dhcp.acquire = lambda rip: True
+    k._maintain_step()
+    assert k._link_up is True
+
+
+def test_carrier_wait_resumes_via_link_return(lk, caplog):
+    k = _gate_keeper(lk, carrier=False)
+    k.redora_wait = 40
+
+    def sleep_with_return(_secs):
+        k._link_returned = True              # what the fast path sets on the edge
+        return True
+    k._sleep_interruptible = sleep_with_return
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        k._maintain_step()
+    assert any("re-acquiring now" in r.getMessage() for r in caplog.records)
+    assert k.redora_wait == lk.REDORA_MIN    # backoff reset for the immediate retry
+
+
 def test_check_link_returned_debounce(lk, monkeypatch):
     k = _link_keeper(lk)
     monkeypatch.setattr(lk.time, "time", lambda: 1000.0)


### PR DESCRIPTION
## What

No point broadcasting DISCOVERs on a dead link, and native dhclient does not either: when the carrier probe confirms no link, the unbound arm now holds the acquire instead of burning DORA attempts, and the existing link-return fast path resumes it within seconds of the carrier coming back.

Design decisions:

- The gate lives in the Keeper's unbound arm (acquire pacing domain), one check per acquire cycle; DhcpClient stays carrier-ignorant. Per-attempt gating inside the protocol loops would couple them to carrier state for no real gain: carrier loss mid-DORA just times out as before, and in-flight attempts still succeed if the link returns mid-exchange.
- Fail open: only a confirmed no-carrier holds the acquire; an unreadable probe never blocks it.
- One INFO line per down-episode, using the existing last-carrier-state as the edge detector; the down-to-up resume logs the same kick line as the failed-acquire path, so operators see one vocabulary.
- A successful bind marks the carrier state up (a completed DORA proves carrier). The cleanup review caught that a stale carrier state could otherwise survive a bound period and silence the hold line on the NEXT down-episode, which is exactly the silence this feature exists to prevent; a test pins it.
- The unbound arm moves to its own _acquire_step, which also keeps the maintain loop inside the default design limits by structure.

## Testing

- 92 unit tests (five new: hold without carrier plus log-once, fail open on an unreadable probe, acquire with carrier, resume via link-return with backoff reset, bind marks carrier up), flake8/pylint 10.00/pyright 0.
- Lab, isolated fake-DHCP bench (on the NEW second bench host): link-return suite 8/8 on this exact head; scenario 2a exercises the gate end to end (keeper restarted with the link down holds quietly, carrier up resumes in ~5s, re-binds). ARP-nudge wire suite 6/6 on the pre-polish head (the delta since is the one-line bind marker and comment moves).

Version bump 1.8.4 to 1.8.5.