### PR TITLE
net/os-carp-vip-dhcp: bump version to 1.9.1

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.9.0
+PLUGIN_VERSION=         1.9.1
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,


### PR DESCRIPTION
## What

Bump `PLUGIN_VERSION` 1.9.0 -> 1.9.1.

1.9.0 is released (tag `v1.9.0`). The changes merged to main after it (PR #58: apply-button initialization, service-control refresh via `data_service_widget`, and BSD license headers on the MVC files) are bugfix-level, so they ship as 1.9.1.

## Testing

Version-only change; no code or behaviour change. Lint CI (php/python/shell/xml) covers well-formedness.
