### PR TITLE
net/os-carp-vip-dhcp: pluggable capture backend, add a dependency-free raw /dev/bpf option (1.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Carrier access gear (BNG / access switches / OLTs) polices subscribers with mech
 
 - **IPv4 DHCP only.** DHCPv6 / IPv6 Neighbor Discovery are out of scope. The v6 side (e.g. a DHCPv6-PD prefix) does **not** float with the VIP, so after an IPv4 failover expect broken/asymmetric IPv6 on the surviving node until it re-acquires — plan v6 HA separately.
 - WAN is the typical — not required — placement.
-- Requires **root** (raw L2/BPF socket) and depends on **Scapy**.
+- Requires **root** (raw L2/BPF socket) and depends on **Scapy**. An experimental `bpf` capture backend (since 1.9.0) runs on a raw `/dev/bpf` descriptor with no Scapy dependency: opt in per host with `sysrc carpvipdhcp_backend=bpf` plus a service restart, and remove the variable (`sysrc -x carpvipdhcp_backend`) to return to the default Scapy backend.
 - **Shared-L2 exposure:** follow mode trusts the DHCP ACK, so on a genuinely shared segment a neighbour who can read the CARP adverts could forge one to relocate the VIP (the same untrusted-shared-L2 risk a plain firewall shares). Moot where the ISP isolates you per VLAN/port; pin the address (follow off) on a shared L2 otherwise.
 
 *Deliberately not included:* DHCP option 82 (inserted by the ISP, not the client); RFC 5227 address-conflict detection/arbitration (a rogue host claiming the VIP is beyond a subscriber device's control); DAI rate-limit pacing (one nudge / 120 s is orders of magnitude under any limit); a unicast-RENEW mode (the broadcast flag makes RFC-2131 servers broadcast OFFER/ACK to a non-promiscuous socket; a server that unicasts to the CARP MAC is still received on the master).

--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.8.5
+PLUGIN_VERSION=         1.9.0
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -67,6 +67,10 @@ carpvipdhcp_start()
         [ -n "${arpnudge}" ] && set -- "$@" --arp-nudge "${arpnudge}"
         # Promiscuous ARP capture is an opt-in fallback (default off).
         [ "${arplistenpromisc}" = "1" ] && set -- "$@" --arp-listen-promisc
+        # Experimental capture-backend override (host-wide dark flag): set
+        # carpvipdhcp_backend=bpf in rc.conf (sysrc carpvipdhcp_backend=bpf)
+        # to run the keepers on the raw /dev/bpf backend instead of scapy.
+        [ -n "${carpvipdhcp_backend}" ] && set -- "$@" --capture-backend "${carpvipdhcp_backend}"
         # -f detach; -r supervise/restart on crash; -R 5 restart delay; -P supervisor pidfile.
         /usr/sbin/daemon -f -r -R 5 -P "${pidfile}" -t "${name}-${id}" "${keeper}" "$@"
         count=$((count + 1))
@@ -187,6 +191,7 @@ carpvipdhcp_status()
 
 load_rc_config "${name}"
 : "${carpvipdhcp_enable:=YES}"
+: "${carpvipdhcp_backend:=}"
 # Optional 2nd arg = a single keeper id to act on (start/stop/restart just that
 # one, e.g. the Services overview per-row buttons and follow_update's re-bounce).
 # Empty = act on all keepers, exactly as before -- this is what boot (syshook)

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -70,7 +70,14 @@ carpvipdhcp_start()
         # Experimental capture-backend override (host-wide dark flag): set
         # carpvipdhcp_backend=bpf in rc.conf (sysrc carpvipdhcp_backend=bpf)
         # to run the keepers on the raw /dev/bpf backend instead of scapy.
-        [ -n "${carpvipdhcp_backend}" ] && set -- "$@" --capture-backend "${carpvipdhcp_backend}"
+        # Validate it here rather than pass it through blind: an unknown value
+        # (a typo) would make the daemon exit 2 on the argparse choice, and
+        # daemon(8) -r would turn that into a silent 5s crash loop. Warn and
+        # fall back to the default instead.
+        case "${carpvipdhcp_backend}" in
+            ''|scapy|bpf) [ -n "${carpvipdhcp_backend}" ] && set -- "$@" --capture-backend "${carpvipdhcp_backend}" ;;
+            *) echo "carpvipdhcp: ignoring unknown carpvipdhcp_backend='${carpvipdhcp_backend}' (use scapy or bpf)" >&2 ;;
+        esac
         # -f detach; -r supervise/restart on crash; -R 5 restart delay; -P supervisor pidfile.
         /usr/sbin/daemon -f -r -R 5 -P "${pidfile}" -t "${name}-${id}" "${keeper}" "$@"
         count=$((count + 1))

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -8,20 +8,22 @@ traffic are handled by CARP. The BOOTP broadcast flag is set so OFFER/ACK are
 broadcast. Optionally (--arp-nudge) it refreshes the upstream gateway's ARP
 entry for the leased address, for gateways that never re-ARP an expired entry
 (traffic then silently blackholes until they get an ARP *request*). Runs on both
-HA nodes for redundancy.
+HA nodes for redundancy. Packet capture and send go through a pluggable backend
+(--capture-backend): scapy (the default), or a dependency-free raw /dev/bpf
+backend (experimental).
 
 Robustness:
   * Full DHCP lifecycle: DORA (Discover/Offer/Request/Ack) -> BOUND, RENEW at
     T1, REBIND at T2, re-DORA at expiry.
   * Single instance via pidfile; heartbeat file (fresh = the lease is renewing).
-  * Resilient sniffer: restarted if its thread dies (e.g. the interface flaps).
+  * Resilient capture: restarted if its thread dies (e.g. the interface flaps).
   * All I/O wrapped in try/except so the main loop never crashes; a non-zero
     exit lets the supervisor restart it.
   * RELEASE is NOT sent on a normal stop (SIGTERM) -- only with
     --once/--release-on-exit -- so the address is not given up needlessly.
 
 Security posture (this daemon parses untrusted WAN traffic as root):
-  * The sniffer is NOT promiscuous by default: the BOOTP broadcast flag makes
+  * The capture is NOT promiscuous by default: the BOOTP broadcast flag makes
     the server broadcast its replies to a non-promiscuous socket, and the
     gateway's unicast ARP reply to a nudge reaches us because the CARP master
     already accepts the VIP's virtual MAC. --arp-listen-promisc is an opt-in
@@ -54,12 +56,15 @@ Usage:
 # A single deployable file is a deliberate constraint of this daemon.
 # pylint: disable=too-many-lines
 import argparse
+import ctypes
 import ipaddress
 import logging
 import os
 import random
 import re
+import select
 import signal
+import struct
 import subprocess
 import sys
 import threading
@@ -69,12 +74,25 @@ from dataclasses import dataclass
 from logging.handlers import RotatingFileHandler
 from typing import Any
 
-# Scapy is the one heavy third-party dependency and the usual suspect when the
-# daemon won't start (missing after an upgrade, ABI mismatch, partial install).
+# The raw /dev/bpf backend drives its ioctls through fcntl, which does not
+# exist on non-POSIX development hosts. Import it defensively (same pattern as
+# scapy below) so the module still loads there; BpfCapture.start() reports the
+# missing module at runtime instead.
+try:
+    import fcntl as _fcntl_module
+    # Typed Any: the POSIX-only stubs would flag every ioctl call on the
+    # non-POSIX hosts this guard exists for.
+    fcntl: Any = _fcntl_module
+except ImportError:
+    fcntl = None  # pylint: disable=invalid-name
+
+# Scapy is the one heavy third-party dependency (needed only by the default
+# scapy capture backend) and the usual suspect when the daemon won't start
+# (missing after an upgrade, ABI mismatch, partial install).
 # Import it defensively: a bare module-level import that throws would kill the
 # process before any log handler exists -> a silent non-start with the traceback
 # going to daemon(8)'s /dev/null. Capture it instead and let main() log it once
-# logging is configured.
+# logging is configured (only when the scapy backend is actually selected).
 try:
     from scapy.all import (  # type: ignore  # pylint: disable=import-error
         ARP, Ether, IP, UDP, BOOTP, DHCP, AsyncSniffer, sendp)
@@ -128,6 +146,7 @@ MIN_T1 = 30                # floor for the renew timer (very short leases)
 REBIND_MARGIN = 15         # ensure T2 is at least this far past T1
 BROADCAST_FLAG = 0x8000    # BOOTP flags: ask the server to broadcast OFFER/ACK
 ETHER_BROADCAST = "ff:ff:ff:ff:ff:ff"
+ETHER_ZERO = "00:00:00:00:00:00"     # ARP "target unknown" hardware address
 IPV4_BROADCAST = "255.255.255.255"   # limited broadcast (never routed off-link)
 DHCP_SERVER_PORT = 67
 DHCP_CLIENT_PORT = 68
@@ -140,7 +159,7 @@ LOG_BACKUPS = 3
 # DhcpReply and turn a message type into an option list. The stateful protocol
 # sequences (DORA / INIT-REBOOT / renew) live in the DhcpClient class further down.
 
-# A parsed DHCP reply, snapshotted from the sniffer thread.
+# A parsed DHCP reply, snapshotted from the capture thread.
 # `message` (DHCP option 56) is the server's optional human-readable text, mainly
 # a NAK reason; `subnet_mask` (option 1) is used to follow a cross-subnet renumber;
 # `giaddr` (BOOTP header) is the relay agent, None when the server is directly
@@ -148,6 +167,19 @@ LOG_BACKUPS = 3
 # shorter constructions stay valid.
 DhcpReply = namedtuple("DhcpReply", "mtype yiaddr server_id lease t1 t2 router message subnet_mask giaddr",
                        defaults=(None, None, None))
+
+# A received BOOTP/DHCP frame in backend-neutral shape: both capture backends
+# (scapy packet / raw bytes) decode to this before the keeper sees it. chaddr
+# is raw bytes; options is a list of (name, value) tuples in the keeper's own
+# option vocabulary (the names in _OPT_ENCODERS/_OPT_DECODERS), which
+# _parse_reply reads regardless of backend. The names are deliberately
+# scapy-compatible: ScapyCapture relays outbound option lists to scapy
+# verbatim (see its docstring).
+BootpFrame = namedtuple("BootpFrame", "op xid yiaddr chaddr giaddr options")
+
+# A received ARP frame (the capture filter already narrows ARP to replies, but
+# op still travels so the handler re-checks rather than trusting the filter).
+ArpFrame = namedtuple("ArpFrame", "op psrc pdst")
 
 # Changed-address phase labels: which exchange saw the differing ACK. Log
 # text and policy input at once -- FollowPolicy relaxes its expected-server
@@ -184,12 +216,12 @@ def _fmt_reply(rx):
             f"gw={rx.router or '-'} mask={rx.subnet_mask or '-'}{msg}")
 
 
-def _parse_reply(p, yiaddr):
-    """Snapshot only the handful of DHCP options the keeper acts on into a
-    DhcpReply; the rest of the reply's option data -- untrusted, from
-    whatever answered on the wire -- is left untouched."""
+def _parse_reply(frame):
+    """Snapshot only the handful of DHCP options the keeper acts on from a
+    BootpFrame into a DhcpReply; the rest of the reply's option data --
+    untrusted, from whatever answered on the wire -- is left untouched."""
     mt = sid = lt = rt = bt = ro = msg = sm = None
-    for o in p[DHCP].options:
+    for o in frame.options:
         if isinstance(o, tuple):
             if o[0] == "message-type":
                 mt = o[1]
@@ -207,10 +239,10 @@ def _parse_reply(p, yiaddr):
                 msg = o[1]
             elif o[0] == "subnet_mask":  # option 1: to follow a cross-subnet renumber
                 sm = o[1]
-    gi = getattr(p[BOOTP], "giaddr", None)   # relay agent; 0.0.0.0 = directly attached
+    gi = frame.giaddr   # relay agent; 0.0.0.0 = directly attached
     if gi in (None, "0.0.0.0", 0):
         gi = None
-    return DhcpReply(mt, yiaddr, sid, lt, rt, bt, ro, msg, sm, gi)
+    return DhcpReply(mt, frame.yiaddr, sid, lt, rt, bt, ro, msg, sm, gi)
 
 
 def _dhcp_options(mtype, extra, id_opts):
@@ -239,6 +271,519 @@ _CGNAT = ipaddress.ip_network("100.64.0.0/10")
 # (arp[6:2]=2). A boundary, not an optimization -- it keeps everything else (incl. the
 # segment's broadcast who-has flood) out of the Python parser.
 SNIFFER_FILTER = f"(udp and (port {DHCP_SERVER_PORT} or port {DHCP_CLIENT_PORT})) or (arp and arp[6:2] = 2)"
