### PR TITLE
net/os-carp-vip-dhcp: adopt a pre-created Host alias

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
@@ -18,4 +18,4 @@ wires up and runs the Keeper defined here. Modules, leaf-first:
 # PLUGIN_VERSION from this line (so the package version and the daemon's own
 # reported version can never drift). Keep the assignment on one line as
 # __version__ = "X.Y.Z" so the Makefile's sed can read it.
-__version__ = "1.10.2"
+__version__ = "1.10.3"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/manage_alias.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/manage_alias.php
@@ -17,8 +17,10 @@
  * state-preserving. A bare `refresh_aliases` only reloads the last-rendered
  * tables and would leave the pf table stale. The plugin never deletes aliases -
  * they may be referenced elsewhere - so clearing aliasName just leaves a stale
- * alias the operator can remove by hand. It also never touches an alias it does
- * not own (one whose description lacks the plugin marker).
+ * alias the operator can remove by hand. A same-named **Host** alias created by
+ * hand is ADOPTED (stamped with the plugin marker and kept in sync), so an
+ * operator can pre-create the alias and stage NAT/rules that reference it before
+ * the keeper first runs; a non-Host alias of that name is left untouched.
  *
  * Run standalone (configd action `carpvipdhcp sync_aliases`) so it reads the
  * current on-disk config; do NOT call it in the same php process that just did a
@@ -58,15 +60,29 @@ foreach ($mdl->aliases->alias->iterateItems() as $item) {
 $created = false;
 $changed = false;
 $marker = 'os-carp-vip-dhcp';
+$managed_desc = 'Managed by os-carp-vip-dhcp (current CARP VIP address)';
 foreach ($wanted as $name => $ip) {
     if (isset($existing[$name])) {
         $item = $existing[$name];
         if (strpos((string)$item->description, $marker) === false) {
-            fwrite(STDERR, sprintf(
-                "alias '%s' exists but is not managed by %s -- leaving it untouched\n",
-                $name,
-                $marker
-            ));
+            // A same-named alias exists that the plugin did not create. Adopt it
+            // -- stamp the marker and take over its content -- so an operator can
+            // pre-create the alias and stage NAT/rules that reference it before
+            // the keeper first runs. Only a Host alias, though: taking over a
+            // Network/URL/port/etc. alias would change its meaning, so those are
+            // left untouched with a warning.
+            if ((string)$item->type !== 'host') {
+                fwrite(STDERR, sprintf(
+                    "alias '%s' exists as a '%s' alias (not Host) -- leaving it untouched\n",
+                    $name,
+                    (string)$item->type
+                ));
+                continue;
+            }
+            $item->description = $managed_desc;
+            $item->content = $ip;
+            $changed = true;
+            fwrite(STDERR, sprintf("adopted pre-existing Host alias '%s'\n", $name));
             continue;
         }
         if ((string)$item->type !== 'host' || (string)$item->content !== $ip) {
@@ -79,7 +95,7 @@ foreach ($wanted as $name => $ip) {
         $item->name = $name;
         $item->type = 'host';
         $item->content = $ip;
-        $item->description = 'Managed by os-carp-vip-dhcp (current CARP VIP address)';
+        $item->description = $managed_desc;
         $created = true;
     }
 }


### PR DESCRIPTION
## What

`sync_aliases` (the configd action that mirrors each keeper's CARP VIP into a firewall Host alias) now **adopts a same-named Host alias the plugin did not create**, instead of skipping it.

## Why

You cannot point an outbound-NAT rule at an alias that does not exist yet, so a "prepare the whole config, then enable" workflow needs the alias to exist first. Previously the plugin only touched aliases carrying its own marker, so a hand-created `wan_carp_vip` was left unmanaged and went stale on a follow. Now the operator can pre-create it and stage rules before the keeper first runs.

## How

In `manage_alias.php`, when a same-named alias exists without the plugin marker:
- if it is a **Host** alias, stamp the marker into its description and take over its content (log `adopted pre-existing Host alias 'X'`), then manage it normally on every follow;
- if it is **not** a Host alias (Network/URL/port/etc.), leave it untouched with a warning (adopting it would change its meaning).

Newly-created aliases are unchanged. Bump to 1.10.3 (single-sourced `__version__`).

## Testing

- `php -l` clean (PHP 8.3).
- Live adopt test on the pve3 clone: pre-create an unmarked Host alias, run `configctl carpvipdhcp sync_aliases`, confirm the alias is stamped with the marker and its content becomes the keeper's VIP (results in the PR thread).
- CI: php -l + PSR-12, shellcheck, xml.
