### PR TITLE
net/os-carp-vip-dhcp: show installed plugin version on the Status page

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.10.0
+PLUGIN_VERSION=         1.10.1
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/StatusController.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/StatusController.php
@@ -31,6 +31,11 @@ class StatusController extends \OPNsense\Base\IndexController
 {
     public function indexAction()
     {
+        // Installed plugin version, resolved once per page load (not per status
+        // poll), so an operator can confirm an upgrade took and spot HA version
+        // skew by comparing each node's Status page.
+        $version = trim((string)(new \OPNsense\Core\Backend())->configdRun('carpvipdhcp version'));
+        $this->view->pluginVersion = $version !== '' ? $version : gettext('unknown');
         $this->view->pick('OPNsense/CarpVipDhcp/status');
     }
 }

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/status.volt
@@ -236,5 +236,6 @@
     </div>
     <div class="col-md-12">
         {{ lang._('CARP demotion (this node)') }}: <strong id="carp_demotion">-</strong>
+        &nbsp;&middot;&nbsp; {{ lang._('Plugin version') }}: <strong>{{ pluginVersion }}</strong>
     </div>
 </div>

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/plugin_version.sh
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/plugin_version.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Print the installed plugin version (empty if somehow not registered). Read-only;
+# wired as the configd "carpvipdhcp version" action and shown on the Status page
+# so an operator can confirm an upgrade took and spot HA version skew between
+# nodes. Kept out of the per-poll diag so pkg(8) is queried once per page load.
+pkg query %v os-carp-vip-dhcp 2>/dev/null || true

--- a/net/os-carp-vip-dhcp/src/opnsense/service/conf/actions.d/actions_carpvipdhcp.conf
+++ b/net/os-carp-vip-dhcp/src/opnsense/service/conf/actions.d/actions_carpvipdhcp.conf
@@ -93,3 +93,10 @@ errors:no
 parameters:
 type:script
 message:clearing carpvipdhcp logs
+
+[version]
+command:/usr/local/opnsense/scripts/OPNsense/CarpVipDhcp/plugin_version.sh
+errors:no
+parameters:
+type:script_output
+message:carpvipdhcp plugin version


### PR DESCRIPTION
## What

Show the installed plugin version on the Status page (Interfaces: Virtual IPs DHCP: Status), in the footer next to "CARP demotion".

## Why

The Status page is per-node. A small version line lets an operator confirm an upgrade actually took, and spot **HA version skew** between master and backup by comparing each node's Status page. That matters for this plugin because the two nodes share the `keeper.conf` format and behaviour (e.g. the recent 11->12 column change), so a version mismatch is a real HA hazard.

## How

- New read-only configd action `carpvipdhcp version` -> `plugin_version.sh` (`pkg query %v os-carp-vip-dhcp`).
- `StatusController::indexAction()` resolves it **once per page load** (not in the 5s status poll) and passes it to the view.
- `status.volt` footer renders it. Falls back to "unknown" if the query returns empty.
- `PLUGIN_VERSION` -> 1.10.1.

## Testing

- CI: php -l / PSR-12, shellcheck (new `plugin_version.sh`), xmllint.
- Read-only, server-rendered once per load; no daemon/config/CARP impact.