+
+# ---- raw wire codec (bpf backend) ----
+# Hand encoders/decoders for exactly the frames the keeper exchanges, so the
+# bpf backend needs no packet library. The decoders parse untrusted WAN input:
+# every access is bounds-checked and a malformed frame decodes to None
+# (dropped) rather than raising.
+
+ETHERTYPE_IPV4 = 0x0800
+ETHERTYPE_ARP = 0x0806
+ETHER_MIN_FRAME = 60         # minimum Ethernet frame (without FCS); short ARP frames are padded
+DHCP_MAGIC = b"\x63\x82\x53\x63"   # RFC 2131 options magic cookie
+BOOTP_HDR_LEN = 236          # fixed BOOTP header before the magic cookie
+BOOTP_MIN_PAYLOAD = 300      # RFC 1542 4.1 minimum BOOTP message; reference clients pad to it
+DHCP_OPT_PAD = 0
+DHCP_OPT_END = 255
+IPPROTO_UDP = 17
+IPV4_TTL = 64                # conventional default TTL (BSD/Linux/scapy send 64)
+
+# DHCP message types the keeper SENDS, by the names the option lists carry
+# (the inverse, code -> display name, is MTYPE_NAMES above).
+_MTYPE_CODES = {"discover": 1, "request": 3, "release": 7}
+
+
+def _ip4(ip):
+    """Dotted-quad string (None -> 0.0.0.0) -> 4 raw bytes."""
+    return ipaddress.IPv4Address(ip or "0.0.0.0").packed
+
+
+def _ip4_str(raw):
+    """4 raw bytes -> dotted-quad string."""
+    return str(ipaddress.IPv4Address(bytes(raw)))
+
+
+def _opt_text(v):
+    """Text-ish option value -> bytes (client-id arrives pre-encoded)."""
+    return v if isinstance(v, bytes) else str(v).encode()
+
+
+# Outbound option encoders: option name -> (wire code, value encoder) for
+# exactly the options the keeper sends. These names ARE the keeper's option
+# vocabulary (BootpFrame.options and _dhcp_options use them).
+_OPT_ENCODERS = {
+    "message-type": (53, lambda v: bytes([_MTYPE_CODES[v]])),
+    "param_req_list": (55, bytes),        # list of option codes
+    "requested_addr": (50, _ip4),
+    "server_id": (54, _ip4),
+    "hostname": (12, _opt_text),
+    "vendor_class_id": (60, _opt_text),
+    "client_id": (61, _opt_text),
+}
+
+
+def _encode_dhcp_options(options):
+    """A scapy-style option list (name/value tuples + "end") -> the raw options
+    field. Options with a None value are dropped (a broadcast RELEASE carries
+    no server-id); the end option is always appended."""
+    out = bytearray()
+    for o in options:
+        if not isinstance(o, tuple) or o[1] is None:
+            continue   # the "end" marker (appended below) or a valueless option
+        code, encode = _OPT_ENCODERS[o[0]]
+        raw = encode(o[1])
+        out += bytes([code, len(raw)]) + raw
+    out.append(DHCP_OPT_END)
+    return bytes(out)
+
+
+def _encode_bootp_request(chaddr, xid, ciaddr, flags, options):
+    """A BOOTREQUEST payload: fixed BOOTP header + cookie + options, padded to
+    the RFC 1542 minimum message size (some servers drop shorter ones)."""
+    hdr = struct.pack("!4BIHH", 1, 1, 6, 0, xid, 0, flags)   # op htype hlen hops xid secs flags
+    hdr += _ip4(ciaddr) + b"\x00" * 12                       # ciaddr, then yiaddr/siaddr/giaddr zero
+    hdr += chaddr.ljust(16, b"\x00")[:16]                    # chaddr field (16 bytes)
+    hdr += b"\x00" * 192                                     # sname (64) + file (128), unused
+    payload = hdr + DHCP_MAGIC + _encode_dhcp_options(options)
+    return payload.ljust(BOOTP_MIN_PAYLOAD, b"\x00")
+
+
+def _inet_checksum(data):
+    """RFC 1071 ones-complement sum over 16-bit words (odd length zero-padded)."""
+    if len(data) % 2:
+        data += b"\x00"
+    total = sum(int.from_bytes(data[i:i + 2], "big") for i in range(0, len(data), 2))
+    while total >> 16:
+        total = (total & 0xFFFF) + (total >> 16)
+    return ~total & 0xFFFF
+
+
+def _encode_ipv4_udp(src, dst, sport, dport, payload):
+    """An IPv4+UDP datagram around payload, checksums computed. A UDP checksum
+    of 0 means "none sent", so a sum that works out to 0 transmits as 0xFFFF
+    (RFC 768)."""
+    udp_len = 8 + len(payload)
+    pseudo = _ip4(src) + _ip4(dst) + struct.pack("!BBH", 0, IPPROTO_UDP, udp_len)
+    udp_hdr = struct.pack("!4H", sport, dport, udp_len, 0)
+    cksum = _inet_checksum(pseudo + udp_hdr + payload) or 0xFFFF
+    udp_hdr = struct.pack("!4H", sport, dport, udp_len, cksum)
+    # version/ihl, tos, total, id, flags/frag, ttl, proto, checksum (zeroed, then patched)
+    ip_hdr = struct.pack("!BBHHHBBH", 0x45, 0, 20 + udp_len, 0, 0, IPV4_TTL, IPPROTO_UDP, 0) + _ip4(src) + _ip4(dst)
+    ip_hdr = ip_hdr[:10] + _inet_checksum(ip_hdr).to_bytes(2, "big") + ip_hdr[12:]
+    return ip_hdr + udp_hdr + payload
+
+
+def _encode_ether(dst, src, ethertype, payload):
+    """An Ethernet II frame."""
+    return mac2raw(dst) + mac2raw(src) + ethertype.to_bytes(2, "big") + payload
+
+
+# The fixed Ethernet/IPv4 ARP header prefix (htype/ptype/hlen/plen), shared by
+# the encoder and the decoder so the two cannot drift.
+_ARP_ETH_IPV4 = struct.pack("!HHBB", 1, ETHERTYPE_IPV4, 6, 4)
+
+
+def _encode_arp_request(hwsrc, psrc, pdst):
+    """An ARP who-has pdst tell psrc with sender hardware hwsrc (the nudge
+    frame; the shaping rationale lives at the ArpNudge call site)."""
+    return (_ARP_ETH_IPV4 + struct.pack("!H", 1)
+            + mac2raw(hwsrc) + _ip4(psrc) + mac2raw(ETHER_ZERO) + _ip4(pdst))
+
+
+def _u32(v):
+    """4-byte big-endian option value -> int (a shorter value is malformed)."""
+    if len(v) < 4:
+        raise ValueError("short integer option")
+    return int.from_bytes(v[:4], "big")
+
+
+def _first_ip(v):
+    """First IPv4 address in an option value (option 3 may list several)."""
+    if len(v) < 4:
+        raise ValueError("short address option")
+    return _ip4_str(v[:4])
+
+
+# Inbound option decoders: wire code -> (option name, value decoder) for
+# exactly the options _parse_reply acts on; everything else is skipped unread
+# (untrusted input, narrow surface).
+_OPT_DECODERS = {
+    1: ("subnet_mask", _first_ip),
+    3: ("router", _first_ip),
+    51: ("lease_time", _u32),
+    53: ("message-type", lambda v: v[0]),
+    54: ("server_id", _first_ip),
+    56: ("message", bytes),
+    58: ("renewal_time", _u32),
+    59: ("rebinding_time", _u32),
+}
+
+
+def _decode_dhcp_options(data):
+    """Bounds-checked TLV walk over the options field of an untrusted reply.
+    Unknown options are skipped without decoding; any truncation ends the walk
+    with what was parsed so far. Never raises on malformed input."""
+    out = []
+    i = 0
+    while i < len(data):
+        code = data[i]
+        if code == DHCP_OPT_PAD:
+            i += 1
+            continue
+        if code == DHCP_OPT_END:
+            break
+        if i + 2 > len(data):    # length byte missing
+            break
+        length = data[i + 1]
+        value = data[i + 2:i + 2 + length]
+        if len(value) < length:  # value truncated
+            break
+        known = _OPT_DECODERS.get(code)
+        if known:
+            try:
+                out.append((known[0], known[1](value)))
+            except (ValueError, IndexError):
+                pass             # malformed value inside a known option -> skip it
+        i += 2 + length
+    return out
+
+
+def _decode_arp(pkt):
+    """Raw ARP payload -> ArpFrame, or None unless it is a well-formed
+    Ethernet/IPv4 ARP."""
+    if len(pkt) < 28 or pkt[:6] != _ARP_ETH_IPV4:
+        return None
+    return ArpFrame(int.from_bytes(pkt[6:8], "big"), _ip4_str(pkt[14:18]), _ip4_str(pkt[24:28]))
+
+
+def _decode_ipv4_bootp(pkt):
+    """Raw IPv4 payload of an Ethernet frame -> BootpFrame, or None unless it
+    is an unfragmented UDP datagram carrying a plausible BOOTP message with
+    the DHCP cookie. Every bound is checked (untrusted WAN input)."""
+    if len(pkt) < 20 or pkt[0] >> 4 != 4:
+        return None
+    ihl = (pkt[0] & 0x0F) * 4
+    total = int.from_bytes(pkt[2:4], "big")
+    if ihl < 20 or total < ihl + 8 or len(pkt) < ihl + 8:
+        return None
+    if pkt[9] != IPPROTO_UDP:
+        return None
+    if int.from_bytes(pkt[6:8], "big") & 0x3FFF:   # MF set or a fragment continuation
+        return None
+    bootp = pkt[ihl + 8:min(total, len(pkt))]      # UDP payload, minus any link padding
+    if len(bootp) < BOOTP_HDR_LEN + 4 or bootp[BOOTP_HDR_LEN:BOOTP_HDR_LEN + 4] != DHCP_MAGIC:
+        return None
+    # The options walk only pays off for server replies; on a shared segment
+    # the filter also passes other clients' broadcast BOOTREQUESTs, which the
+    # keeper drops on op anyway -- skip their TLV walk in this hot path.
+    op = bootp[0]
+    return BootpFrame(op=op,
+                      xid=int.from_bytes(bootp[4:8], "big"),
+                      yiaddr=_ip4_str(bootp[16:20]),
+                      chaddr=bytes(bootp[28:44]),
+                      giaddr=_ip4_str(bootp[24:28]),
+                      options=_decode_dhcp_options(bootp[BOOTP_HDR_LEN + 4:]) if op == BOOTREPLY else [])
+
+
+# ---- /dev/bpf plumbing (bpf backend) ----
+# FreeBSD ioctl codes for the LP64 platforms OPNsense ships on (amd64/aarch64),
+# precomputed from net/bpf.h so no C headers are needed at runtime.
+BIOCGBLEN = 0x40044266       # _IOR('B', 102, u_int): kernel capture buffer size
+BIOCSETF = 0x80104267        # _IOW('B', 103, struct bpf_program): attach the filter
+BIOCPROMISC = 0x20004269     # _IO('B', 105): promiscuous mode
+BIOCSETIF = 0x8020426C       # _IOW('B', 108, struct ifreq): bind to the interface
+BIOCIMMEDIATE = 0x80044270   # _IOW('B', 112, u_int): deliver per packet, not per full buffer
+BIOCSHDRCMPLT = 0x80044275   # _IOW('B', 117, u_int): we supply the Ethernet source MAC
+BPF_ALIGNMENT = 8            # capture records align to sizeof(long)
+BPF_HDR_FIXED = 26           # bh_tstamp(16) + bh_caplen(4) + bh_datalen(4) + bh_hdrlen(2)
+
+# SNIFFER_FILTER compiled to classic-BPF opcodes, embedded so the daemon needs
+# no runtime filter compiler. MUST stay in lockstep with SNIFFER_FILTER;
+# regenerate on any FreeBSD/OPNsense host with:
+#   tcpdump -i <ethernet-iface> -dd '(udp and (port 67 or port 68)) or (arp and arp[6:2] = 2)'
+_BPF_FILTER = (
+    (0x28, 0, 0, 0x0000000C),
+    (0x15, 0, 10, 0x00000800),
+    (0x30, 0, 0, 0x00000017),
+    (0x15, 0, 21, 0x00000011),
+    (0x28, 0, 0, 0x00000014),
+    (0x45, 19, 0, 0x00001FFF),
+    (0xB1, 0, 0, 0x0000000E),
+    (0x48, 0, 0, 0x0000000E),
+    (0x15, 15, 0, 0x00000043),
+    (0x15, 14, 0, 0x00000044),
+    (0x48, 0, 0, 0x00000010),
+    (0x15, 12, 8, 0x00000043),
+    (0x15, 0, 8, 0x000086DD),
+    (0x30, 0, 0, 0x00000014),
+    (0x15, 0, 10, 0x00000011),
+    (0x28, 0, 0, 0x00000036),
+    (0x15, 7, 0, 0x00000043),
+    (0x15, 6, 0, 0x00000044),
+    (0x28, 0, 0, 0x00000038),
+    (0x15, 4, 0, 0x00000043),
+    (0x15, 3, 4, 0x00000044),
+    (0x15, 0, 3, 0x00000806),
+    (0x28, 0, 0, 0x00000014),
+    (0x15, 0, 1, 0x00000002),
+    (0x6, 0, 0, 0x00040000),
+    (0x6, 0, 0, 0x00000000),
+)
+
+
+def _bpf_frames(data):
+    """Walk a raw BPF read buffer, yielding each record's captured bytes.
+    Records are struct bpf_hdr framed and BPF_ALIGNMENT-padded; a malformed
+    record stops the walk rather than misparse the rest."""
+    i = 0
+    while i + BPF_HDR_FIXED <= len(data):
+        caplen, _datalen, hdrlen = struct.unpack_from("=IIH", data, i + 16)
+        if hdrlen < BPF_HDR_FIXED or i + hdrlen + caplen > len(data):
+            break
+        yield data[i + hdrlen:i + hdrlen + caplen]
+        i += (hdrlen + caplen + BPF_ALIGNMENT - 1) & ~(BPF_ALIGNMENT - 1)
+
+
+# ---- capture backends ----
+# Both backends expose the same surface: start/stop/alive for the capture
+# side (decoded BootpFrame/ArpFrame handed to the constructor callbacks on
+# the capture thread) and send_dhcp/send_arp_request for the send side.
+
+def _deliver(handler, frame):
+    """Run a keeper frame callback under its own guard: a failure in there is
+    a handler bug, not a parse error, and must neither kill the capture
+    thread nor be mislabelled as malformed input."""
+    if frame is None:
+        return
+    try:
+        handler(frame)
+    except Exception as e:
+        LOG.debug("frame handler error: %s", e)
+
+
+class ScapyCapture:
+    """Capture/send via scapy (AsyncSniffer + sendp): the default backend.
+    Decodes scapy packets into the same neutral frames as the bpf backend, so
+    the rest of the keeper never touches a packet object. Outbound option
+    lists are relayed to scapy verbatim, which is why the keeper's option
+    vocabulary must stay scapy-compatible."""
+
+    def __init__(self, iface, promisc, on_bootp, on_arp):
+        self.iface = iface
+        self.promisc = promisc
+        self._on_bootp = on_bootp
+        self._on_arp = on_arp
+        self._sniffer = None
+
+    def start(self):
+        """(Re)start the sniffer. False on failure (the caller retries)."""
+        try:
+            self.stop()
+            # Non-promiscuous by default: the BOOTP broadcast flag makes the
+            # server broadcast OFFER/ACK, and the gateway's unicast ARP reply to a
+            # nudge reaches us because the CARP master already accepts the VIP's
+            # virtual MAC. promisc is the opt-in fallback for NICs that
+            # drop non-primary unicast (widens capture -- warned at startup).
+            self._sniffer = AsyncSniffer(
+                iface=self.iface, filter=SNIFFER_FILTER,
+                prn=self._on_packet, store=0, promisc=self.promisc)
+            self._sniffer.start()
+            return True
+        except Exception as e:
+            LOG.error("DHCP-reply sniffer start failed: %s", e)
+            return False
+
+    def stop(self):
+        """Best-effort capture stop (scapy may raise if it never ran)."""
+        try:
+            if self._sniffer:
+                self._sniffer.stop()
+        except Exception:
+            pass
+
+    def alive(self):
+        """True while the sniffer thread is running."""
+        thread = getattr(self._sniffer, "thread", None)
+        return thread is not None and thread.is_alive()
+
+    def _on_packet(self, p):
+        """Sniffer callback: scapy packet -> neutral frame -> keeper callback
+        (via _deliver, so a handler failure is labelled as such). A parse
+        error in the untrusted input is dropped (debug-logged)."""
+        frame = handler = None
+        try:
+            if p.haslayer(BOOTP) and p.haslayer(DHCP):
+                b = p[BOOTP]
+                try:
+                    chaddr = bytes(getattr(b, "chaddr", b"") or b"")
+                except (TypeError, ValueError):
+                    chaddr = b""
+                frame = BootpFrame(b.op, b.xid, b.yiaddr, chaddr,
+                                   getattr(b, "giaddr", None), p[DHCP].options)
+                handler = self._on_bootp
+            elif p.haslayer(ARP):
+                arp = p[ARP]
+                frame, handler = ArpFrame(arp.op, arp.psrc, arp.pdst), self._on_arp
+        except Exception as e:
+            LOG.debug("sniffed packet parse error: %s", e)
+            return
+        _deliver(handler, frame)
+
+    # The DHCP wire tuple: one parameter per field that goes on the wire.
+    def send_dhcp(self, *, eth_src, ip_src, ip_dst, chaddr,  # pylint: disable=too-many-arguments
+                  xid, ciaddr, flags, options):
+        """Broadcast one DHCP client message as scapy layers."""
+        sendp(Ether(src=eth_src, dst=ETHER_BROADCAST) /
+              IP(src=ip_src, dst=ip_dst) /
+              UDP(sport=DHCP_CLIENT_PORT, dport=DHCP_SERVER_PORT) /
+              BOOTP(chaddr=chaddr, xid=xid, ciaddr=ciaddr, flags=flags) /
+              DHCP(options=options),
+              iface=self.iface, verbose=0)
+
+    def send_arp_request(self, hwsrc, psrc, pdst):
+        """Broadcast an ARP who-has pdst tell psrc from hwsrc."""
+        sendp(Ether(src=hwsrc, dst=ETHER_BROADCAST) /
+              ARP(op=1, hwsrc=hwsrc, psrc=psrc,
+                  hwdst=ETHER_ZERO, pdst=pdst),
+              iface=self.iface, verbose=0)
+
+
+class BpfCapture:  # pylint: disable=too-many-instance-attributes
+    """Capture/send on a raw /dev/bpf descriptor -- no packet library. A
+    reader thread walks the BPF buffer and hands decoded neutral frames to
+    the same callbacks the scapy backend feeds. FreeBSD-only (OPNsense's
+    platform); selected with --capture-backend bpf (experimental)."""
+
+    def __init__(self, iface, promisc, on_bootp, on_arp):
+        self.iface = iface
+        self.promisc = promisc
+        self._on_bootp = on_bootp
+        self._on_arp = on_arp
+        self._fd = None
+        self._buflen = 0               # set from BIOCGBLEN in _configure
+        self._thread = None
+        self._closing = False
+
+    def start(self):
+        """(Re)open /dev/bpf bound + filtered to the interface and start the
+        reader thread. False on any failure (the caller retries)."""
+        if fcntl is None:
+            LOG.error("bpf backend unavailable: no fcntl module on this platform")
+            return False
+        try:
+            self.stop()
+            self._closing = False
+            fd = os.open("/dev/bpf", os.O_RDWR)
+            try:
+                self._configure(fd)
+            except Exception:
+                os.close(fd)
+                raise
+            self._fd = fd
+            self._thread = threading.Thread(target=self._read_loop, args=(fd,),
+                                            name="bpf-capture", daemon=True)
+            self._thread.start()
+            return True
+        except Exception as e:
+            LOG.error("bpf capture start failed on %s: %s", self.iface, e)
+            return False
+
+    def _configure(self, fd):
+        """Bind, tune and filter a fresh bpf descriptor."""
+        fcntl.ioctl(fd, BIOCSETIF, struct.pack("16s16x", self.iface.encode()))
+        # Immediate mode: hand packets over as they arrive; the DHCP exchanges
+        # wait on second-scale timeouts, so buffering a full block is not an option.
+        fcntl.ioctl(fd, BIOCIMMEDIATE, struct.pack("I", 1))
+        # Header-complete: our frames carry the CARP vMAC as the Ethernet
+        # source; without this the kernel would overwrite it with the NIC MAC.
+        fcntl.ioctl(fd, BIOCSHDRCMPLT, struct.pack("I", 1))
+        if self.promisc:
+            fcntl.ioctl(fd, BIOCPROMISC)
+        insns = b"".join(struct.pack("HBBI", *insn) for insn in _BPF_FILTER)
+        buf = ctypes.create_string_buffer(insns)   # the kernel copies it during the ioctl
+        # struct bpf_program: u_int bf_len + insn pointer ("@IQ" pads to native layout)
+        fcntl.ioctl(fd, BIOCSETF, struct.pack("@IQ", len(_BPF_FILTER), ctypes.addressof(buf)))
+        # bpf read(2) calls must request exactly the kernel buffer size.
+        self._buflen = struct.unpack("I", fcntl.ioctl(fd, BIOCGBLEN, b"\x00" * 4))[0]
+
+    def stop(self):
+        """Close the descriptor (the kernel detaches filter/promisc) and
+        collect the reader thread; the closing flag stops its select loop."""
+        self._closing = True
+        fd, self._fd = self._fd, None
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        thread, self._thread = self._thread, None
+        if thread and thread.is_alive():
+            thread.join(timeout=2)
+
+    def alive(self):
+        """True while the descriptor is open and the reader thread runs."""
+        return bool(self._fd is not None and self._thread and self._thread.is_alive())
+
+    def _read_loop(self, fd):
+        """Reader thread: select with a timeout so stop() (which closes the
+        fd) is noticed within a second, then walk the BPF buffer records."""
+        while not self._closing:
+            try:
+                ready, _, _ = select.select([fd], [], [], 1.0)
+                if not ready:
+                    continue
+                data = os.read(fd, self._buflen)
+            except (OSError, ValueError):
+                if not self._closing:
+                    LOG.warning("bpf read failed -- capture thread exiting")
+                return
+            for frame in _bpf_frames(data):
+                self._dispatch(frame)
+
+    def _dispatch(self, frame):
+        """Decode one captured Ethernet frame and route it by ethertype to the
+        keeper callback (via _deliver, so a handler failure is labelled as
+        such). A parse error in the untrusted input is dropped (debug-logged)."""
+        decoded = handler = None
+        try:
+            if len(frame) >= 14:
+                ethertype = int.from_bytes(frame[12:14], "big")
+                if ethertype == ETHERTYPE_ARP:
+                    decoded, handler = _decode_arp(frame[14:]), self._on_arp
+                elif ethertype == ETHERTYPE_IPV4:
+                    decoded, handler = _decode_ipv4_bootp(frame[14:]), self._on_bootp
+        except Exception as e:
+            LOG.debug("bpf frame parse error: %s", e)
+            return
+        _deliver(handler, decoded)
+
+    def _write(self, frame):
+        """Inject one raw Ethernet frame on the interface."""
+        fd = self._fd
+        if fd is None:
+            raise OSError("bpf capture not started")
+        os.write(fd, frame)
+
+    # The DHCP wire tuple: one parameter per field that goes on the wire.
+    def send_dhcp(self, *, eth_src, ip_src, ip_dst, chaddr,  # pylint: disable=too-many-arguments
+                  xid, ciaddr, flags, options):
+        """Broadcast one DHCP client message as raw encoded frames."""
+        payload = _encode_bootp_request(chaddr, xid, ciaddr, flags, options)
+        dgram = _encode_ipv4_udp(ip_src, ip_dst, DHCP_CLIENT_PORT, DHCP_SERVER_PORT, payload)
+        self._write(_encode_ether(ETHER_BROADCAST, eth_src, ETHERTYPE_IPV4, dgram))
+
+    def send_arp_request(self, hwsrc, psrc, pdst):
+        """Broadcast an ARP who-has pdst tell psrc from hwsrc."""
+        frame = _encode_ether(ETHER_BROADCAST, hwsrc, ETHERTYPE_ARP,
+                              _encode_arp_request(hwsrc, psrc, pdst))
+        self._write(frame.ljust(ETHER_MIN_FRAME, b"\x00"))   # runt guard: ARP is 42 bytes bare
+
+
+# The capture-backend registry: flag value -> implementation. The argparse
+# choices and Keeper's lookup both read this, so a future backend is added in
+# exactly one place (plus its rc.conf documentation).
+CAPTURE_BACKENDS = {"scapy": ScapyCapture, "bpf": BpfCapture}
 
 
 def _sane_ipv4(ip):
