### PR TITLE
net/os-carp-vip-dhcp: log plugin version (single-sourced in the package)

### DIFF
--- a/net/os-carp-vip-dhcp/Makefile
+++ b/net/os-carp-vip-dhcp/Makefile
@@ -1,5 +1,8 @@
 PLUGIN_NAME=		carp-vip-dhcp
-PLUGIN_VERSION=         1.10.1
+PLUGIN_VERSION!=	sed -n 's/^__version__ = "\(.*\)"$$/\1/p' ${.CURDIR}/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+.if empty(PLUGIN_VERSION)
+.error PLUGIN_VERSION could not be derived from leasekeeper/__init__.py
+.endif
 PLUGIN_COMMENT=		Keep a DHCP lease alive for a CARP virtual IP (DHCP/CGNAT WAN failover)
 PLUGIN_MAINTAINER=	tore@amundsen.org
 # PLUGIN_PYTHON (from Mk/plugins.mk) tracks the target release's base Python,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
@@ -13,3 +13,9 @@ wires up and runs the Keeper defined here. Modules, leaf-first:
   policy     -- ArpNudge + FollowPolicy
   keeper     -- Keeper orchestration
 """
+
+# Single source of truth for the plugin version: the Makefile derives
+# PLUGIN_VERSION from this line (so the package version and the daemon's own
+# reported version can never drift). Keep the assignment on one line as
+# __version__ = "X.Y.Z" so the Makefile's sed can read it.
+__version__ = "1.10.2"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -9,6 +9,7 @@ import socket
 import subprocess
 import time
 
+from . import __version__
 from .capture import CAPTURE_BACKENDS
 from .constants import (
     LOGGER_NAME,
@@ -467,8 +468,8 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
 
         # eth-src matters for L2 debugging but only when it differs from the chaddr.
         ethsrc = f" eth-src={self.eth_src}" if self.eth_src != self.chaddr else ""
-        LOG.info("lease-keeper active on %s: chaddr=%s%s request=%s",
-                 self.iface, self.chaddr, ethsrc, self._follow.target or "any")
+        LOG.info("lease-keeper %s active on %s: chaddr=%s%s request=%s",
+                 __version__, self.iface, self.chaddr, ethsrc, self._follow.target or "any")
         time.sleep(SNIFFER_WARMUP)
 
         while not self._stop:
@@ -491,7 +492,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._capture.stop()
         self._wake_r.close()
         self._wake_w.close()
-        LOG.info("stopped")
+        LOG.info("stopped (lease-keeper %s)", __version__)
         return 0
 
     def claim_once(self):


### PR DESCRIPTION
## What

The keeper now logs the plugin version in its startup and shutdown lines, so each keeper's log is self-identifying: `lease-keeper 1.10.2 active on igc1: ...` and `stopped (lease-keeper 1.10.2)`. Confirms an upgrade took, and helps spot HA version skew when comparing node logs (complements the Status-page version display).

## How (single source of truth)

- `__version__` lives in `leasekeeper/__init__.py`. The daemon reads its OWN version from that package constant (it is not handed the version by rc.d, which would be backwards).
- The **Makefile derives `PLUGIN_VERSION` from that same `__version__`** (`sed` + an `.error` guard if it can't), so the package version and the daemon's reported version cannot drift. One place to bump.
- Bump to 1.10.2.

## Testing

- CI: pytest imports the keeper (validates `from . import __version__`), plus flake8 / pylint 10/10 / pyright / phpcs / shellcheck / xmllint.
- Verified locally that the Makefile's `sed` extracts `1.10.2` from `__init__.py`. The BSD-make derivation itself is evaluated at build time on the OPNsense box (CI has no FreeBSD build runner); the `.error` guard fails the build loudly if the value can't be derived, so it can never ship empty.
