### PR TITLE
net/os-carp-vip-dhcp: fix apply button + service-control refresh; add license headers

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/Api/DiagnosticsController.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/Api/DiagnosticsController.php
@@ -1,5 +1,27 @@
 <?php
 
+/*
+ * Copyright (C) 2026 Tore Amundsen
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+ * CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 namespace OPNsense\CarpVipDhcp\Api;
 
 use OPNsense\Base\ApiControllerBase;

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/Api/ServiceController.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/Api/ServiceController.php
@@ -1,5 +1,27 @@
 <?php
 
+/*
+ * Copyright (C) 2026 Tore Amundsen
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+ * CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 namespace OPNsense\CarpVipDhcp\Api;
 
 use OPNsense\Base\ApiMutableServiceControllerBase;

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/Api/SettingsController.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/Api/SettingsController.php
@@ -1,5 +1,27 @@
 <?php
 
+/*
+ * Copyright (C) 2026 Tore Amundsen
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+ * CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 namespace OPNsense\CarpVipDhcp\Api;
 
 use OPNsense\Base\ApiMutableModelControllerBase;

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/IndexController.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/IndexController.php
@@ -1,5 +1,27 @@
 <?php
 
+/*
+ * Copyright (C) 2026 Tore Amundsen
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+ * CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 namespace OPNsense\CarpVipDhcp;
 
 /**

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/LogController.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/LogController.php
@@ -1,5 +1,27 @@
 <?php
 
+/*
+ * Copyright (C) 2026 Tore Amundsen
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+ * CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 namespace OPNsense\CarpVipDhcp;
 
 /**

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/StatusController.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/StatusController.php
@@ -1,5 +1,27 @@
 <?php
 
+/*
+ * Copyright (C) 2026 Tore Amundsen
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+ * CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 namespace OPNsense\CarpVipDhcp;
 
 /**

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.php
@@ -1,5 +1,27 @@
 <?php
 
+/*
+ * Copyright (C) 2026 Tore Amundsen
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+ * CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 namespace OPNsense\CarpVipDhcp;
 
 use OPNsense\Base\BaseModel;

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/index.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/index.volt
@@ -1,3 +1,25 @@
+{#
+ # Copyright (C) 2026 Tore Amundsen
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without
+ # modification, are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ # FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR
+ # BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+ # CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #}
+
 <script>
     $(document).ready(function () {
         $("#grid-keepers").UIBootgrid({
@@ -9,6 +31,7 @@
             toggle: '/api/carpvipdhcp/settings/toggleKeeper/'
         });
         updateServiceControlUI('carpvipdhcp');
+        $("#reconfigureAct").SimpleActionButton();
     });
 </script>
 
@@ -42,13 +65,11 @@
             </tr>
         </tfoot>
     </table>
-    <div class="col-md-12">
-        <div id="carpvipdhcpChangeMessage" class="alert alert-info" style="display: none" role="alert">
-            {{ lang._('After changing settings, please remember to apply them with the button below.') }}
-        </div>
-        <hr/>
-        {{ partial("layout_partials/base_apply_button", {'data_endpoint': '/api/carpvipdhcp/service/reconfigure'}) }}
-    </div>
 </div>
+
+<div id="carpvipdhcpChangeMessage" class="alert alert-info" style="display: none" role="alert">
+    {{ lang._('After changing settings, please remember to apply them with the button below.') }}
+</div>
+{{ partial("layout_partials/base_apply_button", {'data_endpoint': '/api/carpvipdhcp/service/reconfigure', 'data_service_widget': 'carpvipdhcp'}) }}
 
 {{ partial("layout_partials/base_dialog", ['fields': formDialogKeeper, 'id': 'DialogKeeper', 'label': lang._('Edit CARP-VIP DHCP keeper')]) }}

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/log.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/log.volt
@@ -1,3 +1,25 @@
+{#
+ # Copyright (C) 2026 Tore Amundsen
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without
+ # modification, are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ # FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR
+ # BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+ # CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #}
+
 <script>
     'use strict';
 

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
@@ -1,3 +1,25 @@
+{#
+ # Copyright (C) 2026 Tore Amundsen
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without
+ # modification, are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ # FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR
+ # BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+ # CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #}
+
 <script>
     'use strict';
 


### PR DESCRIPTION
## What

GUI best-practice pass on the settings page (Interfaces: Virtual IPs DHCP).

**Apply button was invisible and non-functional.** `base_apply_button` renders a `<button>` with no inner text; the "Apply" label and click handler are attached by `$("#reconfigureAct").SimpleActionButton()`, which the page never called. So the button was a label-less, unbound `btn btn-primary` box that did nothing on click. Now initialized, and moved out of the `content-box` to the canonical position (matches core `Routes/index.volt` and the `using_grids` example).

**Service-control buttons went stale after apply.** Added `data_service_widget` to the apply button, so a successful reconfigure calls `updateServiceControlUI()` and refreshes the start/stop/restart controls. Before, disabling then re-enabling all keepers left the controls stale until a manual page reload.

**License headers.** Added the BSD 2-clause header (matching the plugin's other source files, e.g. `CarpVipDhcpStatus.php`) to the MVC controllers, model and volt views that lacked it.

## Testing

- `php -l` clean on all changed PHP files (PHP 8.3).
- Deployed `index.volt` to a live master and verified in the GUI: the Apply button now shows "Apply" and reconfigures; disabling/enabling keepers + Apply refreshes the service controls without a manual reload.
- No daemon, config, model schema or behaviour change (view/JS wiring plus comment headers only).