@@ -334,16 +879,17 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
     """RFC 2131 client for one chaddr: owns the held binding (a Lease)
     and the stateful protocol sequences
     (INIT-REBOOT / DORA / RENEW / REBIND / RELEASE) with their send/await
-    machinery. It does NOT own the packet capture: the sniffer owner hands
-    xid-matched replies to feed(). Policy stays with the caller through three
+    machinery. It does NOT own the packet capture: sends travel through the
+    injected capture backend, and the capture owner hands xid-matched replies
+    to feed(). Policy stays with the caller through three
     injected hooks: should_stop (abort mid-sequence), ensure_sniffer (capture
     must be alive before a send), and on_changed_address(got, rx, phase,
     release_on_enforce) -> bool for an ACK whose address differs from the
     expected one (True = the caller validated and adopted it, see adopt())."""
 
-    def __init__(self, iface, chaddr, eth_src, id_opts, *,  # pylint: disable=too-many-arguments
+    def __init__(self, capture, chaddr, eth_src, id_opts, *,  # pylint: disable=too-many-arguments
                  should_stop, ensure_sniffer, on_changed_address):
-        self.iface = iface
+        self._capture = capture
         self.chaddr = chaddr
         self.chraw = mac2raw(chaddr)
         self.eth_src = eth_src
@@ -372,12 +918,10 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
     def _send_dhcp(self, mtype, extra, ciaddr="0.0.0.0"):
         # ciaddr is set for RENEW/REBIND (the client already owns the address);
         # the broadcast flag stays on so the reply is reliably captured by the sniffer.
-        pkt = (Ether(src=self.eth_src, dst=ETHER_BROADCAST) /
-               IP(src=ciaddr, dst=IPV4_BROADCAST) /
-               UDP(sport=DHCP_CLIENT_PORT, dport=DHCP_SERVER_PORT) /
-               BOOTP(chaddr=self.chraw, xid=self.xid, ciaddr=ciaddr, flags=BROADCAST_FLAG) /
-               DHCP(options=_dhcp_options(mtype, extra, self._id_opts)))
-        sendp(pkt, iface=self.iface, verbose=0)
+        self._capture.send_dhcp(
+            eth_src=self.eth_src, ip_src=ciaddr, ip_dst=IPV4_BROADCAST,
+            chaddr=self.chraw, xid=self.xid, ciaddr=ciaddr, flags=BROADCAST_FLAG,
+            options=_dhcp_options(mtype, extra, self._id_opts))
 
     def _wait_for_dhcp_reply(self, want, timeout):
         """Wait up to timeout for a reply of message-type `want`. Returns the
@@ -616,13 +1160,11 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             return
 
         try:
-            pkt = (Ether(src=self.eth_src, dst=ETHER_BROADCAST) /
-                   IP(src=yiaddr, dst=server or IPV4_BROADCAST) /
-                   UDP(sport=DHCP_CLIENT_PORT, dport=DHCP_SERVER_PORT) /
-                   BOOTP(chaddr=self.chraw, xid=self.xid, ciaddr=yiaddr) /
-                   DHCP(options=[("message-type", "release"),
-                                 ("server_id", server), "end"]))
-            sendp(pkt, iface=self.iface, verbose=0)
+            # No broadcast flag: RELEASE expects no reply to capture.
+            self._capture.send_dhcp(
+                eth_src=self.eth_src, ip_src=yiaddr, ip_dst=server or IPV4_BROADCAST,
+                chaddr=self.chraw, xid=self.xid, ciaddr=yiaddr, flags=0,
+                options=[("message-type", "release"), ("server_id", server), "end"])
             LOG.info("DHCP RELEASE of lease %s sent (server %s)", yiaddr, server or "broadcast")
         except Exception as e:
             LOG.error("RELEASE failed: %s", e)
@@ -655,8 +1197,8 @@ class ArpNudge:  # pylint: disable=too-many-instance-attributes
     nudge from a backup (it would steal the VIP's traffic), so anything but a
     confirmed MASTER fails closed (the next interval retries)."""
 
-    def __init__(self, iface, chaddr, interval, is_master):
-        self.iface = iface
+    def __init__(self, capture, chaddr, interval, is_master):
+        self._capture = capture
         self.chaddr = chaddr
         # Interval floor so a typo cannot flood the segment; 0 = disabled.
         self.interval = max(ARP_NUDGE_MIN, interval) if interval else 0
@@ -700,10 +1242,7 @@ class ArpNudge:  # pylint: disable=too-many-instance-attributes
             #   * sending it at all exists for gateways that never re-ARP an
             #     expired entry ("secured ARP") and would otherwise blackhole the
             #     VIP. Only the CARP master sends it (gated above).
-            sendp(Ether(src=self.chaddr, dst=ETHER_BROADCAST) /
-                  ARP(op=1, hwsrc=self.chaddr, psrc=yiaddr,
-                      hwdst="00:00:00:00:00:00", pdst=gateway),
-                  iface=self.iface, verbose=0)
+            self._capture.send_arp_request(self.chaddr, yiaddr, gateway)
             self.last_nudge = time.time()
             # Log the first nudge (and any target change) at INFO so the default log
             # shows the nudge is active; routine repeats at DEBUG (they fire oftener
@@ -718,24 +1257,20 @@ class ArpNudge:  # pylint: disable=too-many-instance-attributes
         except Exception as e:
             LOG.warning("ARP nudge failed (target %s): %s", gateway, e)
 
-    def on_arp_reply(self, p, yiaddr, gateway):
+    def on_arp_reply(self, frame, yiaddr, gateway):
         """Stamp last_reply when the gateway answers our nudge -- a reachability
         signal the status page surfaces by age. Only the reply to OUR who-has
         counts: op=2 (is-at), sender = the nudge target gateway, target = our
-        leased IP. Runs on the sniffer thread; the stamp is a lone atomic write.
+        leased IP. Runs on the capture thread; the stamp is a lone atomic write.
         Advisory only (an on-segment attacker could forge or withhold it);
         nothing here feeds lease/CARP/follow decisions."""
-        try:
-            arp = p[ARP]
-            if arp.op != 2:                     # 2 = is-at (reply); requests are filtered out in BPF
-                return
-            if not gateway or not yiaddr:
-                return
-            if arp.psrc == gateway and arp.pdst == yiaddr:
-                self.last_reply = time.time()
-                LOG.debug("ARP reply from %s (is-at) for %s", gateway, yiaddr)
-        except Exception as e:
-            LOG.debug("ARP reply parse error: %s", e)
+        if frame.op != 2:                       # 2 = is-at (reply); requests are filtered out in BPF
+            return
+        if not gateway or not yiaddr:
+            return
+        if frame.psrc == gateway and frame.pdst == yiaddr:
+            self.last_reply = time.time()
+            LOG.debug("ARP reply from %s (is-at) for %s", gateway, yiaddr)
 
 
 class FollowPolicy:  # pylint: disable=too-many-instance-attributes
@@ -921,7 +1456,7 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
 
 
 class Keeper:  # pylint: disable=too-many-instance-attributes
-    """Orchestration around the components: owns the packet sniffer (feeding
+    """Orchestration around the components: owns the capture backend (feeding
     DHCP replies to DhcpClient, ARP replies to ArpNudge and peer-ACK
     observations to FollowPolicy), the heartbeat, the CARP role watch, the
     acquire pacing (backoff + link-return fast path) and the signal-driven
@@ -931,7 +1466,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
     def __init__(self, iface, chaddr, request_ip=None, eth_src=None, *,  # pylint: disable=too-many-arguments
                  hbfile=None, release_on_exit=False, vhid=None,
                  follow=False, vendor_class=None, client_id=None, hostname=None,
-                 arp_nudge=0, arp_listen_promisc=False):
+                 arp_nudge=0, arp_listen_promisc=False, capture_backend="scapy"):
         self.iface = iface
         self.chaddr = chaddr.lower()
         self.eth_src = (eth_src or chaddr).lower()
@@ -939,38 +1474,30 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self.release_on_exit = release_on_exit
         self.vhid = str(vhid) if vhid else None
 
+        # Capture backend component: owns the capture socket/thread and the
+        # wire codec on both directions, and hands decoded neutral frames
+        # back (DHCP replies and ARP replies, routed below). Promiscuous
+        # capture is off by default; the rationale lives in the module
+        # docstring's security section.
+        self._capture = CAPTURE_BACKENDS[capture_backend](
+            iface, arp_listen_promisc, self._on_dhcp_reply, self._on_arp_reply)
+
         # ARP nudge component: owns the pacing and reachability state; the
         # keeper supplies the lease binding per nudge (_arp_nudge) and the
         # CARP-role probe (via the _carp_master_probe shim).
-        self._nudge = ArpNudge(iface, self.chaddr, arp_nudge, self._carp_master_probe)
+        self._nudge = ArpNudge(self._capture, self.chaddr, arp_nudge, self._carp_master_probe)
 
-        # Promiscuous ARP capture: off by default (the CARP master already
-        # accepts the VIP MAC, so the unicast reply reaches a normal socket).
-        # Opt-in fallback for NICs that drop non-primary unicast MACs.
-        self.arp_listen_promisc = arp_listen_promisc
         self._was_master = None        # CARP role at the last nudge check (None = unknown yet)
         self._nudge_now = False        # operator asked for an immediate nudge (SIGUSR1)
         self._poll_role_now = False    # a CARP transition fired -> re-check role now (SIGUSR2)
         self._renew_asap = False       # renew at the next _hold_lease tick instead of waiting for T1
 
-        # Optional DHCP request options (empty -> not sent); built once and added to
-        # every DISCOVER/REQUEST/RENEW so the server sees a consistent client identity.
-        # ISP interplay: satisfies servers that only lease to a known vendor-class
-        # (opt 60), client-id (61) or hostname (12) -- the "client identity checks"
-        # row of the README's ISP-security section.
-        id_opts = []
-        if vendor_class:
-            id_opts.append(("vendor_class_id", vendor_class))
-        if client_id:
-            id_opts.append(("client_id", client_id.encode()))
-        if hostname:
-            id_opts.append(("hostname", hostname))
-
         # DHCP client component: owns the lease state and the protocol sequences;
-        # the keeper owns the sniffer (feeding it xid-matched replies) and the
+        # the keeper owns the capture (feeding it xid-matched replies) and the
         # policy hooks.
         self._dhcp = DhcpClient(
-            iface, self.chaddr, self.eth_src, id_opts,
+            self._capture, self.chaddr, self.eth_src,
+            _identity_options(vendor_class, client_id, hostname),
             should_stop=lambda: self._stop,
             ensure_sniffer=self._ensure_sniffer,
             on_changed_address=self._on_changed_address)
@@ -992,100 +1519,57 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # return before the 1s tick when there is pending work. Currently the
         # sniffer sets it on an observed address change so the follow fires in
         # milliseconds; a future fast-wake need should reuse this rather than mint
-        # a second event. Set only by the sniffer thread; waited/cleared only by
+        # a second event. Set only by the capture thread; waited/cleared only by
         # the main thread.
         self._wake = threading.Event()
-        self._sniffer = None
 
-    # ---- sniffer (resilient) ----
-    def _stop_sniffer(self):
-        """Best-effort capture stop (scapy may raise if it never ran)."""
-        try:
-            if self._sniffer:
-                self._sniffer.stop()
-        except Exception:
-            pass
-
-    def _start_sniffer(self):
-        try:
-            self._stop_sniffer()
-            # Non-promiscuous by default: the BOOTP broadcast flag makes the
-            # server broadcast OFFER/ACK, and the gateway's unicast ARP reply to a
-            # nudge reaches us because the CARP master already accepts the VIP's
-            # virtual MAC. arp_listen_promisc is the opt-in fallback for NICs that
-            # drop non-primary unicast (widens capture -- warned at startup).
-            self._sniffer = AsyncSniffer(
-                iface=self.iface, filter=SNIFFER_FILTER,
-                prn=self._on_sniff, store=0, promisc=self.arp_listen_promisc)
-            self._sniffer.start()
-            return True
-        except Exception as e:
-            LOG.error("DHCP-reply sniffer start failed: %s", e)
-            return False
-
-    def _sniffer_alive(self):
-        t = getattr(self._sniffer, "thread", None)
-        return bool(self._sniffer and t is not None and t.is_alive())
-
+    # ---- capture (resilient) ----
     def _ensure_sniffer(self):
-        if not self._sniffer_alive():
-            LOG.warning("DHCP-reply sniffer down -- (re)starting")
-            self._start_sniffer()
+        if not self._capture.alive():
+            LOG.warning("DHCP-reply capture down -- (re)starting")
+            self._capture.start()
             time.sleep(1)
 
-    def _on_sniff(self, p):
-        # One sniffer feeds two parsers; keep the DHCP and ARP concerns separate.
-        # The BPF filter already narrowed traffic to DHCP + ARP replies, so this
-        # only routes by layer -- each handler does its own validation/guarding.
-        if p.haslayer(BOOTP):
-            self._on_dhcp_reply(p)
-        elif p.haslayer(ARP):
-            # Gateway answering our nudge (reachability stamp).
-            self._nudge.on_arp_reply(p, self._dhcp.binding.yiaddr, self._nudge_target())
+    def _on_arp_reply(self, frame):
+        """Capture-backend ARP callback: the gateway answering our nudge
+        (reachability stamp); the nudge component does the matching."""
+        self._nudge.on_arp_reply(frame, self._dhcp.binding.yiaddr, self._nudge_target())
 
-    def _chaddr_matches(self, b):
+    def _chaddr_matches(self, frame):
         """True if the reply's BOOTP client hardware address is our chaddr (the
         CARP virtual MAC). Used to accept the PEER's ACK on the shared chaddr:
         the peer node runs an identical keeper on the very same chaddr."""
-        try:
-            raw = bytes(getattr(b, "chaddr", b"") or b"")
-        except (TypeError, ValueError):
-            return False
-        return raw[:6] == self._dhcp.chraw
+        return frame.chaddr[:6] == self._dhcp.chraw
 
-    def _on_dhcp_reply(self, p):
-        try:
-            if not (p.haslayer(BOOTP) and p.haslayer(DHCP)):
-                return
-            b = p[BOOTP]
-            if b.op != BOOTREPLY:
-                return
-            # First-party path: a reply to OUR in-flight exchange (random xid,
-            # regenerated per DORA). Parsed and fed to the waiting client sequence.
-            if b.xid == self._dhcp.xid:
-                self._dhcp.feed(_parse_reply(p, b.yiaddr))
-                return
-            # Not our xid. In follow mode, still watch for the PEER's ACK: both HA
-            # nodes run an identical keeper on the SAME chaddr (the CARP virtual
-            # MAC), so the peer's ACK reveals a changed ISP address one exchange
-            # sooner than our own renewal timer -- closing the window where the
-            # two nodes hold different VIP prefixes long enough for CARP to
-            # dual-master (see docs/single-ip-wan-carp.md, section 3). This is a
-            # deliberately narrow relaxation of the xid trust gate: it requires
-            # our chaddr and an ACK for a plausible, different address, and it
-            # only RECORDS the observation (one atomic ref write) for the main
-            # thread -- which routes it through the same follow hardening
-            # (sane / same-class / expected-server / throttle) as a first-party
-            # ACK and never acts on the sniffer thread.
-            if not self._follow.follow or not self._dhcp.binding.yiaddr or not self._chaddr_matches(b):
-                return
-            rx = _parse_reply(p, b.yiaddr)
-            if (rx.mtype == ACK and rx.yiaddr and rx.yiaddr != self._dhcp.binding.yiaddr
-                    and _sane_ipv4(rx.yiaddr)):
-                self._follow.observe(rx)
-                self._wake.set()   # wake the maintain-loop sleep now, don't wait for the tick
-        except Exception as e:
-            LOG.debug("DHCP reply parse error: %s", e)
+    def _on_dhcp_reply(self, frame):
+        # Runs on the capture thread under the backend's handler guard
+        # (_deliver), so an unexpected failure here is logged and dropped there.
+        if frame.op != BOOTREPLY:
+            return
+        # First-party path: a reply to OUR in-flight exchange (random xid,
+        # regenerated per DORA). Parsed and fed to the waiting client sequence.
+        if frame.xid == self._dhcp.xid:
+            self._dhcp.feed(_parse_reply(frame))
+            return
+        # Not our xid. In follow mode, still watch for the PEER's ACK: both HA
+        # nodes run an identical keeper on the SAME chaddr (the CARP virtual
+        # MAC), so the peer's ACK reveals a changed ISP address one exchange
+        # sooner than our own renewal timer -- closing the window where the
+        # two nodes hold different VIP prefixes long enough for CARP to
+        # dual-master (see docs/single-ip-wan-carp.md, section 3). This is a
+        # deliberately narrow relaxation of the xid trust gate: it requires
+        # our chaddr and an ACK for a plausible, different address, and it
+        # only RECORDS the observation (one atomic ref write) for the main
+        # thread -- which routes it through the same follow hardening
+        # (sane / same-class / expected-server / throttle) as a first-party
+        # ACK and never acts on the capture thread.
+        if not self._follow.follow or not self._dhcp.binding.yiaddr or not self._chaddr_matches(frame):
+            return
+        rx = _parse_reply(frame)
+        if (rx.mtype == ACK and rx.yiaddr and rx.yiaddr != self._dhcp.binding.yiaddr
+                and _sane_ipv4(rx.yiaddr)):
+            self._follow.observe(rx)
+            self._wake.set()   # wake the maintain-loop sleep now, don't wait for the tick
 
     # ---- heartbeat / status file ----
 
@@ -1310,12 +1794,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         return not self._stop
 
     def run(self):
-        """The daemon main loop: sniffer up, then maintain the lease until
+        """The daemon main loop: capture up, then maintain the lease until
         stopped. Never raises; returns the process exit code."""
-        # Start the packet sniffer, retrying forever: a keeper must self-heal, not
+        # Start the packet capture, retrying forever: a keeper must self-heal, not
         # die, if the interface is briefly unavailable at startup.
-        while not self._stop and not self._start_sniffer():
-            LOG.warning("sniffer start failed -- retrying in %ds", SNIFFER_RETRY)
+        while not self._stop and not self._capture.start():
+            LOG.warning("capture start failed -- retrying in %ds", SNIFFER_RETRY)
             self._sleep(SNIFFER_RETRY)
 
         # eth-src matters for L2 debugging but only when it differs from the chaddr.
@@ -1341,7 +1825,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # shutdown
         if self.release_on_exit:
             self._dhcp.release()
-        self._stop_sniffer()
+        self._capture.stop()
         LOG.info("stopped")
         return 0
 
@@ -1445,6 +1929,22 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 self.redora_wait = min(self.redora_wait * 2, REDORA_MAX)
 
 
+def _identity_options(vendor_class, client_id, hostname):
+    """Optional DHCP identity options (empty -> not sent), added to every
+    DISCOVER/REQUEST/RENEW so the server sees a consistent client identity.
+    ISP interplay: satisfies servers that only lease to a known vendor-class
+    (opt 60), client-id (61) or hostname (12) -- the "client identity checks"
+    row of the README's ISP-security section."""
+    id_opts = []
+    if vendor_class:
+        id_opts.append(("vendor_class_id", vendor_class))
+    if client_id:
+        id_opts.append(("client_id", client_id.encode()))
+    if hostname:
+        id_opts.append(("hostname", hostname))
+    return id_opts
+
+
 def acquire_pidfile(path):
     """Single-instance guard: atomically claim the pidfile, replacing a stale
     one; exits the process if another live instance holds it."""
@@ -1498,6 +1998,9 @@ def _build_arg_parser():
                     help="put the capture socket in promiscuous mode so the gateway's "
                          "unicast ARP reply is seen on NICs that filter non-primary "
                          "unicast MACs (default off; only needed if replies aren't seen)")
+    ap.add_argument("--capture-backend", choices=sorted(CAPTURE_BACKENDS), default="scapy",
+                    help="packet capture/send backend: scapy (default), or bpf -- a raw "
+                         "/dev/bpf backend with no packet-library dependency (experimental)")
     ap.add_argument("--once", action="store_true")
     ap.add_argument("--release-on-exit", action="store_true")
     return ap
@@ -1522,14 +2025,14 @@ def _setup_logging(logfile):
 # pylint: disable=protected-access
 def _claim_once(k):
     """--once mode: claim, report, release -- a wiring test, not service mode."""
-    if not k._start_sniffer():
+    if not k._capture.start():
         return 3
     time.sleep(SNIFFER_WARMUP)
     ok = k._dhcp.dora(k._follow.target)
     LOG.info("DHCP claim %s -> %s", k.chaddr, k._dhcp.binding.yiaddr if ok else "FAIL")
     if ok:
         k._dhcp.release()
-    k._stop_sniffer()
+    k._capture.stop()
     return 0 if ok else 1
 # pylint: enable=protected-access
 
@@ -1539,11 +2042,12 @@ def main():
     a = _build_arg_parser().parse_args()
     _setup_logging(a.logfile)
 
-    if _SCAPY_IMPORT_ERROR is not None:
+    if a.capture_backend == "scapy" and _SCAPY_IMPORT_ERROR is not None:
         LOG.critical("cannot import scapy -- the lease keeper cannot run: %s. "
                      "Install the matching py3<minor>-scapy package (see the plugin "
                      "docs) and restart the service.", _SCAPY_IMPORT_ERROR)
         return 3
+    LOG.info("capture backend: %s", a.capture_backend)
 
     for label, mac in (("chaddr", a.chaddr), ("eth-src", a.eth_src)):
         if mac and not MAC_RE.match(mac):
@@ -1554,7 +2058,8 @@ def main():
                hbfile=a.hbfile, release_on_exit=a.release_on_exit or a.once,
                vhid=a.vhid, follow=a.follow,
                vendor_class=a.vendor_class, client_id=a.client_id, hostname=a.hostname,
-               arp_nudge=a.arp_nudge, arp_listen_promisc=a.arp_listen_promisc)
+               arp_nudge=a.arp_nudge, arp_listen_promisc=a.arp_listen_promisc,
+               capture_backend=a.capture_backend)
 
     if a.arp_listen_promisc:
         LOG.warning("ARP listen: PROMISCUOUS capture enabled on %s -- the daemon now "

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -143,6 +143,7 @@ FOLLOW_RETRY_DEADLINE = 120  # re-drive follow_update if we are not restarted wi
 T1_FACTOR = 0.5            # renew at this fraction of the lease (RFC default)
 T2_FACTOR = 0.875          # rebind by this fraction of the lease (RFC default)
 MIN_T1 = 30                # floor for the renew timer (very short leases)
+MIN_LEASE = 2 * MIN_T1     # floor for an accepted lease time, so a tiny (even hostile) opt-51 can't spin renews
 REBIND_MARGIN = 15         # ensure T2 is at least this far past T1
 BROADCAST_FLAG = 0x8000    # BOOTP flags: ask the server to broadcast OFFER/ACK
 ETHER_BROADCAST = "ff:ff:ff:ff:ff:ff"
@@ -196,11 +197,18 @@ MTYPE_NAMES = {1: "DISCOVER", 2: "OFFER", 3: "REQUEST", 4: "DECLINE",
 
 
 def _msg_text(msg):
-    """DHCP option-56 server text (usually a NAK reason) as a stripped str, or ""
-    when absent. Option 56 may arrive as bytes or str depending on the server."""
+    """DHCP option-56 server text (usually a NAK reason) as a sanitized str, or
+    "" when absent. Option 56 may arrive as bytes or str depending on the server.
+
+    The text is attacker-controlled (any host on the segment can race a NAK with
+    a matching xid) and is written to the log, so strip control characters --
+    newlines that would forge log lines and terminal escape sequences -- before
+    it goes anywhere. Printable content is preserved."""
     if isinstance(msg, bytes):
         msg = msg.decode(errors="replace")
-    return str(msg).strip() if msg else ""
+    if not msg:
+        return ""
+    return re.sub(r"[\x00-\x1f\x7f]", "?", str(msg)).strip()
 
 
 def _fmt_reply(rx):
@@ -423,30 +431,36 @@ _OPT_DECODERS = {
 def _decode_dhcp_options(data):
     """Bounds-checked TLV walk over the options field of an untrusted reply.
     Unknown options are skipped without decoding; any truncation ends the walk
-    with what was parsed so far. Never raises on malformed input."""
-    out = []
-    i = 0
-    while i < len(data):
-        code = data[i]
-        if code == DHCP_OPT_PAD:
-            i += 1
+    with what was parsed so far. Never raises on malformed input.
+
+    Option overload (option 52), where a server continues its options into the
+    BOOTP sname/file fields, is deliberately NOT handled: with the keeper's
+    6-entry parameter request list every reply fits the options field many
+    times over, so no server the keeper talks to overloads."""
+    options = []
+    pos = 0
+    while pos < len(data):
+        code = data[pos]
+        if code == DHCP_OPT_PAD:        # a single padding byte, no length/value
+            pos += 1
             continue
-        if code == DHCP_OPT_END:
+        if code == DHCP_OPT_END:        # explicit end of options
             break
-        if i + 2 > len(data):    # length byte missing
+        if pos + 2 > len(data):         # the length byte itself is missing
             break
-        length = data[i + 1]
-        value = data[i + 2:i + 2 + length]
-        if len(value) < length:  # value truncated
+        length = data[pos + 1]
+        value = data[pos + 2:pos + 2 + length]
+        if len(value) < length:         # the value runs past the end of the buffer
             break
-        known = _OPT_DECODERS.get(code)
-        if known:
+        decoder = _OPT_DECODERS.get(code)
+        if decoder is not None:
+            name, decode_value = decoder
             try:
-                out.append((known[0], known[1](value)))
+                options.append((name, decode_value(value)))
             except (ValueError, IndexError):
-                pass             # malformed value inside a known option -> skip it
-        i += 2 + length
-    return out
+                pass                    # malformed value in a known option: skip, keep walking
+        pos += 2 + length
+    return options
 
 
 def _decode_arp(pkt):
@@ -467,11 +481,20 @@ def _decode_ipv4_bootp(pkt):
     total = int.from_bytes(pkt[2:4], "big")
     if ihl < 20 or total < ihl + 8 or len(pkt) < ihl + 8:
         return None
-    if pkt[9] != IPPROTO_UDP:
+    is_udp = pkt[9] == IPPROTO_UDP
+    is_unfragmented = (int.from_bytes(pkt[6:8], "big") & 0x3FFF) == 0   # no MF bit, no frag offset
+    if not (is_udp and is_unfragmented):
         return None
-    if int.from_bytes(pkt[6:8], "big") & 0x3FFF:   # MF set or a fragment continuation
+    # Bound the BOOTP slice by the UDP length too, not just the IP total: a
+    # datagram whose UDP length is shorter than the IP payload would otherwise
+    # let trailing bytes be parsed as DHCP options. Trust the smallest of the
+    # three lengths (untrusted input); a UDP length shorter than its own header
+    # is malformed.
+    udp_len = int.from_bytes(pkt[ihl + 4:ihl + 6], "big")
+    if udp_len < 8:
         return None
-    bootp = pkt[ihl + 8:min(total, len(pkt))]      # UDP payload, minus any link padding
+    end = min(total, ihl + udp_len, len(pkt))
+    bootp = pkt[ihl + 8:end]                        # UDP payload, minus any link padding
     if len(bootp) < BOOTP_HDR_LEN + 4 or bootp[BOOTP_HDR_LEN:BOOTP_HDR_LEN + 4] != DHCP_MAGIC:
         return None
     # The options walk only pays off for server replies; on a shared segment
@@ -492,9 +515,11 @@ def _decode_ipv4_bootp(pkt):
 BIOCGBLEN = 0x40044266       # _IOR('B', 102, u_int): kernel capture buffer size
 BIOCSETF = 0x80104267        # _IOW('B', 103, struct bpf_program): attach the filter
 BIOCPROMISC = 0x20004269     # _IO('B', 105): promiscuous mode
+BIOCGDLT = 0x4004426A        # _IOR('B', 106, u_int): the interface's data-link type
 BIOCSETIF = 0x8020426C       # _IOW('B', 108, struct ifreq): bind to the interface
 BIOCIMMEDIATE = 0x80044270   # _IOW('B', 112, u_int): deliver per packet, not per full buffer
 BIOCSHDRCMPLT = 0x80044275   # _IOW('B', 117, u_int): we supply the Ethernet source MAC
+DLT_EN10MB = 1               # Ethernet: the only link type this codec's offsets assume
 BPF_ALIGNMENT = 8            # capture records align to sizeof(long)
 BPF_HDR_FIXED = 26           # bh_tstamp(16) + bh_caplen(4) + bh_datalen(4) + bh_hdrlen(2)
 
@@ -502,47 +527,65 @@ BPF_HDR_FIXED = 26           # bh_tstamp(16) + bh_caplen(4) + bh_datalen(4) + bh
 # no runtime filter compiler. MUST stay in lockstep with SNIFFER_FILTER;
 # regenerate on any FreeBSD/OPNsense host with:
 #   tcpdump -i <ethernet-iface> -dd '(udp and (port 67 or port 68)) or (arp and arp[6:2] = 2)'
+# The trailing comment on each row is the `tcpdump -d` mnemonic so the table can
+# be audited by eye against the filter string without a FreeBSD box; jump
+# targets are absolute instruction indices (tcpdump's relative jt/jf + here+1).
+# A bench test (testbench repo) asserts `tcpdump -ddd SNIFFER_FILTER` still
+# equals this table, turning the lockstep requirement into an enforced invariant.
 _BPF_FILTER = (
-    (0x28, 0, 0, 0x0000000C),
-    (0x15, 0, 10, 0x00000800),
-    (0x30, 0, 0, 0x00000017),
-    (0x15, 0, 21, 0x00000011),
-    (0x28, 0, 0, 0x00000014),
-    (0x45, 19, 0, 0x00001FFF),
-    (0xB1, 0, 0, 0x0000000E),
-    (0x48, 0, 0, 0x0000000E),
-    (0x15, 15, 0, 0x00000043),
-    (0x15, 14, 0, 0x00000044),
-    (0x48, 0, 0, 0x00000010),
-    (0x15, 12, 8, 0x00000043),
-    (0x15, 0, 8, 0x000086DD),
-    (0x30, 0, 0, 0x00000014),
-    (0x15, 0, 10, 0x00000011),
-    (0x28, 0, 0, 0x00000036),
-    (0x15, 7, 0, 0x00000043),
-    (0x15, 6, 0, 0x00000044),
-    (0x28, 0, 0, 0x00000038),
-    (0x15, 4, 0, 0x00000043),
-    (0x15, 3, 4, 0x00000044),
-    (0x15, 0, 3, 0x00000806),
-    (0x28, 0, 0, 0x00000014),
-    (0x15, 0, 1, 0x00000002),
-    (0x6, 0, 0, 0x00040000),
-    (0x6, 0, 0, 0x00000000),
+    (0x28, 0, 0, 0x0000000C),   # 00 ldh  [12]                 ; ethertype
+    (0x15, 0, 10, 0x00000800),  # 01 jeq  #0x800  -> 02, ->12  ; IPv4?
+    (0x30, 0, 0, 0x00000017),   # 02 ldb  [23]                 ; IPv4 proto
+    (0x15, 0, 21, 0x00000011),  # 03 jeq  #17     -> 04, ->25  ; UDP?
+    (0x28, 0, 0, 0x00000014),   # 04 ldh  [20]                 ; flags+frag
+    (0x45, 19, 0, 0x00001FFF),  # 05 jset #0x1fff ->25, -> 06  ; fragment? drop
+    (0xB1, 0, 0, 0x0000000E),   # 06 ldxb 4*([14]&0xf)         ; X = IP hdr len
+    (0x48, 0, 0, 0x0000000E),   # 07 ldh  [x+14]               ; UDP src port
+    (0x15, 15, 0, 0x00000043),  # 08 jeq  #67     ->24, -> 09  ; sport 67? accept
+    (0x15, 14, 0, 0x00000044),  # 09 jeq  #68     ->24, -> 10  ; sport 68? accept
+    (0x48, 0, 0, 0x00000010),   # 10 ldh  [x+16]               ; UDP dst port
+    (0x15, 12, 8, 0x00000043),  # 11 jeq  #67     ->24, ->20   ; dport 67? accept
+    (0x15, 0, 8, 0x000086DD),   # 12 jeq  #0x86dd -> 13, ->21  ; IPv6? (else ARP)
+    (0x30, 0, 0, 0x00000014),   # 13 ldb  [20]                 ; IPv6 next header
+    (0x15, 0, 10, 0x00000011),  # 14 jeq  #17     -> 15, ->25  ; UDP?
+    (0x28, 0, 0, 0x00000036),   # 15 ldh  [54]                 ; UDP src port (14+40)
+    (0x15, 7, 0, 0x00000043),   # 16 jeq  #67     ->24, -> 17  ; sport 67? accept
+    (0x15, 6, 0, 0x00000044),   # 17 jeq  #68     ->24, -> 18  ; sport 68? accept
+    (0x28, 0, 0, 0x00000038),   # 18 ldh  [56]                 ; UDP dst port
+    (0x15, 4, 0, 0x00000043),   # 19 jeq  #67     ->24, ->20   ; dport 67? accept
+    (0x15, 3, 4, 0x00000044),   # 20 jeq  #68     ->24, ->25   ; dport 68? accept
+    (0x15, 0, 3, 0x00000806),   # 21 jeq  #0x806  -> 22, ->25  ; ARP?
+    (0x28, 0, 0, 0x00000014),   # 22 ldh  [20]                 ; ARP opcode
+    (0x15, 0, 1, 0x00000002),   # 23 jeq  #2      ->24, ->25   ; is-at reply?
+    (0x6, 0, 0, 0x00040000),    # 24 ret  #262144              ; ACCEPT (snap len)
+    (0x6, 0, 0, 0x00000000),    # 25 ret  #0                   ; DROP
 )
 
 
+def _bpf_align(nbytes):
+    """Round a record length up to the BPF record alignment (sizeof(long))."""
+    return (nbytes + BPF_ALIGNMENT - 1) & ~(BPF_ALIGNMENT - 1)
+
+
 def _bpf_frames(data):
-    """Walk a raw BPF read buffer, yielding each record's captured bytes.
-    Records are struct bpf_hdr framed and BPF_ALIGNMENT-padded; a malformed
-    record stops the walk rather than misparse the rest."""
-    i = 0
-    while i + BPF_HDR_FIXED <= len(data):
-        caplen, _datalen, hdrlen = struct.unpack_from("=IIH", data, i + 16)
-        if hdrlen < BPF_HDR_FIXED or i + hdrlen + caplen > len(data):
+    """Yield each captured Ethernet frame from a raw BPF read buffer.
+
+    One read(2) can return several packets back to back, each prefixed by a
+    struct bpf_hdr and padded to the record alignment. bh_tstamp occupies the
+    first 16 bytes; bh_caplen, bh_datalen and bh_hdrlen follow. A record whose
+    header or length is inconsistent ends the walk rather than risk misparsing
+    the rest of the buffer (it is only as trustworthy as the kernel handed it
+    over)."""
+    pos = 0
+    while pos + BPF_HDR_FIXED <= len(data):
+        # bh_caplen (u_int), bh_datalen (u_int), bh_hdrlen (u_short), in host
+        # byte order, immediately after the 16-byte bh_tstamp.
+        caplen, _datalen, hdrlen = struct.unpack_from("=IIH", data, pos + 16)
+        record_end = pos + hdrlen + caplen
+        if hdrlen < BPF_HDR_FIXED or record_end > len(data):
             break
-        yield data[i + hdrlen:i + hdrlen + caplen]
-        i += (hdrlen + caplen + BPF_ALIGNMENT - 1) & ~(BPF_ALIGNMENT - 1)
+        yield data[pos + hdrlen:record_end]
+        pos += _bpf_align(hdrlen + caplen)
 
 
 # ---- capture backends ----
@@ -595,10 +638,19 @@ class ScapyCapture:
             return False
 
     def stop(self):
-        """Best-effort capture stop (scapy may raise if it never ran)."""
+        """Best-effort capture stop (scapy may raise if it never ran).
+
+        Join with a bound: scapy's own stop() joins the sniffer thread with no
+        timeout, so a sniffer that fails to break its loop would hang the main
+        thread here -- and because this runs from _ensure_sniffer mid-sequence,
+        that would freeze the heartbeat and trip a false CARP demotion. Ask it
+        not to join, then join the thread ourselves with a ceiling."""
         try:
             if self._sniffer:
-                self._sniffer.stop()
+                self._sniffer.stop(join=False)
+                thread = getattr(self._sniffer, "thread", None)
+                if thread is not None:
+                    thread.join(timeout=2)
         except Exception:
             pass
 
@@ -653,99 +705,163 @@ class BpfCapture:  # pylint: disable=too-many-instance-attributes
     """Capture/send on a raw /dev/bpf descriptor -- no packet library. A
     reader thread walks the BPF buffer and hands decoded neutral frames to
     the same callbacks the scapy backend feeds. FreeBSD-only (OPNsense's
-    platform); selected with --capture-backend bpf (experimental)."""
+    platform); selected with --capture-backend bpf (experimental).
+
+    Shutdown uses a self-pipe rather than a poll timeout: the reader blocks in
+    select() on both the bpf fd and a wake pipe, and stop() writes one byte to
+    the pipe so the reader returns at once (no periodic wakeups, no up-to-1s
+    stop latency). The stop signal and the wake pipe are created fresh per
+    start(), and the reader owns and closes its own bpf fd on exit, so a reader
+    that outlives its stop() (e.g. stalled in a slow log write) can neither be
+    revived by the next start() nor have its fd number reused underneath it."""
 
     def __init__(self, iface, promisc, on_bootp, on_arp):
         self.iface = iface
         self.promisc = promisc
         self._on_bootp = on_bootp
         self._on_arp = on_arp
-        self._fd = None
-        self._buflen = 0               # set from BIOCGBLEN in _configure
-        self._thread = None
-        self._closing = False
+        self._fd = None                # the live capture fd, or None when stopped
+        self._buflen = 0               # kernel buffer size, from BIOCGBLEN in _configure
+        self._thread = None            # the current reader thread
+        self._stop_event = None        # set to ask the current reader to exit
+        self._wake_writer = None       # write end of this generation's wake pipe
 
     def start(self):
-        """(Re)open /dev/bpf bound + filtered to the interface and start the
-        reader thread. False on any failure (the caller retries)."""
+        """(Re)open /dev/bpf, bind + filter it to the interface, and start the
+        reader thread. Returns False on any failure (the caller retries)."""
         if fcntl is None:
             LOG.error("bpf backend unavailable: no fcntl module on this platform")
             return False
+        self.stop()
+        wake_reader, wake_writer = os.pipe()
         try:
-            self.stop()
-            self._closing = False
             fd = os.open("/dev/bpf", os.O_RDWR)
-            try:
-                self._configure(fd)
-            except Exception:
-                os.close(fd)
-                raise
-            self._fd = fd
-            self._thread = threading.Thread(target=self._read_loop, args=(fd,),
-                                            name="bpf-capture", daemon=True)
-            self._thread.start()
-            return True
-        except Exception as e:
+        except OSError as e:
+            os.close(wake_reader)
+            os.close(wake_writer)
             LOG.error("bpf capture start failed on %s: %s", self.iface, e)
             return False
+        try:
+            self._configure(fd)
+        except Exception as e:
+            os.close(fd)
+            os.close(wake_reader)
+            os.close(wake_writer)
+            LOG.error("bpf capture start failed on %s: %s", self.iface, e)
+            return False
+        stop_event = threading.Event()
+        # The reader owns fd and wake_reader and closes them when it exits.
+        self._thread = threading.Thread(
+            target=self._read_loop, args=(fd, wake_reader, stop_event),
+            name="bpf-capture", daemon=True)
+        self._fd = fd
+        self._stop_event = stop_event
+        self._wake_writer = wake_writer
+        self._thread.start()
+        return True
 
     def _configure(self, fd):
-        """Bind, tune and filter a fresh bpf descriptor."""
+        """Bind, tune and filter a fresh bpf descriptor.
+
+        BIOCSETIF (bind) has to come first -- it is what libpcap does and what
+        BIOCGDLT needs -- so the filter is attached immediately after, keeping
+        the window in which the descriptor would accept unfiltered traffic to a
+        single ioctl."""
         fcntl.ioctl(fd, BIOCSETIF, struct.pack("16s16x", self.iface.encode()))
+        # The codec's frame offsets assume Ethernet; a PPPoE/tun WAN would make
+        # both capture and injection meaningless. Fail loudly instead of leaving
+        # only a "no DHCP OFFER" symptom.
+        dlt = struct.unpack("I", fcntl.ioctl(fd, BIOCGDLT, b"\x00" * 4))[0]
+        if dlt != DLT_EN10MB:
+            raise OSError(f"{self.iface} is not Ethernet (bpf data-link type {dlt}); "
+                          "the bpf backend supports Ethernet only")
+        # Attach the capture filter right after the bind (and before the rest of
+        # the tuning) so almost no unfiltered traffic can enter the buffer.
+        program = b"".join(struct.pack("HBBI", *insn) for insn in _BPF_FILTER)
+        program_buf = ctypes.create_string_buffer(program)   # kernel copies it during the ioctl
+        # struct bpf_program is { u_int bf_len; struct bpf_insn *bf_insns; };
+        # "@IQ" gives the native u_int + pointer layout on LP64.
+        fcntl.ioctl(fd, BIOCSETF,
+                    struct.pack("@IQ", len(_BPF_FILTER), ctypes.addressof(program_buf)))
         # Immediate mode: hand packets over as they arrive; the DHCP exchanges
         # wait on second-scale timeouts, so buffering a full block is not an option.
         fcntl.ioctl(fd, BIOCIMMEDIATE, struct.pack("I", 1))
-        # Header-complete: our frames carry the CARP vMAC as the Ethernet
-        # source; without this the kernel would overwrite it with the NIC MAC.
+        # Header-complete: our frames carry the CARP vMAC as the Ethernet source;
+        # without this the kernel would overwrite it with the NIC's own MAC.
         fcntl.ioctl(fd, BIOCSHDRCMPLT, struct.pack("I", 1))
         if self.promisc:
             fcntl.ioctl(fd, BIOCPROMISC)
-        insns = b"".join(struct.pack("HBBI", *insn) for insn in _BPF_FILTER)
-        buf = ctypes.create_string_buffer(insns)   # the kernel copies it during the ioctl
-        # struct bpf_program: u_int bf_len + insn pointer ("@IQ" pads to native layout)
-        fcntl.ioctl(fd, BIOCSETF, struct.pack("@IQ", len(_BPF_FILTER), ctypes.addressof(buf)))
         # bpf read(2) calls must request exactly the kernel buffer size.
         self._buflen = struct.unpack("I", fcntl.ioctl(fd, BIOCGBLEN, b"\x00" * 4))[0]
 
     def stop(self):
-        """Close the descriptor (the kernel detaches filter/promisc) and
-        collect the reader thread; the closing flag stops its select loop."""
-        self._closing = True
-        fd, self._fd = self._fd, None
-        if fd is not None:
+        """Ask the current reader to exit and wait briefly for it. The reader
+        closes its own fd, so stop() only signals and joins; a reader still
+        alive after the join (stuck in a slow callback) is left to exit on its
+        own -- it holds its own fd, so nothing here can be reused under it."""
+        thread = self._thread
+        stop_event = self._stop_event
+        wake_writer = self._wake_writer
+        self._fd = None
+        self._thread = None
+        self._stop_event = None
+        self._wake_writer = None
+
+        if stop_event is not None:
+            stop_event.set()
+        if wake_writer is not None:
             try:
-                os.close(fd)
+                os.write(wake_writer, b"\x00")   # wake the reader's select() at once
             except OSError:
                 pass
-        thread, self._thread = self._thread, None
-        if thread and thread.is_alive():
+            try:
+                os.close(wake_writer)
+            except OSError:
+                pass
+        if thread is not None and thread.is_alive():
             thread.join(timeout=2)
+            if thread.is_alive():
+                LOG.warning("bpf reader did not exit within 2s -- leaving it to "
+                            "finish; its fd is not reused")
 
     def alive(self):
         """True while the descriptor is open and the reader thread runs."""
-        return bool(self._fd is not None and self._thread and self._thread.is_alive())
+        return self._fd is not None and self._thread is not None and self._thread.is_alive()
 
-    def _read_loop(self, fd):
-        """Reader thread: select with a timeout so stop() (which closes the
-        fd) is noticed within a second, then walk the BPF buffer records."""
-        while not self._closing:
-            try:
-                ready, _, _ = select.select([fd], [], [], 1.0)
-                if not ready:
+    def _read_loop(self, fd, wake_reader, stop_event):
+        """Reader thread: block in select() on the bpf fd and the wake pipe;
+        stop() writes to the pipe to end the wait. Owns fd and wake_reader and
+        closes both on exit, so the fd's lifetime ends exactly when this thread
+        does."""
+        try:
+            while not stop_event.is_set():
+                try:
+                    readable, _, _ = select.select([fd, wake_reader], [], [])
+                except OSError:
+                    return
+                if wake_reader in readable:      # stop() rang -- loop condition ends us
                     continue
-                data = os.read(fd, self._buflen)
-            except (OSError, ValueError):
-                if not self._closing:
-                    LOG.warning("bpf read failed -- capture thread exiting")
-                return
-            for frame in _bpf_frames(data):
-                self._dispatch(frame)
+                try:
+                    data = os.read(fd, self._buflen)
+                except (OSError, ValueError):
+                    if not stop_event.is_set():
+                        LOG.warning("bpf read failed -- capture thread exiting")
+                    return
+                for frame in _bpf_frames(data):
+                    self._dispatch(frame)
+        finally:
+            for owned_fd in (fd, wake_reader):
+                try:
+                    os.close(owned_fd)
+                except OSError:
+                    pass
 
     def _dispatch(self, frame):
         """Decode one captured Ethernet frame and route it by ethertype to the
         keeper callback (via _deliver, so a handler failure is labelled as
         such). A parse error in the untrusted input is dropped (debug-logged)."""
-        decoded = handler = None
+        decoded = None
+        handler = None
         try:
             if len(frame) >= 14:
                 ethertype = int.from_bytes(frame[12:14], "big")
@@ -759,7 +875,8 @@ class BpfCapture:  # pylint: disable=too-many-instance-attributes
         _deliver(handler, decoded)
 
     def _write(self, frame):
-        """Inject one raw Ethernet frame on the interface."""
+        """Inject one raw Ethernet frame on the interface. Main-thread only (the
+        capture thread never sends), so reading self._fd needs no lock."""
         fd = self._fd
         if fd is None:
             raise OSError("bpf capture not started")
@@ -951,8 +1068,10 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         """Adopt lease timing, gateway (opt 3) and subnet mask (opt 1) from an ACK
         -- the one place that knows which DhcpReply fields carry lease state.
         gateway + mask are what the Parameter Request List asks for; keep them for
-        logging + the cross-subnet follow decision."""
-        self.binding.lease_secs = rx.lease or default_lease
+        logging + the cross-subnet follow decision. The lease time is floored at
+        MIN_LEASE so a server (or a spoofed ACK) offering a 1-second lease cannot
+        drive the renew loop into a tight broadcast/CPU spin."""
+        self.binding.lease_secs = max(rx.lease or default_lease, MIN_LEASE)
         self.binding.t1_server, self.binding.t2_server = rx.t1, rx.t2
         self.binding.router = rx.router or self.binding.router
         self.binding.mask_bits = _mask_to_bits(rx.subnet_mask) or self.binding.mask_bits
@@ -1034,6 +1153,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         for attempt in range(1, DORA_ATTEMPTS + 1):
             if self._should_stop():
                 return False
+            self._ensure_sniffer()   # an interface flap between OFFER and here would leave us deaf
             self._rx = None
             try:
                 self._send_dhcp(
@@ -1432,8 +1552,13 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
             LOG.error("follow_update retry failed: %s", e)
 
     def observe(self, rx):
-        """Record a peer-ACK observation (sniffer thread; a lone ref-assign);
-        the main loop consumes it in check_observed()."""
+        """Record a peer-ACK observation (capture thread; a lone ref-assign);
+        the main loop consumes it in check_observed().
+
+        The read-then-clear in check_observed is not atomic against this store,
+        so a peer ACK landing in that narrow window can be dropped. Accepted:
+        the next peer ACK or our own renewal re-detects the change, and the 1s
+        maintain tick keeps polling -- convergence is delayed, never lost."""
         self._observed = rx
 
     def check_observed(self):

--- a/net/os-carp-vip-dhcp/tests/conftest.py
+++ b/net/os-carp-vip-dhcp/tests/conftest.py
@@ -18,6 +18,11 @@ SCRIPT_DIR = os.path.abspath(os.path.join(
     "src", "opnsense", "scripts", "OPNsense", "CarpVipDhcp"))
 sys.path.insert(0, SCRIPT_DIR)
 
+# The canonical test identity (CARP vMAC for vhid 0xfe), shared by the test
+# modules so the fixture MAC lives in exactly one place.
+CHADDR_STR = "00:00:5e:00:01:fe"
+CHADDR = bytes.fromhex(CHADDR_STR.replace(":", ""))
+
 
 def _stub_scapy():
     if "scapy.all" in sys.modules:

--- a/net/os-carp-vip-dhcp/tests/test_codec.py
+++ b/net/os-carp-vip-dhcp/tests/test_codec.py
@@ -1,0 +1,268 @@
+"""Unit tests for the raw wire codec behind the bpf capture backend: golden
+bytes for the frames the keeper sends, defensive decoding of untrusted
+replies (bounds-checked TLV walk), and the BPF capture-buffer walk.
+
+Tests reach into private helpers by design, and use comments over
+per-test docstrings."""
+# pylint: disable=protected-access, missing-function-docstring
+import struct
+
+from conftest import CHADDR
+
+
+# ---- helpers: hand-built server replies (the encoder only builds requests) ----
+
+def _bootp_reply(lk, *, op=2, xid=0x1234, yiaddr="100.64.4.7", giaddr="0.0.0.0",  # pylint: disable=too-many-arguments
+                 chaddr=CHADDR, options=b"", cookie=None):
+    """A raw BOOTP reply payload: fixed header + magic cookie + options."""
+    hdr = struct.pack("!4BIHH", op, 1, 6, 0, xid, 0, 0)
+    hdr += lk._ip4("0.0.0.0") + lk._ip4(yiaddr) + lk._ip4("0.0.0.0") + lk._ip4(giaddr)
+    hdr += chaddr.ljust(16, b"\x00") + b"\x00" * 192
+    return hdr + (lk.DHCP_MAGIC if cookie is None else cookie) + bytes(options)
+
+
+def _ack_options(lk):
+    """Raw TLVs of a typical ACK: type, server-id, lease, router, mask, end."""
+    return bytes(
+        [53, 1, lk.ACK,
+         54, 4, 100, 64, 4, 1,
+         51, 4, 0, 0, 7, 8,           # lease 1800
+         3, 4, 100, 64, 4, 1,
+         1, 4, 255, 255, 255, 0,
+         255])
+
+
+# ---- outbound: golden bytes ----
+
+def test_encode_dhcp_options_golden(lk):
+    raw = lk._encode_dhcp_options([
+        ("message-type", "discover"),
+        ("param_req_list", [1, 3, 51, 54, 58, 59]),
+        ("requested_addr", "100.64.4.7"),
+        "end",
+    ])
+    assert raw == bytes([53, 1, 1,
+                         55, 6, 1, 3, 51, 54, 58, 59,
+                         50, 4, 100, 64, 4, 7,
+                         255])
+
+
+def test_encode_dhcp_options_drops_none_values(lk):
+    # A broadcast RELEASE carries no server-id: the None option vanishes
+    # instead of encoding garbage, and end is still appended exactly once.
+    raw = lk._encode_dhcp_options([("message-type", "release"), ("server_id", None), "end"])
+    assert raw == bytes([53, 1, 7, 255])
+
+
+def test_encode_dhcp_options_identity_options(lk):
+    raw = lk._encode_dhcp_options([
+        ("hostname", "fw1"),
+        ("vendor_class_id", "acme"),
+        ("client_id", b"\x01abc"),      # arrives pre-encoded from the CLI
+    ])
+    assert raw == bytes([12, 3]) + b"fw1" + bytes([60, 4]) + b"acme" + bytes([61, 4]) + b"\x01abc" + bytes([255])
+
+
+def test_encode_bootp_request_layout(lk):
+    payload = lk._encode_bootp_request(CHADDR, 0x11223344, "0.0.0.0", lk.BROADCAST_FLAG,
+                                       [("message-type", "discover"), "end"])
+    assert len(payload) == lk.BOOTP_MIN_PAYLOAD          # padded to the RFC 1542 minimum
+    assert payload[0] == 1 and payload[1] == 1 and payload[2] == 6   # BOOTREQUEST, Ethernet, hlen 6
+    assert payload[4:8] == b"\x11\x22\x33\x44"           # xid, network order
+    assert struct.unpack("!H", payload[10:12])[0] == lk.BROADCAST_FLAG
+    assert payload[28:44] == CHADDR.ljust(16, b"\x00")   # chaddr field, zero-padded
+    assert payload[lk.BOOTP_HDR_LEN:lk.BOOTP_HDR_LEN + 4] == lk.DHCP_MAGIC
+    assert payload[lk.BOOTP_HDR_LEN + 4:lk.BOOTP_HDR_LEN + 8] == bytes([53, 1, 1, 255])
+
+
+def test_encode_bootp_request_renew_sets_ciaddr(lk):
+    payload = lk._encode_bootp_request(CHADDR, 1, "100.64.4.7", 0, [])
+    assert payload[12:16] == bytes([100, 64, 4, 7])      # ciaddr
+    assert payload[16:20] == b"\x00" * 4                 # yiaddr stays zero on a request
+
+
+def test_ipv4_and_udp_checksums_validate(lk):
+    dgram = lk._encode_ipv4_udp("100.64.4.7", "255.255.255.255", 68, 67, b"payload")
+    # A correct ones-complement checksum makes the checksum-of-the-whole zero.
+    assert lk._inet_checksum(dgram[:20]) == 0            # IP header
+    udp_len = len(dgram) - 20
+    pseudo = dgram[12:16] + dgram[16:20] + struct.pack("!BBH", 0, lk.IPPROTO_UDP, udp_len)
+    assert lk._inet_checksum(pseudo + dgram[20:]) == 0   # UDP with pseudo-header
+    assert dgram[9] == lk.IPPROTO_UDP
+    assert struct.unpack("!H", dgram[2:4])[0] == len(dgram)
+
+
+def test_inet_checksum_known_vector(lk):
+    # The classic worked example (an IP header whose checksum field is zeroed).
+    hdr = bytes.fromhex("45000073000040004011" + "0000" + "c0a80001c0a800c7")
+    assert lk._inet_checksum(hdr) == 0xB861
+
+
+def test_encode_arp_request_golden(lk):
+    raw = lk._encode_arp_request("00:00:5e:00:01:fe", "100.64.4.7", "100.64.4.1")
+    assert raw == (struct.pack("!HHBBH", 1, lk.ETHERTYPE_IPV4, 6, 4, 1)
+                   + CHADDR + bytes([100, 64, 4, 7])
+                   + b"\x00" * 6 + bytes([100, 64, 4, 1]))
+
+
+def test_encode_ether_golden(lk):
+    frame = lk._encode_ether(lk.ETHER_BROADCAST, "00:00:5e:00:01:fe", lk.ETHERTYPE_ARP, b"x")
+    assert frame == b"\xff" * 6 + CHADDR + b"\x08\x06" + b"x"
+
+
+# ---- inbound: defensive decoding of untrusted replies ----
+
+def test_decode_dhcp_options_typical_ack(lk):
+    opts = dict(lk._decode_dhcp_options(_ack_options(lk)))
+    assert opts["message-type"] == lk.ACK
+    assert opts["server_id"] == "100.64.4.1" and opts["router"] == "100.64.4.1"
+    assert opts["lease_time"] == 1800 and opts["subnet_mask"] == "255.255.255.0"
+
+
+def test_decode_dhcp_options_pad_end_and_unknown(lk):
+    # pads are stepped over, unknown options (here 42) are skipped unread,
+    # and nothing after the end option is parsed.
+    data = bytes([0, 0, 42, 2, 9, 9, 53, 1, 5, 255, 54, 4, 1, 2, 3, 4])
+    assert lk._decode_dhcp_options(data) == [("message-type", 5)]
+
+
+def test_decode_dhcp_options_truncations_never_raise(lk):
+    assert lk._decode_dhcp_options(b"") == []
+    assert lk._decode_dhcp_options(bytes([53])) == []                # length byte missing
+    assert lk._decode_dhcp_options(bytes([53, 4, 5])) == []          # value truncated
+    # a malformed value inside a known option is skipped; the walk continues
+    assert lk._decode_dhcp_options(bytes([51, 2, 1, 2, 53, 1, 5])) == [("message-type", 5)]
+    assert lk._decode_dhcp_options(bytes([53, 0])) == []             # empty message-type
+
+
+def test_decode_dhcp_options_message_stays_bytes(lk):
+    # option 56 arrives as bytes; _msg_text does the decoding later.
+    assert lk._decode_dhcp_options(bytes([56, 4]) + b"nope") == [("message", b"nope")]
+
+
+def test_decode_arp(lk):
+    good = lk._encode_arp_request("00:00:5e:00:01:fe", "100.64.4.7", "100.64.4.1")
+    assert lk._decode_arp(good) == lk.ArpFrame(1, "100.64.4.7", "100.64.4.1")
+    assert lk._decode_arp(good[:20]) is None                         # truncated
+    assert lk._decode_arp(b"\x00\x02" + good[2:]) is None            # not Ethernet hardware
+    reply = b"\x00\x01\x08\x00\x06\x04\x00\x02" + good[8:]
+    assert lk._decode_arp(reply).op == 2
+
+
+def test_decode_ipv4_bootp_end_to_end(lk):
+    payload = _bootp_reply(lk, options=_ack_options(lk), giaddr="100.64.4.9")
+    frame = lk._decode_ipv4_bootp(lk._encode_ipv4_udp("100.64.4.1", "255.255.255.255", 67, 68, payload))
+    assert frame.op == lk.BOOTREPLY and frame.xid == 0x1234
+    assert frame.yiaddr == "100.64.4.7" and frame.giaddr == "100.64.4.9"
+    assert frame.chaddr[:6] == CHADDR
+    # ...and the frame satisfies the backend-neutral reply parser end to end.
+    rx = lk._parse_reply(frame)
+    assert rx.mtype == lk.ACK and rx.yiaddr == "100.64.4.7"
+    assert rx.server_id == "100.64.4.1" and rx.lease == 1800
+    assert rx.subnet_mask == "255.255.255.0" and rx.giaddr == "100.64.4.9"
+
+
+def test_decode_ipv4_bootp_trims_link_padding(lk):
+    # Ethernet pads short frames: bytes past the IP total length must not
+    # leak into the options walk.
+    payload = _bootp_reply(lk, options=bytes([53, 1, 5, 255]))
+    dgram = lk._encode_ipv4_udp("100.64.4.1", "255.255.255.255", 67, 68, payload)
+    frame = lk._decode_ipv4_bootp(dgram + b"\x35\x01\x06" * 4)   # padding that mimics option bytes
+    assert dict(frame.options)["message-type"] == 5
+
+
+def test_decode_ipv4_bootp_rejects_malformed(lk):
+    payload = _bootp_reply(lk, options=bytes([53, 1, 5, 255]))
+    dgram = lk._encode_ipv4_udp("100.64.4.1", "255.255.255.255", 67, 68, payload)
+    assert lk._decode_ipv4_bootp(b"") is None
+    assert lk._decode_ipv4_bootp(dgram[:30]) is None                      # truncated
+    assert lk._decode_ipv4_bootp(b"\x65" + dgram[1:]) is None             # not IPv4
+    not_udp = dgram[:9] + b"\x06" + dgram[10:]
+    assert lk._decode_ipv4_bootp(not_udp) is None                         # TCP proto
+    fragged = dgram[:6] + b"\x20\x00" + dgram[8:]
+    assert lk._decode_ipv4_bootp(fragged) is None                         # MF set
+    bad_cookie = lk._encode_ipv4_udp("100.64.4.1", "255.255.255.255", 67, 68,
+                                     _bootp_reply(lk, cookie=b"\x00\x00\x00\x00"))
+    assert lk._decode_ipv4_bootp(bad_cookie) is None
+    short_bootp = lk._encode_ipv4_udp("100.64.4.1", "255.255.255.255", 67, 68, b"\x02" * 100)
+    assert lk._decode_ipv4_bootp(short_bootp) is None
+
+
+# ---- the BPF capture-buffer walk ----
+
+def _bpf_record(lk, frame):
+    hdr = struct.pack("=16xIIH", len(frame), len(frame), lk.BPF_HDR_FIXED)
+    record = hdr + frame
+    pad = -len(record) % lk.BPF_ALIGNMENT
+    return record + b"\x00" * pad
+
+
+def test_bpf_frames_walks_records(lk):
+    frames = [b"first-frame!", b"the-second-frame-is-longer"]
+    data = b"".join(_bpf_record(lk, f) for f in frames)
+    assert list(lk._bpf_frames(data)) == frames
+
+
+def test_bpf_frames_stops_on_malformed(lk):
+    good = _bpf_record(lk, b"good-frame")
+    truncated = struct.pack("=16xIIH", 4096, 4096, lk.BPF_HDR_FIXED) + b"tiny"
+    assert list(lk._bpf_frames(good + truncated)) == [b"good-frame"]
+    assert not list(lk._bpf_frames(b"\x00" * 10))                    # shorter than a header
+    bad_hdrlen = struct.pack("=16xIIH", 4, 4, 2) + b"\x00" * 8
+    assert not list(lk._bpf_frames(bad_hdrlen))
+
+
+# ---- BpfCapture: dispatch + send paths (no descriptor needed) ----
+
+def _bpf_capture(lk):
+    frames = {"bootp": [], "arp": [], "sent": []}
+    cap = lk.BpfCapture("eth0", False, frames["bootp"].append, frames["arp"].append)
+    cap._write = frames["sent"].append
+    return cap, frames
+
+
+def test_bpf_dispatch_routes_by_ethertype(lk):
+    cap, frames = _bpf_capture(lk)
+    arp = lk._encode_ether(lk.ETHER_BROADCAST, "00:00:5e:00:01:fe", lk.ETHERTYPE_ARP,
+                           b"\x00\x01\x08\x00\x06\x04\x00\x02" + CHADDR
+                           + bytes([100, 64, 4, 1]) + b"\x00" * 6 + bytes([100, 64, 4, 7]))
+    cap._dispatch(arp)
+    dhcp = lk._encode_ether(lk.ETHER_BROADCAST, "00:00:5e:00:01:fe", lk.ETHERTYPE_IPV4,
+                            lk._encode_ipv4_udp("100.64.4.1", "255.255.255.255", 67, 68,
+                                                _bootp_reply(lk, options=_ack_options(lk))))
+    cap._dispatch(dhcp)
+    cap._dispatch(b"\x00" * 5)          # runt garbage is dropped quietly
+    assert frames["arp"] == [lk.ArpFrame(2, "100.64.4.1", "100.64.4.7")]
+    assert len(frames["bootp"]) == 1 and frames["bootp"][0].yiaddr == "100.64.4.7"
+
+
+def test_bpf_send_dhcp_round_trips(lk):
+    # What send_dhcp writes must decode back through our own defensive parser:
+    # broadcast Ethernet/IP framing, the right ports, and the option list intact.
+    cap, frames = _bpf_capture(lk)
+    cap.send_dhcp(eth_src="00:00:5e:00:01:fe", ip_src="0.0.0.0", ip_dst="255.255.255.255",
+                  chaddr=CHADDR, xid=0xABCD, ciaddr="0.0.0.0", flags=lk.BROADCAST_FLAG,
+                  options=[("message-type", "discover"), ("requested_addr", "100.64.4.7"), "end"])
+    frame = frames["sent"][0]
+    assert frame[:6] == b"\xff" * 6 and frame[6:12] == CHADDR
+    assert frame[12:14] == b"\x08\x00"
+    ip = frame[14:]
+    assert struct.unpack("!HH", ip[20:24]) == (lk.DHCP_CLIENT_PORT, lk.DHCP_SERVER_PORT)
+    decoded = lk._decode_ipv4_bootp(ip)
+    assert decoded.op == 1 and decoded.xid == 0xABCD and decoded.chaddr[:6] == CHADDR
+
+
+def test_bpf_send_arp_pads_to_min_frame(lk):
+    cap, frames = _bpf_capture(lk)
+    cap.send_arp_request("00:00:5e:00:01:fe", "100.64.4.7", "100.64.4.1")
+    frame = frames["sent"][0]
+    assert len(frame) == lk.ETHER_MIN_FRAME
+    assert lk._decode_arp(frame[14:]) == lk.ArpFrame(1, "100.64.4.7", "100.64.4.1")
+
+
+def test_bpf_filter_program_shape(lk):
+    # The embedded opcode table must be a plausible classic-BPF program:
+    # 4-field instructions ending in the two return statements tcpdump emits.
+    assert all(len(insn) == 4 for insn in lk._BPF_FILTER)
+    assert lk._BPF_FILTER[-2][0] == 0x6 and lk._BPF_FILTER[-1][0] == 0x6
+    assert lk._BPF_FILTER[-1][3] == 0                    # default: drop

--- a/net/os-carp-vip-dhcp/tests/test_codec.py
+++ b/net/os-carp-vip-dhcp/tests/test_codec.py
@@ -162,6 +162,30 @@ def test_decode_ipv4_bootp_end_to_end(lk):
     assert rx.subnet_mask == "255.255.255.0" and rx.giaddr == "100.64.4.9"
 
 
+def test_decode_ipv4_bootp_bounds_by_udp_length(lk):
+    # A UDP length shorter than the IP payload must not let trailing bytes be
+    # parsed as options: bytes past udp_len are dropped like link padding.
+    payload = _bootp_reply(lk, options=bytes([53, 1, 5, 255]))
+    dgram = bytearray(lk._encode_ipv4_udp("100.64.4.1", "255.255.255.255", 67, 68, payload))
+    ihl = (dgram[0] & 0x0F) * 4
+    # append attacker bytes that look like an option, then shrink UDP length to exclude them
+    dgram += bytes([54, 4, 9, 9, 9, 9])
+    dgram[2:4] = (len(dgram)).to_bytes(2, "big")                 # IP total covers the extra bytes
+    true_udp_len = ihl + 8 + len(payload) - ihl                 # = 8 + len(payload)
+    dgram[ihl + 4:ihl + 6] = (8 + len(payload)).to_bytes(2, "big")
+    frame = lk._decode_ipv4_bootp(bytes(dgram))
+    assert dict(frame.options) == {"message-type": 5}           # the trailing option is excluded
+    assert true_udp_len == 8 + len(payload)
+
+
+def test_decode_ipv4_bootp_rejects_short_udp_length(lk):
+    payload = _bootp_reply(lk, options=bytes([53, 1, 5, 255]))
+    dgram = bytearray(lk._encode_ipv4_udp("100.64.4.1", "255.255.255.255", 67, 68, payload))
+    ihl = (dgram[0] & 0x0F) * 4
+    dgram[ihl + 4:ihl + 6] = (4).to_bytes(2, "big")             # UDP length < its own 8-byte header
+    assert lk._decode_ipv4_bootp(bytes(dgram)) is None
+
+
 def test_decode_ipv4_bootp_trims_link_padding(lk):
     # Ethernet pads short frames: bytes past the IP total length must not
     # leak into the options walk.

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -7,8 +7,11 @@ import os
 import re
 import time
 import types
+from typing import Any
 
 import pytest
+
+from conftest import CHADDR, CHADDR_STR
 
 
 def test_sane_ipv4(lk):
@@ -33,8 +36,8 @@ def test_fs_safe(lk):
 
 def _client(lk, id_opts=None, on_changed=None):
     """A bare DhcpClient with stub hooks and a captured send list -- the
-    protocol tests need no Keeper."""
-    c = lk.DhcpClient("eth0", "00:00:5e:00:01:fe", "00:00:5e:00:01:fe", id_opts or [],
+    protocol tests need no Keeper and no capture backend."""
+    c = lk.DhcpClient(None, CHADDR_STR, CHADDR_STR, id_opts or [],
                       should_stop=lambda: False,
                       ensure_sniffer=lambda: None,
                       on_changed_address=on_changed or (lambda *a: False))
@@ -154,7 +157,7 @@ def test_fmt_reply_readable(lk):
 def _keeper(lk, **kw):
     """A Keeper on the canonical test identity (iface/vMAC/VIP), hbfile off."""
     kw.setdefault("hbfile", None)
-    return lk.Keeper("eth0", "00:00:5e:00:01:fe", "100.64.4.7", **kw)
+    return lk.Keeper("eth0", CHADDR_STR, "100.64.4.7", **kw)
 
 
 def _link_keeper(lk):
@@ -287,44 +290,34 @@ def _ack(lk, yiaddr, server="100.64.4.1"):
     return lk.DhcpReply(5, yiaddr, server, 1800, None, None, None)
 
 
-class _DhcpPkt:
-    """Minimal stand-in for a scapy DHCP reply: p[BOOTP].xid/op/yiaddr and
-    p[DHCP].options, with haslayer() so _on_dhcp_reply parses it."""
-    def __init__(self, lk, xid, options, *, yiaddr="100.64.4.7",  # pylint: disable=too-many-arguments
-                 chaddr=b"\x00\x00\x5e\x00\x01\xfe", op=None, giaddr="0.0.0.0"):
-        self._lk = lk
-        self._bootp = types.SimpleNamespace(xid=xid, op=(lk.BOOTREPLY if op is None else op),
-                                            yiaddr=yiaddr, chaddr=chaddr, giaddr=giaddr)
-        self._dhcp = types.SimpleNamespace(options=options)
-
-    def haslayer(self, layer):
-        return layer in (self._lk.BOOTP, self._lk.DHCP)
-
-    def __getitem__(self, layer):
-        return self._bootp if layer is self._lk.BOOTP else self._dhcp
+def _dhcp_frame(lk, xid, options, *, yiaddr="100.64.4.7",  # pylint: disable=too-many-arguments
+                chaddr=CHADDR, op=None, giaddr="0.0.0.0"):
+    """A backend-neutral BootpFrame as either capture backend would hand it
+    to the keeper."""
+    return lk.BootpFrame(lk.BOOTREPLY if op is None else op, xid, yiaddr, chaddr, giaddr, options)
 
 
 def test_parse_reply_extracts_fields_and_relay(lk):
     # The pure wire decoder pulls the acted-on options into a DhcpReply and maps
     # the relay giaddr (0.0.0.0 -> None when directly attached).
-    pkt = _DhcpPkt(lk, 0x1234, [("message-type", lk.ACK), ("server_id", "100.64.4.1"),
-                                ("lease_time", 1800), ("router", "100.64.4.1"),
-                                ("subnet_mask", "255.255.255.0"), "end"],
-                   yiaddr="100.64.4.7", giaddr="100.64.4.9")
-    rx = lk._parse_reply(pkt, "100.64.4.7")
+    frame = _dhcp_frame(lk, 0x1234, [("message-type", lk.ACK), ("server_id", "100.64.4.1"),
+                                     ("lease_time", 1800), ("router", "100.64.4.1"),
+                                     ("subnet_mask", "255.255.255.0"), "end"],
+                        yiaddr="100.64.4.7", giaddr="100.64.4.9")
+    rx = lk._parse_reply(frame)
     assert rx.mtype == lk.ACK and rx.yiaddr == "100.64.4.7"
     assert rx.server_id == "100.64.4.1" and rx.lease == 1800
     assert rx.router == "100.64.4.1" and rx.subnet_mask == "255.255.255.0"
     assert rx.giaddr == "100.64.4.9"           # relay in path
-    directly_attached = _DhcpPkt(lk, 0x1234, [("message-type", lk.ACK), "end"], giaddr="0.0.0.0")
-    assert lk._parse_reply(directly_attached, "100.64.4.7").giaddr is None
+    directly_attached = _dhcp_frame(lk, 0x1234, [("message-type", lk.ACK), "end"], giaddr="0.0.0.0")
+    assert lk._parse_reply(directly_attached).giaddr is None
 
 
 def test_on_dhcp_reply_captures_option56_message(lk):
     keeper = _keeper(lk)
-    pkt = _DhcpPkt(lk, keeper._dhcp.xid, [("message-type", lk.NAK), ("server_id", "100.64.4.1"),
-                                          ("message", "pool exhausted"), "end"])
-    keeper._on_dhcp_reply(pkt)
+    frame = _dhcp_frame(lk, keeper._dhcp.xid, [("message-type", lk.NAK), ("server_id", "100.64.4.1"),
+                                               ("message", "pool exhausted"), "end"])
+    keeper._on_dhcp_reply(frame)
     assert keeper._dhcp._rx.message == "pool exhausted"
 
 
@@ -391,10 +384,10 @@ def _observe_keeper(lk, tmp_path):
 
 
 def _peer_ack(lk, yiaddr, xid=0x22222222, server="100.64.4.1",
-              chaddr=b"\x00\x00\x5e\x00\x01\xfe"):
+              chaddr=CHADDR):
     """A DHCP ACK on our shared chaddr but a DIFFERENT xid -- i.e. the peer's."""
-    return _DhcpPkt(lk, xid, [("message-type", lk.ACK), ("server_id", server),
-                              ("lease_time", 1800), "end"], yiaddr=yiaddr, chaddr=chaddr)
+    return _dhcp_frame(lk, xid, [("message-type", lk.ACK), ("server_id", server),
+                                 ("lease_time", 1800), "end"], yiaddr=yiaddr, chaddr=chaddr)
 
 
 def test_observed_peer_ack_records_change_and_wakes(lk, tmp_path):
@@ -422,9 +415,9 @@ def test_observed_ignores_wrong_chaddr(lk, tmp_path):
 
 def test_observed_ignores_non_ack(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
-    keeper._on_dhcp_reply(_DhcpPkt(lk, 0x22222222,
-                                   [("message-type", lk.OFFER), ("server_id", "100.64.4.1"), "end"],
-                                   yiaddr="100.64.4.60"))
+    keeper._on_dhcp_reply(_dhcp_frame(lk, 0x22222222,
+                                      [("message-type", lk.OFFER), ("server_id", "100.64.4.1"), "end"],
+                                      yiaddr="100.64.4.60"))
     assert keeper._follow._observed is None
 
 
@@ -439,9 +432,9 @@ def test_observed_ignored_when_not_follow(lk):
 
 def test_own_xid_reply_uses_first_party_path(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
-    keeper._on_dhcp_reply(_DhcpPkt(lk, keeper._dhcp.xid,
-                                   [("message-type", lk.ACK), ("server_id", "100.64.4.1"), "end"],
-                                   yiaddr="100.64.4.60"))
+    keeper._on_dhcp_reply(_dhcp_frame(lk, keeper._dhcp.xid,
+                                      [("message-type", lk.ACK), ("server_id", "100.64.4.1"), "end"],
+                                      yiaddr="100.64.4.60"))
     assert keeper._follow._observed is None   # not the observed path
     assert keeper._dhcp._rx is not None and keeper._dhcp._rx.yiaddr == "100.64.4.60"
 
@@ -518,13 +511,17 @@ def test_arp_nudge_component_direct(lk):
     # ArpNudge alone (no Keeper): interval floor at construction, the injected
     # master probe gates every send, and the reachability stamp starts at 0.
     role = {"master": True}
-    n = lk.ArpNudge("eth0", "00:00:5e:00:01:fe", 1, lambda: role["master"])
+    sent = []
+    capture = types.SimpleNamespace(send_arp_request=lambda *a: sent.append(a))
+    n = lk.ArpNudge(capture, CHADDR_STR, 1, lambda: role["master"])
     assert n.interval == lk.ARP_NUDGE_MIN     # floored: a typo cannot flood the segment
     assert n.last_reply == 0.0
 
     n.maybe_nudge("100.64.4.7", "100.64.4.1")
     first = n.last_nudge
     assert first > 0   # master + due -> sent
+    # the who-has goes out from (chaddr, leased IP) toward the gateway
+    assert sent == [(CHADDR_STR, "100.64.4.7", "100.64.4.1")]
 
     role["master"] = False
     n.maybe_nudge("100.64.4.7", "100.64.4.1", force=True)
@@ -719,36 +716,22 @@ def test_nudge_missing_gateway_warns_once(lk, caplog):
 
 # ---- ARP-reply listening (reachability confirmation) ----
 
-class _ArpPkt:
-    """Minimal stand-in for a scapy ARP packet: p[ARP] -> op/psrc/pdst/hwsrc, and
-    haslayer(ARP) so the sniffer dispatcher routes it."""
-    def __init__(self, lk, op, psrc, pdst, hwsrc=""):
-        self._lk = lk
-        self._arp = types.SimpleNamespace(op=op, psrc=psrc, pdst=pdst, hwsrc=hwsrc)
-
-    def haslayer(self, layer):
-        return layer is self._lk.ARP
-
-    def __getitem__(self, layer):
-        return self._arp
-
-
 def test_arp_reply_ignores_unrelated(lk):
     keeper = _nudge_keeper(lk)
     keeper._dhcp.binding.router = "100.64.4.254"
-    keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.9", "100.64.4.7"))    # wrong sender
-    keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.254", "100.64.4.99"))  # wrong target IP
-    keeper._on_sniff(_ArpPkt(lk, 1, "100.64.4.254", "100.64.4.7"))   # a request, not a reply
+    keeper._on_arp_reply(lk.ArpFrame(2, "100.64.4.9", "100.64.4.7"))     # wrong sender
+    keeper._on_arp_reply(lk.ArpFrame(2, "100.64.4.254", "100.64.4.99"))  # wrong target IP
+    keeper._on_arp_reply(lk.ArpFrame(1, "100.64.4.254", "100.64.4.7"))   # a request, not a reply
     assert keeper._nudge.last_reply == 0.0
 
 
 def test_arp_reply_stamps_reachability_and_logs(lk, caplog):
     # A matching is-at reply from the nudge target, dispatched through the
-    # sniffer path, stamps the reachability epoch and logs at DEBUG.
+    # capture callback, stamps the reachability epoch and logs at DEBUG.
     keeper = _nudge_keeper(lk)
     keeper._dhcp.binding.router = "100.64.4.1"
     with caplog.at_level("DEBUG", logger="lease-keeper"):
-        keeper._on_sniff(_ArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
+        keeper._on_arp_reply(lk.ArpFrame(2, "100.64.4.1", "100.64.4.7"))
     assert keeper._nudge.last_reply > 0
     assert any("ARP reply from 100.64.4.1" in r.getMessage() for r in caplog.records)
 
@@ -775,10 +758,83 @@ def test_sniffer_filter_captures_arp_and_honours_promisc(lk, monkeypatch):
 
     monkeypatch.setattr(lk, "AsyncSniffer", _Cap)
     keeper = _keeper(lk, arp_listen_promisc=True)
-    assert keeper._start_sniffer() is True
+    assert keeper._capture.start() is True
     assert "arp" in captured["filter"]        # ARP replies now reach the parser
     assert "port 67" in captured["filter"]     # ...alongside DHCP, unchanged
     assert captured["promisc"] is True         # opt-in flag reaches the socket
+
+
+# ---- capture backends: selection and the scapy packet -> frame adapter ----
+
+def test_backend_selection_defaults_scapy(lk):
+    assert isinstance(_keeper(lk)._capture, lk.ScapyCapture)
+    assert isinstance(_keeper(lk, capture_backend="bpf")._capture, lk.BpfCapture)
+
+
+class _ScapyDhcpPkt:
+    """Minimal stand-in for a scapy DHCP reply: p[BOOTP].xid/op/yiaddr/chaddr/
+    giaddr and p[DHCP].options, with haslayer() -- what ScapyCapture decodes.
+    chaddr is typed Any: one test hands it a non-bytes value on purpose."""
+    def __init__(self, lk, xid, options, *, yiaddr="100.64.4.7",  # pylint: disable=too-many-arguments
+                 chaddr: Any = CHADDR, op=None, giaddr="0.0.0.0"):
+        self._lk = lk
+        self._bootp = types.SimpleNamespace(xid=xid, op=(lk.BOOTREPLY if op is None else op),
+                                            yiaddr=yiaddr, chaddr=chaddr, giaddr=giaddr)
+        self._dhcp = types.SimpleNamespace(options=options)
+
+    def haslayer(self, layer):
+        return layer in (self._lk.BOOTP, self._lk.DHCP)
+
+    def __getitem__(self, layer):
+        return self._bootp if layer is self._lk.BOOTP else self._dhcp
+
+
+class _ScapyArpPkt:
+    """Minimal stand-in for a scapy ARP packet: p[ARP] -> op/psrc/pdst."""
+    def __init__(self, lk, op, psrc, pdst):
+        self._lk = lk
+        self._arp = types.SimpleNamespace(op=op, psrc=psrc, pdst=pdst)
+
+    def haslayer(self, layer):
+        return layer is self._lk.ARP
+
+    def __getitem__(self, layer):
+        return self._arp
+
+
+def _capture_pair(lk):
+    """A ScapyCapture wired to recording callbacks."""
+    frames = {"bootp": [], "arp": []}
+    cap = lk.ScapyCapture("eth0", False, frames["bootp"].append, frames["arp"].append)
+    return cap, frames
+
+
+def test_scapy_adapter_decodes_dhcp_to_frame(lk):
+    cap, frames = _capture_pair(lk)
+    cap._on_packet(_ScapyDhcpPkt(lk, 0x1234, [("message-type", lk.ACK), "end"],
+                                 yiaddr="100.64.4.7", giaddr="100.64.4.9"))
+    frame = frames["bootp"][0]
+    assert frame.op == lk.BOOTREPLY and frame.xid == 0x1234
+    assert frame.yiaddr == "100.64.4.7" and frame.giaddr == "100.64.4.9"
+    assert frame.chaddr[:6] == CHADDR
+    assert ("message-type", lk.ACK) in frame.options
+    assert not frames["arp"]
+
+
+def test_scapy_adapter_decodes_arp_to_frame(lk):
+    cap, frames = _capture_pair(lk)
+    cap._on_packet(_ScapyArpPkt(lk, 2, "100.64.4.1", "100.64.4.7"))
+    assert frames["arp"] == [lk.ArpFrame(2, "100.64.4.1", "100.64.4.7")]
+    assert not frames["bootp"]
+
+
+def test_scapy_adapter_tolerates_malformed_chaddr(lk):
+    # An unconvertible chaddr must not drop the reply: it decodes to empty
+    # bytes (the frame still reaches the first-party xid path).
+    cap, frames = _capture_pair(lk)
+    cap._on_packet(_ScapyDhcpPkt(lk, 0x1234, [("message-type", lk.ACK), "end"],
+                                 chaddr="not-raw-bytes"))   # bytes(str) raises TypeError
+    assert frames["bootp"][0].chaddr == b""
 
 
 # ---- follow across a changed gateway (cross-subnet renumber) ----

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -107,6 +107,25 @@ def test_acquire_reboot_first_then_dora(lk):
     assert calls == ["dora"]   # subsequent acquires: DISCOVER only
 
 
+def test_absorb_reply_floors_lease(lk):
+    # A tiny (or spoofed) opt-51 must not drive a tight renew spin: the accepted
+    # lease is floored at MIN_LEASE, while a normal lease passes through.
+    c = _client(lk)
+    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1, None, None, None))
+    assert c.binding.lease_secs == lk.MIN_LEASE
+    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 3600, None, None, None))
+    assert c.binding.lease_secs == 3600
+
+
+def test_msg_text_scrubs_control_chars(lk):
+    # Option-56 text is attacker-controlled and hits the log: newlines and
+    # escape sequences are neutralized, printable content is kept.
+    assert lk._msg_text(b"no leases") == "no leases"
+    assert lk._msg_text(b"line1\nJul 1 forged") == "line1?Jul 1 forged"
+    assert lk._msg_text(b"\x1b[2Jwipe") == "?[2Jwipe"
+    assert lk._msg_text(b"") == ""
+
+
 def test_adopt_binds_and_refreshes_server(lk):
     c = _client(lk)
     c.binding.server = "100.64.4.1"   # from the OFFER


### PR DESCRIPTION
## What

Packet capture and send move behind a pluggable backend, selected with a new `--capture-backend` flag:

- **scapy** (default, unchanged behaviour)
- **bpf** (new): a dependency-free backend on a raw `/dev/bpf` descriptor

Both decode to the same neutral `BootpFrame`/`ArpFrame` shapes, so `DhcpClient`, `ArpNudge` and the `Keeper` no longer touch a packet object at all. The flag ships dark: no GUI exposure, scapy stays the default, and a host opts in with `sysrc carpvipdhcp_backend=bpf` plus a service restart. With bpf selected the daemon runs with no scapy installed.

## Why

scapy is the plugin's one heavy dependency and its most common start-up failure source (the defensive `_MISSING` import exists for it): tens of MB RSS and a slow import for a daemon that sends four message types and reads eight options. A stdlib-only path (`/dev/bpf` + a hand codec) removes that and strengthens the case for upstreaming.

## Design

- **Neutral boundary.** `wire`/frame types + `_parse_reply` are backend-agnostic; each backend decodes into them. The keeper's option vocabulary stays scapy-compatible (ScapyCapture relays option lists verbatim), documented at the boundary.
- **bpf backend.** Binds `/dev/bpf` with precomputed FreeBSD ioctls (amd64 + aarch64 LP64), attaches the capture filter as a precompiled classic-BPF opcode table (annotated with its `tcpdump -d` disassembly and kept in lockstep with `SNIFFER_FILTER` by a bench test), hand-encodes the four client messages (BOOTP padded to the RFC 1542 minimum, real IP/UDP checksums), and parses replies with a bounds-checked TLV walk over exactly the options the keeper acts on. Malformed input is dropped, never raised.
- **Isolation of the risky surface.** Each backend owns its optional-import guard (scapy in one, fcntl in the other). The whole hand-rolled surface is confined to the bpf path; scapy stays the default and cannot regress from it.

## Review applied

A multi-lens review (RFC/wire correctness, security of the untrusted parser, concurrency/lifecycle, design alternatives) ran on the diff. Findings addressed, notably:

- The bpf reader stops via a self-pipe with a per-start stop event and owns/closes its own fd, so a reader that outlives its stop() cannot be revived or have its fd number reused; idle capture no longer wakes once a second.
- `ScapyCapture.stop()` bounds its join (scapy joins unbounded), so a stuck sniffer cannot freeze the main thread mid-sequence and trip a false CARP demotion.
- `_configure` verifies the link type is Ethernet and fails loudly on a PPPoE/tun WAN; the filter attaches right after the bind to minimize the unfiltered window.
- Hardening shared by both backends: option-56 server text is scrubbed of control/escape characters before it reaches the log; the accepted lease is floored so a 1-second option-51 cannot spin the renew loop; the decoder bounds the BOOTP slice by the UDP length. The rc script validates the backend value rather than letting a typo become a silent crash loop.

## Testing

- **Unit:** 123 tests, including golden-byte encoders for every sent frame, checksum validity, and defensive decoding of truncated / fragmented / padded / oversized input. pylint 10/10 (`--enable=useless-suppression`), pyright clean, flake8 clean.
- **Lab fake-DHCP bench (isolated, prod-safe), per backend:**
  - filter-lockstep: the embedded `_BPF_FILTER` equals `tcpdump -ddd` of `SNIFFER_FILTER` on the clone's own libpcap (26 insns).
  - link-return, full DORA + link-return fast path + rebind: **9/9 on bpf and 9/9 on scapy** against a lenient server (dnsmasq), and **9/9 on bpf against a strict raw-socket server (Kea)** that does its own IP/UDP checksum and length validation. The keeper confirms the selected backend in its own log on every run.
  - ARP nudge on the wire: the nudge frame is sent and logged on the bpf backend.

## Not in this PR (follow-ups)

- Real-WAN evidence for bpf against a live ISP is partial (an earlier lab run bound and renewed on a real CGNAT line before that bench went offline); a full real-WAN pass is queued for when it returns.
- Splitting the ~2200-line `lease_keeper.py` into a `leasekeeper/` package is planned as its own structural PR after this lands (spec committed as MODULE-SPLIT.md).
- Runtime filter compilation via libpcap is deferred to the IPv6 phase, when the filter would become dynamic.

Version 1.8.5 -> 1.9.0.