### PR TITLE
os-carp-vip-dhcp: default-route reconciler (observe/enforce) keyed on CARP role

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ All per-keeper; sensible defaults mean most setups only pick a CARP VIP and enab
 - **CARP failover on lease loss** *(optional)*: demote this node (hand the VIP to the peer) if the keeper stops holding the correct lease.
 - **DHCP identity options** *(advanced)*: set a vendor-class (opt 60), client-id (61) or hostname (12) for servers that only lease to a known value. On a server that keys the lease on the **client-id** (not the chaddr), **both HA nodes must present the *same* client-id** - a divergent one gets them different addresses and breaks the shared VIP. HA config-sync keeps it identical.
 - **Capture backend** *(advanced, experimental)*: pick the packet-capture engine per keeper: **Default** (follow the host-wide `carpvipdhcp_backend` rc.conf flag if set, else Scapy), **scapy**, or **bpf** (the dependency-free raw `/dev/bpf` backend). Lets a bpf rollout be staged one VIP at a time; leave on Default unless you are testing bpf.
+- **Own the default route by CARP role** *(advanced, default off)*: make one keeper own the IPv4 default route as a function of CARP role and lease - only the master node holding the lease keeps a default (via the lease gateway), every other state has none, so a failover moves the default with the role instead of leaving a backup black-holing traffic. **observe** logs what it would do without touching the routing table; **enforce** installs and withdraws it. Pairs with marking the WAN gateway down (`force_down`) so OPNsense does not install a competing default. See *Owning the default route by CARP role*.
 - **HA config sync** *(optional)*: replicate the keeper config to the peer (System ‣ High Availability ‣ Settings), so you configure once on the master. Safe: the config is node-agnostic.
 - **Self-healing & health banner:** the daemon never exits on a transient fault (it keeps its heartbeat fresh so CARP doesn't falsely demote the node), and a GUI banner warns if any enabled keeper stops holding its lease - closing the silent-failure gap on a redundant spare.
 
@@ -147,6 +148,21 @@ A follow also runs the system's **newwanip hooks** for the VIP's interface, so c
 A **cross-subnet** renumber is handled too: when the ACK moves the gateway, the plugin also updates the VIP prefix and the WAN gateway from the ACK's subnet mask and gateway, and reapplies routing. The one gap left is an ACK that changes the gateway **without** carrying a subnet mask: then only the address moves, and the keeper logs a loud warning to fix the interface prefix and System > Gateways by hand.
 
 **HA note:** firewall aliases are covered by OPNsense HA config sync, so an alias update propagates to the backup too. The CARP VIP itself is intentionally *not* synced (`advskew` differs per node).
+
+</details>
+
+<details>
+<summary><b>Owning the default route by CARP role</b></summary>
+
+On a single-IP CARP WAN, a backup node that still holds (or advertises) a default route can black-hole traffic - it has no live lease of its own, so its default leads nowhere useful. This option makes **one** keeper own the IPv4 default route (`0.0.0.0/0`) as a strict function of CARP role and lease, so the failure mode is a *withdrawn* default (fail-stop), never a black-holed one.
+
+- **The rule:** the CARP **master** that holds this keeper's lease keeps a default via the **lease gateway** (DHCP option 3); every other state - backup, or master without a lease - keeps **none**. It is level-triggered and idempotent (it reconciles on each role/lease change and converges), and a failover moves the default with the role within ~1 s because it reacts to the CARP transition, not a slow poll.
+- **Modes:** **off** *(default)* does nothing. **observe** logs the decision it *would* make without writing the routing table - run this first to watch the behaviour on your own box. **enforce** actually installs and withdraws the default.
+- **With os-frr:** the default lives in the kernel FIB, so `redistribute kernel` makes the advertised default follow the CARP role for free - the backup stops advertising `0/0` instead of advertising a route it cannot honour. It also works **without** FRR (it just keeps the backup route-honest locally); the keeper makes no FRR calls.
+- **Only one keeper may enforce** - there is a single default route, so two enforcing keepers would fight over it (the settings page rejects a second one). Others may still run in **observe**.
+- **Pair with `force_down`:** OPNsense installs its own default from the WAN gateway unconditionally, which would fight the keeper. Mark the WAN gateway down (System ‣ Gateways, **Mark Gateway as Down**) so OPNsense installs no default and the keeper owns it cleanly. On a static single-IP WAN this changes only the default-route decision; gateway monitoring (RTT/loss) still runs. Roll it out gently: **observe** first, then **enforce** with `force_down`.
+
+Part of the [Single-IP WAN failover](net/os-carp-vip-dhcp/docs/single-ip-wan-carp.md) picture.
 
 </details>
 

--- a/net/os-carp-vip-dhcp/docs/single-ip-wan-carp.md
+++ b/net/os-carp-vip-dhcp/docs/single-ip-wan-carp.md
@@ -668,6 +668,13 @@ only because the VIP, its on-link path to the gateway, is suppressed in backup s
 has the right default route installed, and the moment CARP brings the VIP up on it, that
 route starts working - **no routing reconfiguration on role change.**
 
+> **`defaultRouteMode`:** the design above is the baseline (`off`, the default), where
+> OPNsense installs the default on both nodes and it never moves. If you instead set a
+> keeper's `defaultRouteMode` to `enforce`, that keeper owns the default per CARP role
+> (install as master, withdraw otherwise), which requires the WAN gateway's **Mark
+> Gateway as Down** (`force_down`) so OPNsense does not also manage it. See the README's
+> default-route ownership section. In `off` this section applies unchanged.
+
 ```mermaid
 flowchart LR
     subgraph BK["Backup state"]

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -82,8 +82,9 @@ carpvipdhcp_start()
             ''|scapy|bpf) [ -n "${backend}" ] && set -- "$@" --capture-backend "${backend}" ;;
             *) echo "carpvipdhcp: ignoring unknown capture backend '${backend}' (use scapy or bpf)" >&2 ;;
         esac
-        # Default-route ownership by CARP role. Pass only observe/enforce; empty
-        # or "off" leaves the daemon default (off, inert). Validate here rather
+        # Default-route ownership by CARP role (the 13th keeper.conf column). Pass
+        # only observe/enforce; empty or "off" leaves the daemon default (off,
+        # inert). Validate here rather
         # than pass a typo through: an unknown value fails the daemon's argparse
         # choice, and daemon(8) -r would turn that exit into a silent crash loop.
         case "${defaultroutemode}" in

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -7,7 +7,7 @@
 # rc(8) wrapper for the CARP-VIP DHCP lease keepers (lease_keeper.py).
 # Reads /usr/local/etc/carpvipdhcp/keeper.conf (rendered by the configd template):
 # one line per enabled keeper ->
-#   REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE|ARP_LISTEN_PROMISC.
+#   REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE|ARP_LISTEN_PROMISC|CAPTURE_BACKEND|DEFAULT_ROUTE_MODE.
 # Starts one supervised daemon per line, keyed by a filesystem-safe request-IP id.
 
 . /etc/rc.subr
@@ -35,7 +35,7 @@ carpvipdhcp_start()
 {
     [ -f "${conf}" ] || { echo "no config"; return 0; }
     count=0
-    while IFS='|' read -r request iface chaddr demote vhid follow vendorclass clientid hostname arpnudge arplistenpromisc capturebackend || [ -n "${request}" ]; do
+    while IFS='|' read -r request iface chaddr demote vhid follow vendorclass clientid hostname arpnudge arplistenpromisc capturebackend defaultroutemode || [ -n "${request}" ]; do
         [ -n "${request}" ] || continue
         case "${request}" in \#*) continue ;; esac
         if [ -z "${iface}" ] || [ -z "${chaddr}" ]; then
@@ -81,6 +81,15 @@ carpvipdhcp_start()
         case "${backend}" in
             ''|scapy|bpf) [ -n "${backend}" ] && set -- "$@" --capture-backend "${backend}" ;;
             *) echo "carpvipdhcp: ignoring unknown capture backend '${backend}' (use scapy or bpf)" >&2 ;;
+        esac
+        # Default-route ownership by CARP role. Pass only observe/enforce; empty
+        # or "off" leaves the daemon default (off, inert). Validate here rather
+        # than pass a typo through: an unknown value fails the daemon's argparse
+        # choice, and daemon(8) -r would turn that exit into a silent crash loop.
+        case "${defaultroutemode}" in
+            ''|off) : ;;
+            observe|enforce) set -- "$@" --default-route-mode "${defaultroutemode}" ;;
+            *) echo "carpvipdhcp: ignoring unknown default-route mode '${defaultroutemode}' (use off, observe or enforce)" >&2 ;;
         esac
         # -f detach; -r supervise/restart on crash; -R 5 restart delay; -P supervisor pidfile.
         /usr/sbin/daemon -f -r -R 5 -P "${pidfile}" -t "${name}-${id}" "${keeper}" "$@"

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
@@ -31,6 +31,13 @@
         <help><![CDATA[Enforce mode only. When set, this node demotes itself (handing the CARP virtual IP to the peer) if this keeper stops holding its DHCP lease. Only meaningful with "Follow dynamic DHCP address" OFF (a following keeper adopts a new address instead of losing its lease, so the two are mutually exclusive). When unset (default), the keeper just keeps the lease alive on both nodes redundantly, without affecting CARP.]]></help>
     </field>
     <field>
+        <id>keeper.defaultRouteMode</id>
+        <label>Own default route by CARP role</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help><![CDATA[Default OFF. Make this keeper own the IPv4 default route (0.0.0.0/0) by CARP role: the master node holding this keeper's lease keeps a default via the lease gateway, every other state keeps none, so a node offers a default only while it can actually route one (a failover moves it, a backup withdraws it, instead of black-holing). <b>Off</b>: inert. <b>Observe</b>: log the decision it would make, without touching the routing table (use this first). <b>Enforce</b>: actually install and withdraw the default. Only ONE keeper (the WAN VIP) may enforce. In enforce mode, also tick the WAN gateway's "Mark Gateway as Down" (force_down) so OPNsense does not install a competing default. With os-frr the redistributed kernel default then follows the CARP role automatically; it also works without FRR. See the README.]]></help>
+    </field>
+    <field>
         <id>keeper.arpNudgeInterval</id>
         <label>ARP nudge interval (s)</label>
         <type>text</type>

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.php
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.php
@@ -66,6 +66,7 @@ class CarpVipDhcp extends BaseModel
         // of losing its lease, so it must never demote CARP on a change.
         $vipSeen = [];
         $aliasSeen = [];
+        $enforceSeen = false;
         foreach ($this->keepers->keeper->iterateItems() as $keeper) {
             $base = $keeper->__reference;
             $vip = (string)$keeper->carpVip;
@@ -94,6 +95,21 @@ class CarpVipDhcp extends BaseModel
                         . 'following keeper adopts the new address instead of losing its lease.'),
                     $base . '.demoteOnLeaseLoss'
                 ));
+            }
+            // At most one keeper may enforce the default route: there is a single
+            // 0.0.0.0/0, so two enforcing keepers would install/withdraw it against
+            // each other. Checked regardless of enabled (like the vip/alias
+            // invariants above) so the conflict surfaces at edit time, before a
+            // later enable silently creates two FIB-fighters. observe is unlimited.
+            if ((string)$keeper->defaultRouteMode === 'enforce') {
+                if ($enforceSeen) {
+                    $messages->appendMessage(new Message(
+                        gettext('Only one keeper may enforce the default route (they would fight over '
+                            . 'the single default). Set the other keepers to off or observe.'),
+                        $base . '.defaultRouteMode'
+                    ));
+                }
+                $enforceSeen = true;
             }
         }
 

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
@@ -116,6 +116,26 @@
                     </OptionValues>
                 </captureBackend>
 
+                <!--
+                    Own the IPv4 WAN default route as a function of CARP role and
+                    lease: the CARP-master node that holds this keeper's lease
+                    keeps 0.0.0.0/0 via the lease gateway; every other state has
+                    none, so a node advertises a default only while it can route
+                    one (via os-frr redistribute kernel; works without FRR too).
+                    off (default): inert. observe: log what it would do, no FIB
+                    write. enforce: actually install/withdraw. Only ONE keeper
+                    (the WAN VIP) may enforce. See the README.
+                -->
+                <defaultRouteMode type="OptionField">
+                    <Required>N</Required>
+                    <Default>off</Default>
+                    <OptionValues>
+                        <off>Off (default)</off>
+                        <observe>Observe (log only, no route change)</observe>
+                        <enforce>Enforce (own the default route)</enforce>
+                    </OptionValues>
+                </defaultRouteMode>
+
                 <description type="DescriptionField"/>
             </keeper>
         </keepers>

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -186,6 +186,15 @@ def main():
     a = _build_arg_parser().parse_args()
     _setup_logging(a.logfile)
 
+    # Fail-stop FIRST, before any early exit below: a crashed predecessor (whose
+    # backend is now missing, or that was restarted with a bad arg) may have left a
+    # default in the FIB, still redistributed by FRR. Withdraw it as non-master
+    # here -- pure route(8), no capture backend -- since the backend preflight and
+    # the arg checks can each return before Keeper.run() would otherwise do it.
+    # Skipped for --once (a wiring test, not a supervised service restart).
+    if not a.once:
+        Keeper.fail_stop_withdraw_default(a.default_route_mode, a.vhid)
+
     # Fail fast (with a logged reason) if the selected backend cannot run on
     # this host -- checked uniformly through the registry so a future backend
     # with an optional dependency is covered without a special case here.

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -186,78 +186,84 @@ def main():
     a = _build_arg_parser().parse_args()
     _setup_logging(a.logfile)
 
-    # Fail-stop FIRST, before any early exit below: a crashed predecessor (whose
-    # backend is now missing, or that was restarted with a bad arg) may have left a
-    # default in the FIB, still redistributed by FRR. Withdraw it as non-master
-    # here -- pure route(8), no capture backend -- since the backend preflight and
-    # the arg checks can each return before Keeper.run() would otherwise do it.
-    # Skipped for --once (a wiring test, not a supervised service restart), and
-    # when there is no CARP vhid (nothing owns a default route by role).
-    if not a.once and a.vhid:
-        DefaultRouteReconciler.withdraw_if_enabled(a.default_route_mode)
-
-    # Fail fast (with a logged reason) if the selected backend cannot run on
-    # this host -- checked uniformly through the registry so a future backend
-    # with an optional dependency is covered without a special case here.
-    reason = CAPTURE_BACKENDS[a.capture_backend].unavailable_reason()
-    if reason is not None:
-        LOG.critical("capture backend %r cannot run: %s -- the lease keeper cannot start",
-                     a.capture_backend, reason)
-        return 3
-    LOG.info("capture backend: %s", a.capture_backend)
-
-    for label, mac in (("chaddr", a.chaddr), ("eth-src", a.eth_src)):
-        if mac and not MAC_RE.match(mac):
-            LOG.error("invalid %s MAC address: %r", label, mac)
-            return 2
-
-    k = Keeper(a.iface, a.chaddr, a.request, a.eth_src,
-               hbfile=a.hbfile, release_on_exit=a.release_on_exit or a.once,
-               vhid=a.vhid, follow=a.follow,
-               vendor_class=a.vendor_class, client_id=a.client_id, hostname=a.hostname,
-               arp_nudge=a.arp_nudge, arp_listen_promisc=a.arp_listen_promisc,
-               capture_backend=a.capture_backend, default_route_mode=a.default_route_mode)
-
-    if a.arp_listen_promisc:
-        LOG.warning("ARP listen: PROMISCUOUS capture enabled on %s -- the daemon now "
-                    "sees all traffic on the segment (opt-in fallback for NICs that "
-                    "drop the gateway's unicast ARP reply otherwise)", a.iface)
-
-    def _sig(*_):
-        # Flag only -- no logging or other non-async-signal-safe work in the
-        # handler (like the SIGUSR1/2 handlers below). set_wakeup_fd wakes the
-        # loop at once; run() logs "stopped" when it exits.
-        k.request_stop()
-    signal.signal(signal.SIGINT, _sig)
-    signal.signal(signal.SIGTERM, _sig)
-
-    def _sig_arp_nudge(*_):
-        # Operator-requested immediate ARP nudge (configd action / kill -USR1).
-        k.trigger_nudge()
-    signal.signal(signal.SIGUSR1, _sig_arp_nudge)  # type: ignore[attr-defined]  # pylint: disable=no-member
-
-    def _sig_carp(*_):
-        # CARP transition (rc.syshook.d/carp/50-carpvipdhcp sends SIGUSR2).
-        k.recheck_carp_role()
-    signal.signal(signal.SIGUSR2, _sig_carp)  # type: ignore[attr-defined]  # pylint: disable=no-member
-
-    if a.once:
-        return k.claim_once()
-
-    # Wake the maintain-loop sleep the instant a signal is delivered: Python's
-    # C-level signal machinery writes the signal number to this fd, which is
-    # async-signal-safe and needs no work in the handler (the _sig* handlers
-    # above only set a flag). The loop selects on the read end and drains it.
-    signal.set_wakeup_fd(k.wake_fileno())
-
-    pf = acquire_pidfile(a.pidfile)
+    # Single-instance guard BEFORE any FIB mutation: the startup fail-stop withdraw
+    # below deletes a default, so a duplicate start (pidfile held by the live owner)
+    # must exit HERE -- already running -- rather than clobber the owner's default
+    # and only then discover it is the duplicate. Held across the withdraw and the
+    # backend/arg checks; the finally releases it on every exit. --once is a wiring
+    # test: no guard and no FIB mutation, so it takes neither (pf stays None).
+    pf = None if a.once else acquire_pidfile(a.pidfile)
     try:
-        return k.run()
+        # Fail-stop: a crashed predecessor (whose backend is now missing, or that
+        # was restarted with a bad arg) may have left a default in the FIB, still
+        # redistributed by FRR. Withdraw it as non-master here -- pure route(8), no
+        # capture backend -- BEFORE the backend preflight and the arg checks, each
+        # of which can return before Keeper.run() would otherwise do it. Skipped for
+        # --once, and when no CARP vhid owns a default route by role.
+        if not a.once and a.vhid:
+            DefaultRouteReconciler.withdraw_if_enabled(a.default_route_mode)
+
+        # Fail fast (with a logged reason) if the selected backend cannot run on
+        # this host -- checked uniformly through the registry so a future backend
+        # with an optional dependency is covered without a special case here.
+        reason = CAPTURE_BACKENDS[a.capture_backend].unavailable_reason()
+        if reason is not None:
+            LOG.critical("capture backend %r cannot run: %s -- the lease keeper cannot start",
+                         a.capture_backend, reason)
+            return 3
+        LOG.info("capture backend: %s", a.capture_backend)
+
+        for label, mac in (("chaddr", a.chaddr), ("eth-src", a.eth_src)):
+            if mac and not MAC_RE.match(mac):
+                LOG.error("invalid %s MAC address: %r", label, mac)
+                return 2
+
+        k = Keeper(a.iface, a.chaddr, a.request, a.eth_src,
+                   hbfile=a.hbfile, release_on_exit=a.release_on_exit or a.once,
+                   vhid=a.vhid, follow=a.follow,
+                   vendor_class=a.vendor_class, client_id=a.client_id, hostname=a.hostname,
+                   arp_nudge=a.arp_nudge, arp_listen_promisc=a.arp_listen_promisc,
+                   capture_backend=a.capture_backend, default_route_mode=a.default_route_mode)
+
+        if a.arp_listen_promisc:
+            LOG.warning("ARP listen: PROMISCUOUS capture enabled on %s -- the daemon now "
+                        "sees all traffic on the segment (opt-in fallback for NICs that "
+                        "drop the gateway's unicast ARP reply otherwise)", a.iface)
+
+        def _sig(*_):
+            # Flag only -- no logging or other non-async-signal-safe work in the
+            # handler (like the SIGUSR1/2 handlers below). set_wakeup_fd wakes the
+            # loop at once; run() logs "stopped" when it exits.
+            k.request_stop()
+        signal.signal(signal.SIGINT, _sig)
+        signal.signal(signal.SIGTERM, _sig)
+
+        def _sig_arp_nudge(*_):
+            # Operator-requested immediate ARP nudge (configd action / kill -USR1).
+            k.trigger_nudge()
+        signal.signal(signal.SIGUSR1, _sig_arp_nudge)  # type: ignore[attr-defined]  # pylint: disable=no-member
+
+        def _sig_carp(*_):
+            # CARP transition (rc.syshook.d/carp/50-carpvipdhcp sends SIGUSR2).
+            k.recheck_carp_role()
+        signal.signal(signal.SIGUSR2, _sig_carp)  # type: ignore[attr-defined]  # pylint: disable=no-member
+
+        if a.once:
+            return k.claim_once()
+
+        # Wake the maintain-loop sleep the instant a signal is delivered: Python's
+        # C-level signal machinery writes the signal number to this fd, which is
+        # async-signal-safe and needs no work in the handler (the _sig* handlers
+        # above only set a flag). The loop selects on the read end and drains it.
+        signal.set_wakeup_fd(k.wake_fileno())
+        try:
+            return k.run()
+        finally:
+            # Stop the C-level signal machinery from writing to the wake socket
+            # before run() closes it; otherwise a signal in the shutdown window
+            # writes to a closed fd (harmless, but noisy on stderr).
+            signal.set_wakeup_fd(-1)
     finally:
-        # Stop the C-level signal machinery from writing to the wake socket
-        # before run() closes it; otherwise a signal in the shutdown window
-        # writes to a closed fd (harmless, but noisy on stderr).
-        signal.set_wakeup_fd(-1)
         if pf and os.path.exists(pf):
             try:
                 os.unlink(pf)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -64,6 +64,7 @@ from logging.handlers import RotatingFileHandler
 from leasekeeper.capture import CAPTURE_BACKENDS
 from leasekeeper.constants import LOGGER_NAME
 from leasekeeper.keeper import Keeper
+from leasekeeper.route import DefaultRouteMode
 from leasekeeper.util import MAC_RE
 
 LOG = logging.getLogger(LOGGER_NAME)
@@ -148,6 +149,11 @@ def _build_arg_parser():
     ap.add_argument("--capture-backend", choices=sorted(CAPTURE_BACKENDS), default="scapy",
                     help="packet capture/send backend: scapy (default), or bpf -- a raw "
                          "/dev/bpf backend with no packet-library dependency (experimental)")
+    ap.add_argument("--default-route-mode", choices=[m.value for m in DefaultRouteMode],
+                    default=DefaultRouteMode.OFF.value,
+                    help="own the IPv4 default route by CARP role: off (default), observe "
+                         "(log what it would do, no FIB write), or enforce (install/withdraw "
+                         "0/0 via the lease gateway while CARP master holding a lease)")
     ap.add_argument("--once", action="store_true")
     ap.add_argument("--release-on-exit", action="store_true")
     return ap
@@ -200,7 +206,7 @@ def main():
                vhid=a.vhid, follow=a.follow,
                vendor_class=a.vendor_class, client_id=a.client_id, hostname=a.hostname,
                arp_nudge=a.arp_nudge, arp_listen_promisc=a.arp_listen_promisc,
-               capture_backend=a.capture_backend)
+               capture_backend=a.capture_backend, default_route_mode=a.default_route_mode)
 
     if a.arp_listen_promisc:
         LOG.warning("ARP listen: PROMISCUOUS capture enabled on %s -- the daemon now "

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -64,7 +64,7 @@ from logging.handlers import RotatingFileHandler
 from leasekeeper.capture import CAPTURE_BACKENDS
 from leasekeeper.constants import LOGGER_NAME
 from leasekeeper.keeper import Keeper
-from leasekeeper.route import DefaultRouteMode
+from leasekeeper.route import DefaultRouteMode, DefaultRouteReconciler
 from leasekeeper.util import MAC_RE
 
 LOG = logging.getLogger(LOGGER_NAME)
@@ -191,9 +191,10 @@ def main():
     # default in the FIB, still redistributed by FRR. Withdraw it as non-master
     # here -- pure route(8), no capture backend -- since the backend preflight and
     # the arg checks can each return before Keeper.run() would otherwise do it.
-    # Skipped for --once (a wiring test, not a supervised service restart).
-    if not a.once:
-        Keeper.fail_stop_withdraw_default(a.default_route_mode, a.vhid)
+    # Skipped for --once (a wiring test, not a supervised service restart), and
+    # when there is no CARP vhid (nothing owns a default route by role).
+    if not a.once and a.vhid:
+        DefaultRouteReconciler.withdraw_if_enabled(a.default_route_mode)
 
     # Fail fast (with a logged reason) if the selected backend cannot run on
     # this host -- checked uniformly through the registry so a future backend

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
@@ -18,4 +18,4 @@ wires up and runs the Keeper defined here. Modules, leaf-first:
 # PLUGIN_VERSION from this line (so the package version and the daemon's own
 # reported version can never drift). Keep the assignment on one line as
 # __version__ = "X.Y.Z" so the Makefile's sed can read it.
-__version__ = "1.10.3"
+__version__ = "1.11.0"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
@@ -25,7 +25,7 @@ LOG = logging.getLogger(LOGGER_NAME)
 
 
 @dataclass
-class Lease:
+class Lease:  # pylint: disable=too-many-instance-attributes
     """The held DHCP binding: address, granting server, timing, and the
     routing facts (options 3/1) the Parameter Request List asks for. During
     a DORA it briefly holds the unconfirmed OFFER candidate; otherwise it is
@@ -39,6 +39,11 @@ class Lease:
     t2_server: int | None = None   # server-provided rebinding time (DHCP opt 59)
     router: str | None = None      # default gateway (DHCP opt 3, fallback: server)
     mask_bits: int | None = None   # subnet prefix length from opt 1
+    # The opt-3 gateway of the CURRENT lease, for the route reconciler: unlike the
+    # sticky `router` above (kept as a nudge/logging hint), this is None when the
+    # lease in hand did not itself supply a router, so a new lease that omits it is
+    # never routed via the previous lease's (possibly wrong-subnet) gateway.
+    lease_router: str | None = None
 
 
 class DhcpClient:  # pylint: disable=too-many-instance-attributes
@@ -114,17 +119,26 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                 return rx
         return None
 
-    def _absorb_reply(self, rx, default_lease):
+    def _absorb_reply(self, rx, default_lease, fresh_bind=False):
         """Adopt lease timing, gateway (opt 3) and subnet mask (opt 1) from an ACK
         -- the one place that knows which DhcpReply fields carry lease state.
         gateway + mask are what the Parameter Request List asks for; keep them for
         logging + the cross-subnet follow decision. The lease time is floored at
         MIN_LEASE so a server (or a spoofed ACK) offering a 1-second lease cannot
-        drive the renew loop into a tight broadcast/CPU spin."""
+        drive the renew loop into a tight broadcast/CPU spin. fresh_bind: this ACK
+        is a new binding (a DORA/adopt), not a renew of the held lease."""
         self.binding.lease_secs = max(rx.lease or default_lease, MIN_LEASE)
         self.binding.t1_server, self.binding.t2_server = rx.t1, rx.t2
         self.binding.router = rx.router or self.binding.router
         self.binding.mask_bits = _mask_to_bits(rx.subnet_mask) or self.binding.mask_bits
+        # lease_router tracks the CURRENT lease's own gateway (see the field). A
+        # fresh bind takes it verbatim from this ACK (None if the ACK omits opt 3,
+        # so no default is installed via a stale gateway); a renew of the same
+        # address keeps the current lease's gateway unless the ACK refreshes it.
+        if fresh_bind:
+            self.binding.lease_router = rx.router
+        else:
+            self.binding.lease_router = rx.router or self.binding.lease_router
 
     def adopt(self, rx):
         """Bind to the address in rx: the ACK that completes a DORA, or a
@@ -134,7 +148,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         the ACK's server-id, keeping the previous one when the ACK has none."""
         self.binding.yiaddr = rx.yiaddr
         self.binding.server = rx.server_id or self.binding.server
-        self._absorb_reply(rx, DEFAULT_LEASE)
+        self._absorb_reply(rx, DEFAULT_LEASE, fresh_bind=True)
 
     def expire(self):
         """Forget the held binding WITHOUT a RELEASE (on-time lease expiry, or a
@@ -168,7 +182,15 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         the offer until the ACK lands). Returns True once BOUND, False on
         failure/NAK."""
         self.xid = _new_xid()
-        return self._discover(request_ip) and self._request_offer(request_ip)
+        if self._discover(request_ip) and self._request_offer(request_ip):
+            return True
+        # A failed DORA (NAK / timeout after an OFFER) must not leave the
+        # unconfirmed offered address in binding.yiaddr: _discover parks it there
+        # so _request_offer can REQUEST it, but _maintain_step reads a set yiaddr
+        # as "bound" and would then renew -- and the route reconciler install a
+        # default for -- a lease we never actually got. Clear it so we re-acquire.
+        self.binding.yiaddr = None
+        return False
 
     def _discover(self, request_ip):
         """SELECTING: broadcast DISCOVER until a server OFFERs; record the

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
@@ -172,7 +172,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             if request_ip:
                 if self.reboot(request_ip):
                     return True
-                LOG.info("INIT-REBOOT did not bind %s -- falling back to DISCOVER", request_ip)
+                LOG.info("INIT-REBOOT did not bind %s -- falling back to %s", request_ip, Phase.DORA)
 
         return self.dora(request_ip)
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
@@ -329,7 +329,12 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                 return False
             rx = self._wait_for_dhcp_reply(ACK, RENEW_TIMEOUT)
             if rx and rx.mtype == NAK:
-                return False   # NAK -> re-DORA
+                # DHCPNAK: the server revoked the lease. RFC 2131 4.4.5 says go back
+                # to INIT (re-DISCOVER), not keep REBINDing an address it refused, so
+                # forget the binding here; the caller withdraws any owned default and
+                # re-acquires. expire() keeps the server/router hints for the re-DORA.
+                self.expire()
+                return False
             if rx:
                 got = rx.yiaddr
                 if got and got != self.binding.yiaddr:

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -86,6 +86,11 @@ class _SignalFlags:
     # by the next per-tick role poll, and the periodic ARP nudge keeps reachability
     # fresh regardless of a dropped manual nudge (SIGUSR1) -- so a lost edge costs
     # at most one poll interval of latency, never a missed state change.
+    # The one stretch where that interval is longer than a tick is inside a
+    # blocking DhcpClient.renew()/reboot() reply wait, which services only the stop
+    # callback: a CARP edge that lands there is reconciled when the call returns
+    # (the renew/rebind-success arms and the REBIND loop all reconcile), so failover
+    # convergence is delayed by at most one renew/rebind attempt there, not lost.
     @property
     def stopping(self):
         """Terminal stop flag; polled (never cleared) by every loop/sleep guard."""
@@ -679,6 +684,13 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             self._reconcile_default_route(master)
             self._arp_nudge(force=True, master=master)
             return
+        if not b.yiaddr:
+            # renew() got a DHCPNAK and forgot the binding (lease revoked): withdraw
+            # any default we owned at once and drop to the unbound arm to re-acquire,
+            # rather than REBINDing an address the server just refused.
+            LOG.warning("DHCP RENEW got NAK -- lease revoked, re-acquiring")
+            self._reconcile_default_route()
+            return
         LOG.warning("DHCP RENEW failed at T1 -- trying REBIND until T2")
 
         elapsed = t1
@@ -704,6 +716,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             if self._dhcp.renew(rebind=True):
                 ok = True
                 break
+            if not b.yiaddr:
+                # A NAK during REBIND likewise revoked the lease: withdraw and
+                # re-acquire instead of spinning REBIND until T2 with the default up.
+                LOG.warning("DHCP REBIND got NAK -- lease revoked, re-acquiring")
+                self._reconcile_default_route()
+                return
         if ok:
             LOG.info("DHCP REBIND ok %s (lease=%ss, expires ~%s)",
                      b.yiaddr, b.lease_secs, _clock_at(b.lease_secs))

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -688,6 +688,14 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 break
             elapsed += step
             self._hb()   # still holding the lease until T2 -- keep the heartbeat fresh
+            # REBIND can span the whole T1..T2 window; keep the CARP-role
+            # bookkeeping and the default route reconciled here too, exactly as
+            # _hold_lease does per tick. Otherwise a failover during this degraded
+            # path relies solely on the SIGUSR2 edge, with no periodic fallback
+            # for a missed one until REBIND exits.
+            master = self._probe_carp_master()
+            self._poll_carp_role(master)
+            self._reconcile_default_route(master)
             if self._dhcp.renew(rebind=True):
                 ok = True
                 break

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -44,30 +44,62 @@ _UNSET = object()
 
 @dataclass
 class _SignalFlags:
-    """The only shared state a signal handler may write.
+    """The only shared state a signal handler may write, behind a tiny protocol
+    that makes the safe usage the only usage.
 
-    A signal handler (request_stop / trigger_nudge / recheck_carp_role) runs on
-    the MAIN thread, between bytecodes; the single safe thing it may do is flip
-    one of these booleans to True. They are plain booleans on purpose: a set is
-    one bytecode, hence atomic w.r.t. signal delivery (never torn); they are
-    independent of one another (no flag has to be consistent with another); and
-    the maintain loop drains each with check-and-clear + idempotent handling --
-    which is what makes this correct WITHOUT a lock. Do NOT let a handler do
-    more: no I/O, and no mutation of the binding / lease / role or any other
-    shared state -- that reintroduces re-entrancy and consistency bugs. Add a
-    new signal-driven request the same way: a new field here, set by the
-    handler, drained by the loop; never by doing work in the handler.
+    A signal handler (request_stop / request_nudge / request_recheck_role) runs
+    on the MAIN thread, between bytecodes; the single safe thing it does is flip
+    one of these booleans to True -- one bytecode, hence atomic w.r.t. signal
+    delivery (never torn), and independent of the others. The maintain loop
+    drains each edge flag with take_*() (check-and-clear in one place) and polls
+    the terminal stop flag via `stopping`. The fields are private and reached
+    only through these methods so the rule "a handler only ever sets True, the
+    loop only ever clears" is structural, not a comment a later edit can quietly
+    break: this is what makes the path correct WITHOUT a lock. Do NOT let a
+    handler do more (no I/O, no mutation of the binding / lease / role), and do
+    NOT set a flag from another thread -- either reintroduces re-entrancy and
+    consistency bugs. Add a new signal-driven request as another private bool
+    plus a request_*/take_* pair, never by doing work in the handler.
     """
-    stop: bool = False           # SIGINT / SIGTERM -> request_stop()
-    nudge: bool = False          # SIGUSR1          -> trigger_nudge()
-    recheck_role: bool = False   # SIGUSR2 (CARP)   -> recheck_carp_role()
+    _stop: bool = False           # SIGINT / SIGTERM
+    _nudge: bool = False          # SIGUSR1
+    _recheck_role: bool = False   # SIGUSR2 (CARP transition / route_reload)
+
+    # -- handler side: set True (idempotent, async-signal-safe: one bytecode) --
+    def request_stop(self):
+        """Ask the loop to exit (SIGINT/SIGTERM handler)."""
+        self._stop = True
+
+    def request_nudge(self):
+        """Ask for an immediate ARP nudge (SIGUSR1 handler)."""
+        self._nudge = True
+
+    def request_recheck_role(self):
+        """Ask for a CARP-role re-check (SIGUSR2 handler)."""
+        self._recheck_role = True
+
+    # -- main-loop side --
+    @property
+    def stopping(self):
+        """Terminal stop flag; polled (never cleared) by every loop/sleep guard."""
+        return self._stop
+
+    def take_nudge(self):
+        """Whether an immediate ARP nudge was requested; clears it (loop only)."""
+        pending, self._nudge = self._nudge, False
+        return pending
+
+    def take_recheck_role(self):
+        """Whether a CARP-role re-check was requested; clears it (loop only)."""
+        pending, self._recheck_role = self._recheck_role, False
+        return pending
 
 
 @dataclass(frozen=True)
 class _Config:
     """The keeper's fixed identity/config, set once from the constructor and
     never mutated -- so a frozen dataclass. master_marker is derived from vhid
-    (the ifconfig CARP-master line for this vhid), built once here."""
+    (the ifconfig CARP-master line for this vhid)."""
     iface: str
     chaddr: str
     eth_src: str
@@ -144,7 +176,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._dhcp = DhcpClient(
             self._capture, self._cfg.chaddr, self._cfg.eth_src,
             _identity_options(vendor_class, client_id, hostname),
-            should_stop=lambda: self._signals.stop,
+            should_stop=lambda: self._signals.stopping,
             ensure_sniffer=self._ensure_sniffer,
             on_changed_address=self._on_changed_address)
 
@@ -161,7 +193,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # (_reconcile_default_route). liveness_probe is left unset for now: the
         # split-brain install-gate is a deliberate follow-up that needs a
         # debounced carrier signal (a single transient ifconfig miss must not
-        # flap the default); see docs/default-route-carp-ownership.md.
+        # flap the default); see docs/single-ip-wan-carp.md.
         self._defroute = DefaultRouteReconciler(default_route_mode)
 
         self.redora_wait = REDORA_MIN
@@ -449,23 +481,23 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
     def request_stop(self):
         """Ask the daemon to exit (SIGINT/SIGTERM). Flag only; set_wakeup_fd
         wakes the loop so it exits at once."""
-        self._signals.stop = True
+        self._signals.request_stop()
 
     def trigger_nudge(self):
         """Request an immediate ARP nudge (SIGUSR1 / configd action). Flag only;
         no network I/O in signal context."""
-        self._signals.nudge = True
+        self._signals.request_nudge()
 
     def recheck_carp_role(self):
         """Re-check the CARP role now (SIGUSR2 from the CARP syshook) instead of
         waiting for the next ~30s poll. Flag only."""
-        self._signals.recheck_role = True
+        self._signals.request_recheck_role()
 
     # ---- main loop / sleeps ----
 
     def _sleep(self, secs):
         slept = 0
-        while slept < secs and not self._signals.stop:
+        while slept < secs and not self._signals.stopping:
             time.sleep(1)
             slept += 1
         return slept
@@ -475,9 +507,8 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         operator-requested immediate nudge (SIGUSR1) and a CARP-transition re-check
         (SIGUSR2) so both act within a second instead of at the next heartbeat tick."""
         slept = 0
-        while slept < secs and not self._signals.stop:
-            if self._signals.recheck_role:
-                self._signals.recheck_role = False
+        while slept < secs and not self._signals.stopping:
+            if self._signals.take_recheck_role():
                 # A CARP transition just fired (kernel -> devd -> rc.syshook.d/carp
                 # -> SIGUSR2); re-check the role now so a backup->master keeper
                 # nudges + renews immediately instead of at the next ~30s poll, and
@@ -487,8 +518,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 self._poll_carp_role(master)
                 self._reconcile_default_route(master)
 
-            if self._signals.nudge:
-                self._signals.nudge = False
+            if self._signals.take_nudge():
                 # Operator actions are rare and intentional -- always log them,
                 # unlike the periodic nudges (whose freshness the status page
                 # already shows without flooding the log every interval).
@@ -505,7 +535,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             # and let _maintain_step re-DORA immediately (the bound path skips this).
             if self._dhcp.binding.yiaddr is None and slept % LINK_POLL_STEP == 0 and self._check_link_returned():
                 self._link.returned = True
-                return not self._signals.stop
+                return not self._signals.stopping
 
             # Event-driven sleep: return at once when the wake socket is written
             # (a fresh observation or an operator signal), otherwise time out
@@ -517,7 +547,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 except (BlockingIOError, OSError):
                     pass
             slept += 1
-        return not self._signals.stop
+        return not self._signals.stopping
 
     def _hold_lease(self, secs):
         """Sleep up to secs while holding a lease, rewriting the heartbeat every
@@ -525,12 +555,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         the CARP demotion hook only sees heartbeat freshness). Returns False early
         on stop."""
         remaining = secs
-        while remaining > 0 and not self._signals.stop:
+        while remaining > 0 and not self._signals.stopping:
             if self._renew_asap:
                 # Return as if T1 elapsed: the caller renews right away, which
                 # re-teaches upstream DHCP-snooping state after a master change.
                 self._renew_asap = False
-                return not self._signals.stop
+                return not self._signals.stopping
 
             chunk = min(HB_REFRESH, remaining)
             if not self._sleep_interruptible(chunk):
@@ -545,14 +575,14 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             self._poll_carp_role(master)   # backup->master? renew early + nudge now
             self._reconcile_default_route(master)   # keep the default route in step with role+lease
             self._arp_nudge(master=master)
-        return not self._signals.stop
+        return not self._signals.stopping
 
     def run(self):
         """The daemon main loop: capture up, then maintain the lease until
         stopped. Never raises; returns the process exit code."""
         # Start the packet capture, retrying forever: a keeper must self-heal, not
         # die, if the interface is briefly unavailable at startup.
-        while not self._signals.stop and not self._capture.start():
+        while not self._signals.stopping and not self._capture.start():
             LOG.warning("capture start failed -- retrying in %ds", SNIFFER_RETRY)
             self._sleep(SNIFFER_RETRY)
 
@@ -562,7 +592,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                  __version__, self._cfg.iface, self._cfg.chaddr, ethsrc, self._follow.target or "any")
         time.sleep(SNIFFER_WARMUP)
 
-        while not self._signals.stop:
+        while not self._signals.stopping:
             # The keeper must NEVER die on a bad DHCP state: catch any unexpected
             # error, keep the heartbeat fresh so CARP does not falsely demote us,
             # and retry after a short backoff.
@@ -628,7 +658,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
 
         elapsed = t1
         ok = False
-        while elapsed < t2 and not self._signals.stop:
+        while elapsed < t2 and not self._signals.stopping:
             # Jitter the REBIND retransmit cadence: both nodes hit T2 together
             # (identical lease timers), so an un-jittered step would broadcast
             # REBIND in lockstep. Overshooting t2 slightly is harmless (the guard

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -79,6 +79,13 @@ class _SignalFlags:
         self._recheck_role = True
 
     # -- main-loop side --
+    # take_*() reads-then-clears and is NOT masked against signal delivery: a
+    # signal landing between the read and the store can be erased by the store,
+    # dropping that one edge. This needs no lock or signal masking because each
+    # edge has a periodic fallback -- a dropped CARP re-check (SIGUSR2) is caught
+    # by the next per-tick role poll, and the periodic ARP nudge keeps reachability
+    # fresh regardless of a dropped manual nudge (SIGUSR1) -- so a lost edge costs
+    # at most one poll interval of latency, never a missed state change.
     @property
     def stopping(self):
         """Terminal stop flag; polled (never cleared) by every loop/sleep guard."""
@@ -421,20 +428,24 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         """Drive the IPv4 default route toward its CARP-role-owned desired state
         (install 0/0 via the lease gateway only while master AND holding a lease;
         withdraw it otherwise -- see leasekeeper/route.py). Level-triggered and
-        idempotent, so it rides the CARP-role cadence -- the per-tick heartbeat
-        probe (bound) and the acquire loop (unbound), plus the SIGUSR2 CARP edge
-        -- and converges without having to catch every transition. No-op unless a
+        idempotent, so it can ride every point that changes the inputs -- the
+        per-tick heartbeat probe (bound), the acquire arm (unbound and just after
+        a successful acquire), the SIGUSR2 CARP edge, and a fail-stop non-master
+        withdraw at startup and on shutdown -- converging without having to catch
+        every transition. No-op unless a
         vhid is configured (no CARP role to key on) and the mode is
         observe/enforce. `master` reuses the tick's probe when the caller has it.
 
-        Passes bound=yiaddr-is-set and gateway=binding.router; reconcile() owns
-        the contract for why bound must not be inferred from the sticky gateway."""
+        Passes bound=yiaddr-is-set and gateway=binding.lease_router (the CURRENT
+        lease's own opt-3 gateway, not the sticky binding.router hint), so a new
+        lease that omits option 3 never installs a default via a stale gateway;
+        reconcile() owns the contract for why bound must not be inferred from it."""
         if not self._cfg.vhid or not self._defroute.enabled:
             return
         if master is _UNSET:
             master = self._probe_carp_master()
         b = self._dhcp.binding
-        self._defroute.reconcile(master, b.yiaddr is not None, b.router)
+        self._defroute.reconcile(master, b.yiaddr is not None, b.lease_router)
 
     # ---- ARP nudge ----
 
@@ -580,6 +591,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
     def run(self):
         """The daemon main loop: capture up, then maintain the lease until
         stopped. Never raises; returns the process exit code."""
+        # Fail-stop on startup, before the capture-retry loop below can block: a
+        # predecessor that crashed (no graceful withdraw) may have left a default
+        # in the FIB. We hold no lease yet, so reconcile as non-master to withdraw
+        # any such stale default even if capture never (re)opens.
+        self._reconcile_default_route(master=False)
         # Start the packet capture, retrying forever: a keeper must self-heal, not
         # die, if the interface is briefly unavailable at startup.
         while not self._signals.stopping and not self._capture.start():
@@ -606,7 +622,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                     pass
                 self._sleep(LOOP_ERROR_BACKOFF)
 
-        # shutdown
+        # shutdown: relinquish an owned default so a stopped, disabled or
+        # mode-changed (enforce -> off) enforcing keeper does not leave 0/0 in the
+        # FIB, still redistributed by FRR, with nothing managing it. Reconcile as
+        # non-master -> withdraw; observe logs a would-withdraw and off is a no-op.
+        self._reconcile_default_route(master=False)
         if self._cfg.release_on_exit:
             self._dhcp.release()
         self._capture.stop()
@@ -728,6 +748,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             self._hb()
             self._arp_nudge(force=True)
             self.redora_wait = REDORA_MIN
+            # Own the default now the lease is in hand: the pre-acquire reconcile
+            # saw bound=False, and _hold_lease's first tick is a full HB_REFRESH
+            # away -- without this a freshly-acquired master would sit with no
+            # default for up to that interval (fail-stop, but a needless gap).
+            self._reconcile_default_route()
         else:
             LOG.warning("DHCP acquire (DISCOVER/REQUEST) failed -- retrying in %ds", self.redora_wait)
             if not self._wait_unbound(_jittered(self.redora_wait)):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -62,6 +62,36 @@ class _SignalFlags:
     recheck_role: bool = False   # SIGUSR2 (CARP)   -> recheck_carp_role()
 
 
+@dataclass(frozen=True)
+class _Config:
+    """The keeper's fixed identity/config, set once from the constructor and
+    never mutated -- so a frozen dataclass. master_marker is derived from vhid
+    (the ifconfig CARP-master line for this vhid), built once here."""
+    iface: str
+    chaddr: str
+    eth_src: str
+    hbfile: "str | None"
+    release_on_exit: bool
+    vhid: "str | None"
+
+    @property
+    def master_marker(self):
+        return CARP_MASTER_FMT.format(vhid=self.vhid) if self.vhid else None
+
+
+@dataclass
+class _LinkState:
+    """WAN-carrier state for the unbound link-return fast path (main-loop only).
+    up: last carrier seen (None = not probed). ifconfig_failed: gate to log an
+    ifconfig probe failure once per episode. kick_at: epoch of the last
+    link-return kick (debounce). returned: set by _sleep_interruptible on a
+    carrier return while unbound."""
+    up: "bool | None" = None
+    ifconfig_failed: bool = False
+    kick_at: float = 0.0
+    returned: bool = False
+
+
 class Keeper:  # pylint: disable=too-many-instance-attributes
     """Orchestration around the components: owns the capture backend (feeding
     DHCP replies to DhcpClient, ARP replies to ArpNudge and peer-ACK
@@ -74,15 +104,14 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                  hbfile=None, release_on_exit=False, vhid=None,
                  follow=False, vendor_class=None, client_id=None, hostname=None,
                  arp_nudge=0, arp_listen_promisc=False, capture_backend="scapy"):
-        self.iface = iface
-        self.chaddr = chaddr.lower()
-        self.eth_src = (eth_src or chaddr).lower()
-        self.hbfile = hbfile
-        self.release_on_exit = release_on_exit
-        self.vhid = str(vhid) if vhid else None
-        # The CARP-master marker is fixed once the vhid is known; build it here
-        # rather than reformatting it on every probe.
-        self._master_marker = CARP_MASTER_FMT.format(vhid=self.vhid) if self.vhid else None
+        # Fixed identity/config, immutable once set (see _Config).
+        self._cfg = _Config(
+            iface=iface,
+            chaddr=chaddr.lower(),
+            eth_src=(eth_src or chaddr).lower(),
+            hbfile=hbfile,
+            release_on_exit=release_on_exit,
+            vhid=str(vhid) if vhid else None)
 
         # Capture backend component: owns the capture socket/thread and the
         # wire codec on both directions, and hands decoded neutral frames
@@ -95,7 +124,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # ARP nudge component: owns the pacing and reachability state; the
         # keeper supplies the lease binding per nudge (_arp_nudge) and the
         # CARP-role probe (via the _carp_master_probe shim).
-        self._nudge = ArpNudge(self._capture, self.chaddr, arp_nudge, self._carp_master_probe)
+        self._nudge = ArpNudge(self._capture, self._cfg.chaddr, arp_nudge, self._carp_master_probe)
 
         self._was_master = None        # CARP role at the last nudge check (None = unknown yet)
 
@@ -109,7 +138,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # the keeper owns the capture (feeding it xid-matched replies) and the
         # policy hooks.
         self._dhcp = DhcpClient(
-            self._capture, self.chaddr, self.eth_src,
+            self._capture, self._cfg.chaddr, self._cfg.eth_src,
             _identity_options(vendor_class, client_id, hostname),
             should_stop=lambda: self._signals.stop,
             ensure_sniffer=self._ensure_sniffer,
@@ -117,17 +146,15 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
 
         # Follow/enforce policy component: owns the target address and the
         # follow bookkeeping; drives the client via adopt()/release()/expire().
-        self._follow = FollowPolicy(request_ip, follow, self.chaddr, self._dhcp,
+        self._follow = FollowPolicy(request_ip, follow, self._cfg.chaddr, self._dhcp,
                                     self._hb_mismatch,
                                     dispatch=self._dispatch_follow_update)
 
         self.redora_wait = REDORA_MIN
-        # Link-return fast path (only while UNBOUND): a carrier down->up edge resets
-        # the backoff and re-DORAs at once, like dhclient's link-up -> state_reboot.
-        self._link_up = None           # last carrier state seen (None = unknown / not probed)
-        self._ifconfig_failed = False  # ifconfig probe episode gate (log the failure once)
-        self._link_kick_at = 0.0       # epoch of the last link-return kick (debounce)
-        self._link_returned = False    # set by _sleep_interruptible on a carrier return while unbound
+        # Link-return fast path (only while UNBOUND): a carrier down->up edge
+        # resets the backoff and re-DORAs at once, like dhclient's link-up ->
+        # state_reboot. Its carrier state is grouped in _LinkState.
+        self._link = _LinkState()
 
         # Wake pipe for the maintain-loop sleep: _sleep_interruptible selects on
         # the read end, and _signal_wake() writes one byte to make it return at
@@ -202,13 +229,13 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
     # ---- heartbeat / status file ----
 
     def _write_hb(self, content):
-        if not self.hbfile:
+        if not self._cfg.hbfile:
             return
         try:
-            _atomic_write(self.hbfile, content)
+            _atomic_write(self._cfg.hbfile, content)
         except Exception as e:
             # The heartbeat drives CARP gating, so a write failure is worth surfacing.
-            LOG.warning("heartbeat write failed (%s): %s", self.hbfile, e)
+            LOG.warning("heartbeat write failed (%s): %s", self._cfg.hbfile, e)
 
     def _hb(self):
         t1, t2, src = self._dhcp.timing()
@@ -256,16 +283,16 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         episode -- otherwise a wrong --iface or a broken ifconfig looks identical
         to a healthy backup in the log."""
         try:
-            out = subprocess.check_output(["/sbin/ifconfig", self.iface], errors="replace")
+            out = subprocess.check_output(["/sbin/ifconfig", self._cfg.iface], errors="replace")
         except (OSError, subprocess.SubprocessError) as e:
-            if not self._ifconfig_failed:
+            if not self._link.ifconfig_failed:
                 LOG.warning("ifconfig %s probe failed (%s) -- CARP role and carrier "
-                            "state unknown until it recovers", self.iface, e)
-                self._ifconfig_failed = True
+                            "state unknown until it recovers", self._cfg.iface, e)
+                self._link.ifconfig_failed = True
             return None
-        if self._ifconfig_failed:
-            LOG.info("ifconfig %s probe recovered", self.iface)
-            self._ifconfig_failed = False
+        if self._link.ifconfig_failed:
+            LOG.info("ifconfig %s probe recovered", self._cfg.iface)
+            self._link.ifconfig_failed = False
         return out.decode(errors="replace") if isinstance(out, bytes) else out
 
     def _probe_carp_master(self) -> "bool | None":
@@ -273,12 +300,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         the probe itself fails; no vhid configured -> True (nothing to gate on).
         Callers apply their own policy on a None probe -- the ARP nudge fails closed
         (no nudge unless a confirmed MASTER); the CARP-transition poll just skips."""
-        if self._master_marker is None:   # no vhid configured -> nothing to gate on
+        if self._cfg.master_marker is None:   # no vhid configured -> nothing to gate on
             return True
         out = self._ifconfig()
         if out is None:
             return None
-        return self._master_marker in out
+        return self._cfg.master_marker in out
 
     def _carp_master_probe(self) -> "bool | None":
         """ArpNudge's is_master hook -> the CARP probe (late-bound through the
@@ -309,13 +336,13 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         up = self._iface_link_up()
         if up is None:
             return False
-        prev = self._link_up
-        self._link_up = up
+        prev = self._link.up
+        self._link.up = up
         if up and prev is False:
             now = time.time()
-            if now - self._link_kick_at < LINK_KICK_DEBOUNCE:
+            if now - self._link.kick_at < LINK_KICK_DEBOUNCE:
                 return False
-            self._link_kick_at = now
+            self._link.kick_at = now
             return True
         return False
 
@@ -327,7 +354,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         access node's DHCP-snooping binding, so neither should wait out its
         normal timer. Independent of the ARP nudge setting. `master` lets the
         maintain loop pass the role it already probed this tick."""
-        if not self.vhid:
+        if not self._cfg.vhid:
             return
         if master is _UNSET:
             master = self._probe_carp_master()
@@ -335,13 +362,13 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             return
         if master and self._was_master is False:
             LOG.info("became CARP master for vhid %s -- immediate ARP nudge and early lease renew",
-                     self.vhid)
+                     self._cfg.vhid)
             self._renew_asap = True
             self._arp_nudge(force=True, master=master)
         elif not master and self._was_master:
             # The symmetric event: without it, "why did the nudges stop?" needs
             # ifconfig instead of the log.
-            LOG.info("lost CARP master for vhid %s -- ARP nudges pause on this node", self.vhid)
+            LOG.info("lost CARP master for vhid %s -- ARP nudges pause on this node", self._cfg.vhid)
         self._was_master = master
 
     # ---- ARP nudge ----
@@ -440,7 +467,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             # seconds; a down->up edge means the WAN just came back, so stop waiting
             # and let _maintain_step re-DORA immediately (the bound path skips this).
             if self._dhcp.binding.yiaddr is None and slept % LINK_POLL_STEP == 0 and self._check_link_returned():
-                self._link_returned = True
+                self._link.returned = True
                 return not self._signals.stop
 
             # Event-driven sleep: return at once when the wake socket is written
@@ -492,9 +519,9 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             self._sleep(SNIFFER_RETRY)
 
         # eth-src matters for L2 debugging but only when it differs from the chaddr.
-        ethsrc = f" eth-src={self.eth_src}" if self.eth_src != self.chaddr else ""
+        ethsrc = f" eth-src={self._cfg.eth_src}" if self._cfg.eth_src != self._cfg.chaddr else ""
         LOG.info("lease-keeper %s active on %s: chaddr=%s%s request=%s",
-                 __version__, self.iface, self.chaddr, ethsrc, self._follow.target or "any")
+                 __version__, self._cfg.iface, self._cfg.chaddr, ethsrc, self._follow.target or "any")
         time.sleep(SNIFFER_WARMUP)
 
         while not self._signals.stop:
@@ -512,7 +539,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 self._sleep(LOOP_ERROR_BACKOFF)
 
         # shutdown
-        if self.release_on_exit:
+        if self._cfg.release_on_exit:
             self._dhcp.release()
         self._capture.stop()
         self._wake_r.close()
@@ -528,7 +555,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             return 3
         time.sleep(SNIFFER_WARMUP)
         ok = self._dhcp.dora(self._follow.target)
-        LOG.info("DHCP claim %s -> %s", self.chaddr, self._dhcp.binding.yiaddr if ok else "FAIL")
+        LOG.info("DHCP claim %s -> %s", self._cfg.chaddr, self._dhcp.binding.yiaddr if ok else "FAIL")
         if ok:
             self._dhcp.release()
         self._capture.stop()
@@ -591,9 +618,9 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         return. Returns True (and resets the re-DORA backoff) if the link-return
         fast path fired during the sleep, so the caller re-acquires at once
         instead of waiting out the backoff (matches native dhclient)."""
-        self._link_returned = False
+        self._link.returned = False
         self._sleep_interruptible(secs)
-        if self._link_returned:
+        if self._link.returned:
             LOG.info("WAN link returned while unbound -- re-acquiring now")
             self.redora_wait = REDORA_MIN
             return True
@@ -613,16 +640,16 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # only a confirmed "no carrier" (False) holds the acquire; an
         # unreadable probe (None) never blocks it.
         if self._iface_link_up() is False:
-            if self._link_up is not False:   # log once per down-episode
+            if self._link.up is not False:   # log once per down-episode
                 LOG.info("no carrier on %s -- waiting for the link before the DHCP acquire",
-                         self.iface)
-            self._link_up = False
+                         self._cfg.iface)
+            self._link.up = False
             self._wait_unbound(REDORA_MIN)
             return
 
         b = self._dhcp.binding
         if self._dhcp.acquire(self._follow.target):
-            self._link_up = True   # a completed DORA proves carrier
+            self._link.up = True   # a completed DORA proves carrier
             LOG.info("DHCP BOUND %s (lease=%ss, expires ~%s, server=%s, gw=%s, mask=%s)",
                      b.yiaddr, b.lease_secs, _clock_at(b.lease_secs),
                      b.server, b.router or "?",

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -452,6 +452,22 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         b = self._dhcp.binding
         self._defroute.reconcile(master, b.yiaddr is not None, b.lease_router)
 
+    @staticmethod
+    def fail_stop_withdraw_default(default_route_mode, vhid):
+        """Withdraw a default a crashed predecessor may have left in the FIB, as a
+        non-master (we hold no lease at startup). This is pure route(8) with no
+        capture backend, so main() runs it BEFORE the backend preflight and the arg
+        checks -- each of which can return early, and Keeper.run() (which would
+        otherwise do this) then never executes, leaving a stale 0/0 installed and
+        redistributed while the supervisor keeps restarting. No-op unless a vhid is
+        configured and the mode is observe/enforce (the same gate, and the same
+        non-master withdraw, as _reconcile_default_route)."""
+        if not vhid:
+            return
+        reconciler = DefaultRouteReconciler(default_route_mode)
+        if reconciler.enabled:
+            reconciler.reconcile(is_master=False, bound=False, gateway=None)
+
     # ---- ARP nudge ----
 
     def _nudge_target(self):
@@ -595,12 +611,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
 
     def run(self):
         """The daemon main loop: capture up, then maintain the lease until
-        stopped. Never raises; returns the process exit code."""
-        # Fail-stop on startup, before the capture-retry loop below can block: a
-        # predecessor that crashed (no graceful withdraw) may have left a default
-        # in the FIB. We hold no lease yet, so reconcile as non-master to withdraw
-        # any such stale default even if capture never (re)opens.
-        self._reconcile_default_route(master=False)
+        stopped. Never raises; returns the process exit code.
+
+        The startup fail-stop withdraw (a crashed predecessor's stale default) runs
+        in main() via Keeper.fail_stop_withdraw_default BEFORE the backend preflight,
+        so it happens even when a backend/arg early-exit means run() is never
+        reached; the shutdown withdraw below is the graceful counterpart."""
         # Start the packet capture, retrying forever: a keeper must self-heal, not
         # die, if the interface is briefly unavailable at startup.
         while not self._signals.stopping and not self._capture.start():

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -465,41 +465,22 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         return master
 
     def _on_lease_extended(self, phase):
-        """A RENEW or REBIND (the Phase) landed a fresh lease: refresh the
-        heartbeat, then off one shared CARP probe reconcile the default route (a
-        renewed lease can carry a new option-3 gateway, so track it at once instead
-        of at the next tick) and force an ARP nudge."""
+        """A RENEW or REBIND (the Phase) landed a fresh lease: refresh the heartbeat
+        and force an ARP nudge. The default route is reconciled by the loop-head
+        reconcile on the next _maintain_step entry (a renewed lease can carry a new
+        option-3 gateway), so it is not repeated here."""
         b = self._dhcp.binding
         LOG.info("DHCP %s ok %s (lease=%ss, expires ~%s)", phase, b.yiaddr, b.lease_secs,
                  _clock_at(b.lease_secs))
         self._hb()
-        master = self._probe_carp_master()
-        self._reconcile_default_route(master)
-        self._arp_nudge(force=True, master=master)
+        self._arp_nudge(force=True)
 
     def _on_lease_revoked(self, phase):
         """A RENEW or REBIND (the Phase) drew a DHCPNAK: renew() has already
         forgotten the binding (RFC 2131 4.4.5 -> INIT, not keep REBINDing a refused
-        address), so withdraw any default we owned at once; the next step
-        re-acquires."""
+        address), so the next _maintain_step entry is unbound and its loop-head
+        reconcile withdraws any default we owned; just log the revoke here."""
         LOG.warning("DHCP %s got NAK -- lease revoked, re-acquiring", phase)
-        self._reconcile_default_route()
-
-    @staticmethod
-    def fail_stop_withdraw_default(default_route_mode, vhid):
-        """Withdraw a default a crashed predecessor may have left in the FIB, as a
-        non-master (we hold no lease at startup). This is pure route(8) with no
-        capture backend, so main() runs it BEFORE the backend preflight and the arg
-        checks -- each of which can return early, and Keeper.run() (which would
-        otherwise do this) then never executes, leaving a stale 0/0 installed and
-        redistributed while the supervisor keeps restarting. No-op unless a vhid is
-        configured and the mode is observe/enforce (the same gate, and the same
-        non-master withdraw, as _reconcile_default_route)."""
-        if not vhid:
-            return
-        reconciler = DefaultRouteReconciler(default_route_mode)
-        if reconciler.enabled:
-            reconciler.reconcile(is_master=False, bound=False, gateway=None)
 
     # ---- ARP nudge ----
 
@@ -643,9 +624,10 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         stopped. Never raises; returns the process exit code.
 
         The startup fail-stop withdraw (a crashed predecessor's stale default) runs
-        in main() via Keeper.fail_stop_withdraw_default BEFORE the backend preflight,
-        so it happens even when a backend/arg early-exit means run() is never
-        reached; the shutdown withdraw below is the graceful counterpart."""
+        in main() via DefaultRouteReconciler.withdraw_if_enabled (gated on a vhid)
+        BEFORE the backend preflight, so it happens even when a backend/arg
+        early-exit means run() is never reached; the shutdown withdraw below is the
+        graceful counterpart."""
         # Start the packet capture, retrying forever: a keeper must self-heal, not
         # die, if the interface is briefly unavailable at startup.
         while not self._signals.stopping and not self._capture.start():
@@ -705,8 +687,18 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         retried, so a transient fault can never terminate the keeper."""
         b = self._dhcp.binding
         if not b.yiaddr:
+            # Unbound: withdraw any default we still own (the role is irrelevant when
+            # unbound -- every value withdraws -- so master=False, no ifconfig), then
+            # try to (re)acquire.
+            self._reconcile_default_route(master=False)
             self._acquire_step()
             return
+        # Bound: own the default by CARP role, here at the loop head. _maintain_step
+        # is re-entered after every transition (a just-acquired lease, a renew that
+        # changed the gateway, a NAK, an expiry), so this single reconcile tracks
+        # them all; only the long blocking waits below (which do not return to the
+        # loop head) add their own periodic reconcile.
+        self._reconcile_default_route()
 
         # Maintain: wait until T1, then RENEW; bail early on stop.
         t1, t2, src = self._dhcp.timing()
@@ -754,7 +746,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             self._on_lease_extended(Phase.REBIND)
             return
 
-        LOG.error("DHCP lease expired -- re-acquiring (back to DISCOVER)")
+        LOG.error("DHCP lease expired -- re-acquiring (back to %s)", Phase.DORA)
         self._dhcp.expire()
 
     def _wait_unbound(self, secs):
@@ -776,10 +768,8 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         the link-return fast path cuts either wait short."""
         self._ensure_sniffer()  # a dead sniffer would silently fail every DORA
         self._hb()  # active but not holding yet -> publish bound=-
-        # Unbound: a former master that lost its lease must withdraw its default
-        # (want is False while yiaddr is None). The role is irrelevant when unbound
-        # -- every value withdraws -- so pass master=False and skip the ifconfig.
-        self._reconcile_default_route(master=False)
+        # (The default-route withdraw for the unbound state is the loop-head
+        # reconcile in _maintain_step, before this arm runs.)
 
         # No point broadcasting DISCOVERs on a dead link (native dhclient
         # does not either): wait for the carrier instead of burning DORA
@@ -803,15 +793,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                      b.server, b.router or "?",
                      f"/{b.mask_bits}" if b.mask_bits else "none")
             self._hb()
+            self._arp_nudge(force=True)
             self.redora_wait = REDORA_MIN
-            # Own the default now the lease is in hand: the pre-acquire reconcile
-            # saw bound=False, and _hold_lease's first tick is a full HB_REFRESH
-            # away -- without this a freshly-acquired master would sit with no
-            # default for up to that interval (fail-stop, but a needless gap). One
-            # shared CARP probe feeds both the nudge and the reconcile.
-            master = self._probe_carp_master()
-            self._arp_nudge(force=True, master=master)
-            self._reconcile_default_route(master)
+            # Owning the default is the loop-head reconcile on the next _maintain_step
+            # entry (now bound): _acquire_step returns straight to run(), which
+            # re-enters at once, so the install is immediate without a call here.
         else:
             LOG.warning("DHCP acquire (DISCOVER/REQUEST) failed -- retrying in %ds", self.redora_wait)
             if not self._wait_unbound(_jittered(self.redora_wait)):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -8,6 +8,7 @@ import select
 import socket
 import subprocess
 import time
+from dataclasses import dataclass
 
 from . import __version__
 from .capture import CAPTURE_BACKENDS
@@ -38,6 +39,27 @@ IFCONFIG_STATUS = "status: "                 # any status line present (up or do
 # once per tick and shares it, but None is a valid probe result, so a distinct
 # sentinel means "probe it now".
 _UNSET = object()
+
+
+@dataclass
+class _SignalFlags:
+    """The only shared state a signal handler may write.
+
+    A signal handler (request_stop / trigger_nudge / recheck_carp_role) runs on
+    the MAIN thread, between bytecodes; the single safe thing it may do is flip
+    one of these booleans to True. They are plain booleans on purpose: a set is
+    one bytecode, hence atomic w.r.t. signal delivery (never torn); they are
+    independent of one another (no flag has to be consistent with another); and
+    the maintain loop drains each with check-and-clear + idempotent handling --
+    which is what makes this correct WITHOUT a lock. Do NOT let a handler do
+    more: no I/O, and no mutation of the binding / lease / role or any other
+    shared state -- that reintroduces re-entrancy and consistency bugs. Add a
+    new signal-driven request the same way: a new field here, set by the
+    handler, drained by the loop; never by doing work in the handler.
+    """
+    stop: bool = False           # SIGINT / SIGTERM -> request_stop()
+    nudge: bool = False          # SIGUSR1          -> trigger_nudge()
+    recheck_role: bool = False   # SIGUSR2 (CARP)   -> recheck_carp_role()
 
 
 class Keeper:  # pylint: disable=too-many-instance-attributes
@@ -76,8 +98,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._nudge = ArpNudge(self._capture, self.chaddr, arp_nudge, self._carp_master_probe)
 
         self._was_master = None        # CARP role at the last nudge check (None = unknown yet)
-        self._nudge_now = False        # operator asked for an immediate nudge (SIGUSR1)
-        self._poll_role_now = False    # a CARP transition fired -> re-check role now (SIGUSR2)
+
+        # The only shared state a signal handler may write (invariant on the type).
+        self._signals = _SignalFlags()
+
+        # Main-loop-only state (set by the loop itself, never by a handler):
         self._renew_asap = False       # renew at the next _hold_lease tick instead of waiting for T1
 
         # DHCP client component: owns the lease state and the protocol sequences;
@@ -86,7 +111,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._dhcp = DhcpClient(
             self._capture, self.chaddr, self.eth_src,
             _identity_options(vendor_class, client_id, hostname),
-            should_stop=lambda: self._stop,
+            should_stop=lambda: self._signals.stop,
             ensure_sniffer=self._ensure_sniffer,
             on_changed_address=self._on_changed_address)
 
@@ -104,7 +129,6 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._link_kick_at = 0.0       # epoch of the last link-return kick (debounce)
         self._link_returned = False    # set by _sleep_interruptible on a carrier return while unbound
 
-        self._stop = False
         # Wake pipe for the maintain-loop sleep: _sleep_interruptible selects on
         # the read end, and _signal_wake() writes one byte to make it return at
         # once instead of waiting out the 1s tick. Woken from two places: the
@@ -339,10 +363,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         else:
             self._nudge.maybe_nudge(yiaddr, gateway, force=force, master=master)
 
-    # ---- operator/signal API (signal handlers set a flag only; the loop wakes
-    # via the wake socket -- from the capture thread through _signal_wake, and
-    # from signal delivery through signal.set_wakeup_fd(wake_fileno) wired in
-    # main(), which is async-signal-safe C-level machinery) ----
+    # ---- operator/signal API (signal handlers set a flag only -- see the
+    # _SignalFlags invariant for why that rule is load-bearing; the
+    # loop wakes via the wake socket -- from the capture thread through
+    # _signal_wake, and from signal delivery through signal.set_wakeup_fd(
+    # wake_fileno) wired in main(), which is async-signal-safe C-level machinery) ----
 
     def wake_fileno(self):
         """The wake socket's write-end fd, for signal.set_wakeup_fd() so any
@@ -364,23 +389,23 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
     def request_stop(self):
         """Ask the daemon to exit (SIGINT/SIGTERM). Flag only; set_wakeup_fd
         wakes the loop so it exits at once."""
-        self._stop = True
+        self._signals.stop = True
 
     def trigger_nudge(self):
         """Request an immediate ARP nudge (SIGUSR1 / configd action). Flag only;
         no network I/O in signal context."""
-        self._nudge_now = True
+        self._signals.nudge = True
 
     def recheck_carp_role(self):
         """Re-check the CARP role now (SIGUSR2 from the CARP syshook) instead of
         waiting for the next ~30s poll. Flag only."""
-        self._poll_role_now = True
+        self._signals.recheck_role = True
 
     # ---- main loop / sleeps ----
 
     def _sleep(self, secs):
         slept = 0
-        while slept < secs and not self._stop:
+        while slept < secs and not self._signals.stop:
             time.sleep(1)
             slept += 1
         return slept
@@ -390,16 +415,16 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         operator-requested immediate nudge (SIGUSR1) and a CARP-transition re-check
         (SIGUSR2) so both act within a second instead of at the next heartbeat tick."""
         slept = 0
-        while slept < secs and not self._stop:
-            if self._poll_role_now:
-                self._poll_role_now = False
+        while slept < secs and not self._signals.stop:
+            if self._signals.recheck_role:
+                self._signals.recheck_role = False
                 # A CARP transition just fired (kernel -> devd -> rc.syshook.d/carp
                 # -> SIGUSR2); re-check the role now so a backup->master keeper
                 # nudges + renews immediately instead of at the next ~30s poll.
                 self._poll_carp_role()
 
-            if self._nudge_now:
-                self._nudge_now = False
+            if self._signals.nudge:
+                self._signals.nudge = False
                 # Operator actions are rare and intentional -- always log them,
                 # unlike the periodic nudges (whose freshness the status page
                 # already shows without flooding the log every interval).
@@ -416,7 +441,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             # and let _maintain_step re-DORA immediately (the bound path skips this).
             if self._dhcp.binding.yiaddr is None and slept % LINK_POLL_STEP == 0 and self._check_link_returned():
                 self._link_returned = True
-                return not self._stop
+                return not self._signals.stop
 
             # Event-driven sleep: return at once when the wake socket is written
             # (a fresh observation or an operator signal), otherwise time out
@@ -428,7 +453,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 except (BlockingIOError, OSError):
                     pass
             slept += 1
-        return not self._stop
+        return not self._signals.stop
 
     def _hold_lease(self, secs):
         """Sleep up to secs while holding a lease, rewriting the heartbeat every
@@ -436,12 +461,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         the CARP demotion hook only sees heartbeat freshness). Returns False early
         on stop."""
         remaining = secs
-        while remaining > 0 and not self._stop:
+        while remaining > 0 and not self._signals.stop:
             if self._renew_asap:
                 # Return as if T1 elapsed: the caller renews right away, which
                 # re-teaches upstream DHCP-snooping state after a master change.
                 self._renew_asap = False
-                return not self._stop
+                return not self._signals.stop
 
             chunk = min(HB_REFRESH, remaining)
             if not self._sleep_interruptible(chunk):
@@ -455,14 +480,14 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             master = self._probe_carp_master()
             self._poll_carp_role(master)   # backup->master? renew early + nudge now
             self._arp_nudge(master=master)
-        return not self._stop
+        return not self._signals.stop
 
     def run(self):
         """The daemon main loop: capture up, then maintain the lease until
         stopped. Never raises; returns the process exit code."""
         # Start the packet capture, retrying forever: a keeper must self-heal, not
         # die, if the interface is briefly unavailable at startup.
-        while not self._stop and not self._capture.start():
+        while not self._signals.stop and not self._capture.start():
             LOG.warning("capture start failed -- retrying in %ds", SNIFFER_RETRY)
             self._sleep(SNIFFER_RETRY)
 
@@ -472,7 +497,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                  __version__, self.iface, self.chaddr, ethsrc, self._follow.target or "any")
         time.sleep(SNIFFER_WARMUP)
 
-        while not self._stop:
+        while not self._signals.stop:
             # The keeper must NEVER die on a bad DHCP state: catch any unexpected
             # error, keep the heartbeat fresh so CARP does not falsely demote us,
             # and retry after a short backoff.
@@ -538,7 +563,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
 
         elapsed = t1
         ok = False
-        while elapsed < t2 and not self._stop:
+        while elapsed < t2 and not self._signals.stop:
             # Jitter the REBIND retransmit cadence: both nodes hit T2 together
             # (identical lease timers), so an un-jittered step would broadcast
             # REBIND in lockstep. Overshooting t2 slightly is harmless (the guard

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -15,8 +15,8 @@ from .capture import CAPTURE_BACKENDS
 from .constants import (
     LOGGER_NAME,
     ACK, BootpOp, DhcpOptName, HB_REFRESH, LINK_KICK_DEBOUNCE, LINK_POLL_STEP,
-    LOOP_ERROR_BACKOFF, REBIND_POLL_STEP, REDORA_MAX, REDORA_MIN, SNIFFER_RETRY,
-    SNIFFER_WARMUP)
+    LOOP_ERROR_BACKOFF, Phase, REBIND_POLL_STEP, REDORA_MAX, REDORA_MIN,
+    SNIFFER_RETRY, SNIFFER_WARMUP)
 from .dhcpclient import DhcpClient
 from .policy import ArpNudge, FollowPolicy
 from .route import DefaultRouteReconciler
@@ -452,6 +452,39 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         b = self._dhcp.binding
         self._defroute.reconcile(master, b.yiaddr is not None, b.lease_router)
 
+    def _role_tick(self, master=_UNSET):
+        """One shared CARP-role probe driving both the role poll and the
+        default-route reconcile, so a heartbeat tick, the SIGUSR2 edge and the
+        REBIND loop never spawn two ifconfigs or let the poll and the reconcile
+        drift apart. Returns the probed role for any further per-tick use (the ARP
+        nudge). Pass an already-probed role to skip the ifconfig."""
+        if master is _UNSET:
+            master = self._probe_carp_master()
+        self._poll_carp_role(master)
+        self._reconcile_default_route(master)
+        return master
+
+    def _on_lease_extended(self, phase):
+        """A RENEW or REBIND (the Phase) landed a fresh lease: refresh the
+        heartbeat, then off one shared CARP probe reconcile the default route (a
+        renewed lease can carry a new option-3 gateway, so track it at once instead
+        of at the next tick) and force an ARP nudge."""
+        b = self._dhcp.binding
+        LOG.info("DHCP %s ok %s (lease=%ss, expires ~%s)", phase, b.yiaddr, b.lease_secs,
+                 _clock_at(b.lease_secs))
+        self._hb()
+        master = self._probe_carp_master()
+        self._reconcile_default_route(master)
+        self._arp_nudge(force=True, master=master)
+
+    def _on_lease_revoked(self, phase):
+        """A RENEW or REBIND (the Phase) drew a DHCPNAK: renew() has already
+        forgotten the binding (RFC 2131 4.4.5 -> INIT, not keep REBINDing a refused
+        address), so withdraw any default we owned at once; the next step
+        re-acquires."""
+        LOG.warning("DHCP %s got NAK -- lease revoked, re-acquiring", phase)
+        self._reconcile_default_route()
+
     @staticmethod
     def fail_stop_withdraw_default(default_route_mode, vhid):
         """Withdraw a default a crashed predecessor may have left in the FIB, as a
@@ -546,9 +579,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 # nudges + renews immediately instead of at the next ~30s poll, and
                 # re-own the default route on the same edge (a failover flips which
                 # node installs 0/0). One shared CARP probe feeds both, as the tick does.
-                master = self._probe_carp_master()
-                self._poll_carp_role(master)
-                self._reconcile_default_route(master)
+                self._role_tick()
 
             if self._signals.take_nudge():
                 # Operator actions are rare and intentional -- always log them,
@@ -601,11 +632,9 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
 
             self._hb()
             self._follow.watchdog()   # re-drive a follow whose apply stalled
-            # One CARP-role probe per tick, shared by the role poll and the
-            # nudge below (both would otherwise spawn their own ifconfig).
-            master = self._probe_carp_master()
-            self._poll_carp_role(master)   # backup->master? renew early + nudge now
-            self._reconcile_default_route(master)   # keep the default route in step with role+lease
+            # One CARP-role probe per tick, shared by the role poll, the route
+            # reconcile (both via _role_tick) and the nudge below.
+            master = self._role_tick()
             self._arp_nudge(master=master)
         return not self._signals.stopping
 
@@ -690,24 +719,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         if not self._hold_lease(t1):
             return
         if self._dhcp.renew():
-            LOG.info("DHCP RENEW ok %s (lease=%ss, expires ~%s)",
-                     b.yiaddr, b.lease_secs, _clock_at(b.lease_secs))
-            self._hb()
-            # A renewed lease can carry a new option-3 gateway; reconcile now (one
-            # shared CARP probe, as _hold_lease does) so the FIB tracks it at once
-            # instead of only at the next per-tick poll.
-            master = self._probe_carp_master()
-            self._reconcile_default_route(master)
-            self._arp_nudge(force=True, master=master)
+            self._on_lease_extended(Phase.RENEW)
             return
-        if not b.yiaddr:
-            # renew() got a DHCPNAK and forgot the binding (lease revoked): withdraw
-            # any default we owned at once and drop to the unbound arm to re-acquire,
-            # rather than REBINDing an address the server just refused.
-            LOG.warning("DHCP RENEW got NAK -- lease revoked, re-acquiring")
-            self._reconcile_default_route()
+        if not b.yiaddr:            # renew() drew a NAK and forgot the binding
+            self._on_lease_revoked(Phase.RENEW)
             return
-        LOG.warning("DHCP RENEW failed at T1 -- trying REBIND until T2")
+        LOG.warning("DHCP %s failed at T1 -- trying %s until T2", Phase.RENEW, Phase.REBIND)
 
         elapsed = t1
         ok = False
@@ -726,27 +743,15 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             # _hold_lease does per tick. Otherwise a failover during this degraded
             # path relies solely on the SIGUSR2 edge, with no periodic fallback
             # for a missed one until REBIND exits.
-            master = self._probe_carp_master()
-            self._poll_carp_role(master)
-            self._reconcile_default_route(master)
+            self._role_tick()
             if self._dhcp.renew(rebind=True):
                 ok = True
                 break
-            if not b.yiaddr:
-                # A NAK during REBIND likewise revoked the lease: withdraw and
-                # re-acquire instead of spinning REBIND until T2 with the default up.
-                LOG.warning("DHCP REBIND got NAK -- lease revoked, re-acquiring")
-                self._reconcile_default_route()
+            if not b.yiaddr:            # a NAK during REBIND likewise revoked the lease
+                self._on_lease_revoked(Phase.REBIND)
                 return
         if ok:
-            LOG.info("DHCP REBIND ok %s (lease=%ss, expires ~%s)",
-                     b.yiaddr, b.lease_secs, _clock_at(b.lease_secs))
-            self._hb()
-            # As with RENEW above: a rebound lease can carry a new gateway, so
-            # reconcile immediately rather than waiting for the next poll.
-            master = self._probe_carp_master()
-            self._reconcile_default_route(master)
-            self._arp_nudge(force=True, master=master)
+            self._on_lease_extended(Phase.REBIND)
             return
 
         LOG.error("DHCP lease expired -- re-acquiring (back to DISCOVER)")
@@ -772,8 +777,9 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._ensure_sniffer()  # a dead sniffer would silently fail every DORA
         self._hb()  # active but not holding yet -> publish bound=-
         # Unbound: a former master that lost its lease must withdraw its default
-        # (want is False while yiaddr is None); the bound-path tick never runs here.
-        self._reconcile_default_route()
+        # (want is False while yiaddr is None). The role is irrelevant when unbound
+        # -- every value withdraws -- so pass master=False and skip the ifconfig.
+        self._reconcile_default_route(master=False)
 
         # No point broadcasting DISCOVERs on a dead link (native dhclient
         # does not either): wait for the carrier instead of burning DORA
@@ -797,13 +803,15 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                      b.server, b.router or "?",
                      f"/{b.mask_bits}" if b.mask_bits else "none")
             self._hb()
-            self._arp_nudge(force=True)
             self.redora_wait = REDORA_MIN
             # Own the default now the lease is in hand: the pre-acquire reconcile
             # saw bound=False, and _hold_lease's first tick is a full HB_REFRESH
             # away -- without this a freshly-acquired master would sit with no
-            # default for up to that interval (fail-stop, but a needless gap).
-            self._reconcile_default_route()
+            # default for up to that interval (fail-stop, but a needless gap). One
+            # shared CARP probe feeds both the nudge and the reconcile.
+            master = self._probe_carp_master()
+            self._arp_nudge(force=True, master=master)
+            self._reconcile_default_route(master)
         else:
             LOG.warning("DHCP acquire (DISCOVER/REQUEST) failed -- retrying in %ds", self.redora_wait)
             if not self._wait_unbound(_jittered(self.redora_wait)):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -672,7 +672,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             LOG.info("DHCP RENEW ok %s (lease=%ss, expires ~%s)",
                      b.yiaddr, b.lease_secs, _clock_at(b.lease_secs))
             self._hb()
-            self._arp_nudge(force=True)
+            # A renewed lease can carry a new option-3 gateway; reconcile now (one
+            # shared CARP probe, as _hold_lease does) so the FIB tracks it at once
+            # instead of only at the next per-tick poll.
+            master = self._probe_carp_master()
+            self._reconcile_default_route(master)
+            self._arp_nudge(force=True, master=master)
             return
         LOG.warning("DHCP RENEW failed at T1 -- trying REBIND until T2")
 
@@ -703,7 +708,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             LOG.info("DHCP REBIND ok %s (lease=%ss, expires ~%s)",
                      b.yiaddr, b.lease_secs, _clock_at(b.lease_secs))
             self._hb()
-            self._arp_nudge(force=True)
+            # As with RENEW above: a rebound lease can carry a new gateway, so
+            # reconcile immediately rather than waiting for the next poll.
+            master = self._probe_carp_master()
+            self._reconcile_default_route(master)
+            self._arp_nudge(force=True, master=master)
             return
 
         LOG.error("DHCP lease expired -- re-acquiring (back to DISCOVER)")

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -19,6 +19,7 @@ from .constants import (
     SNIFFER_WARMUP)
 from .dhcpclient import DhcpClient
 from .policy import ArpNudge, FollowPolicy
+from .route import DefaultRouteReconciler
 from .util import _atomic_write, _clock_at, _jittered, _sane_ipv4
 from .wire import _parse_reply
 
@@ -76,6 +77,7 @@ class _Config:
 
     @property
     def master_marker(self):
+        """The ifconfig CARP-master line to grep for this vhid (None if unset)."""
         return CARP_MASTER_FMT.format(vhid=self.vhid) if self.vhid else None
 
 
@@ -100,10 +102,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
     operator actions. The lease lives in DhcpClient; the changed-address
     decision and the target address live in FollowPolicy."""
 
-    def __init__(self, iface, chaddr, request_ip=None, eth_src=None, *,  # pylint: disable=too-many-arguments
+    def __init__(self, iface, chaddr, request_ip=None,  # pylint: disable=too-many-arguments,too-many-locals
+                 eth_src=None, *,
                  hbfile=None, release_on_exit=False, vhid=None,
                  follow=False, vendor_class=None, client_id=None, hostname=None,
-                 arp_nudge=0, arp_listen_promisc=False, capture_backend="scapy"):
+                 arp_nudge=0, arp_listen_promisc=False, capture_backend="scapy",
+                 default_route_mode="off"):
         # Fixed identity/config, immutable once set (see _Config).
         self._cfg = _Config(
             iface=iface,
@@ -149,6 +153,16 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._follow = FollowPolicy(request_ip, follow, self._cfg.chaddr, self._dhcp,
                                     self._hb_mismatch,
                                     dispatch=self._dispatch_follow_update)
+
+        # Default-route ownership component (opt-in via defaultRouteMode): owns
+        # the IPv4 default route as a function of (CARP role, lease-held, lease
+        # gateway) -- off/observe/enforce, where off and observe never touch the
+        # FIB. Driven from the main loop only, on the CARP-role cadence
+        # (_reconcile_default_route). liveness_probe is left unset for now: the
+        # split-brain install-gate is a deliberate follow-up that needs a
+        # debounced carrier signal (a single transient ifconfig miss must not
+        # flap the default); see docs/default-route-carp-ownership.md.
+        self._defroute = DefaultRouteReconciler(default_route_mode)
 
         self.redora_wait = REDORA_MIN
         # Link-return fast path (only while UNBOUND): a carrier down->up edge
@@ -371,6 +385,25 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             LOG.info("lost CARP master for vhid %s -- ARP nudges pause on this node", self._cfg.vhid)
         self._was_master = master
 
+    def _reconcile_default_route(self, master=_UNSET):
+        """Drive the IPv4 default route toward its CARP-role-owned desired state
+        (install 0/0 via the lease gateway only while master AND holding a lease;
+        withdraw it otherwise -- see leasekeeper/route.py). Level-triggered and
+        idempotent, so it rides the CARP-role cadence -- the per-tick heartbeat
+        probe (bound) and the acquire loop (unbound), plus the SIGUSR2 CARP edge
+        -- and converges without having to catch every transition. No-op unless a
+        vhid is configured (no CARP role to key on) and the mode is
+        observe/enforce. `master` reuses the tick's probe when the caller has it.
+
+        Passes bound=yiaddr-is-set and gateway=binding.router; reconcile() owns
+        the contract for why bound must not be inferred from the sticky gateway."""
+        if not self._cfg.vhid or not self._defroute.enabled:
+            return
+        if master is _UNSET:
+            master = self._probe_carp_master()
+        b = self._dhcp.binding
+        self._defroute.reconcile(master, b.yiaddr is not None, b.router)
+
     # ---- ARP nudge ----
 
     def _nudge_target(self):
@@ -447,8 +480,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 self._signals.recheck_role = False
                 # A CARP transition just fired (kernel -> devd -> rc.syshook.d/carp
                 # -> SIGUSR2); re-check the role now so a backup->master keeper
-                # nudges + renews immediately instead of at the next ~30s poll.
-                self._poll_carp_role()
+                # nudges + renews immediately instead of at the next ~30s poll, and
+                # re-own the default route on the same edge (a failover flips which
+                # node installs 0/0). One shared CARP probe feeds both, as the tick does.
+                master = self._probe_carp_master()
+                self._poll_carp_role(master)
+                self._reconcile_default_route(master)
 
             if self._signals.nudge:
                 self._signals.nudge = False
@@ -506,6 +543,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             # nudge below (both would otherwise spawn their own ifconfig).
             master = self._probe_carp_master()
             self._poll_carp_role(master)   # backup->master? renew early + nudge now
+            self._reconcile_default_route(master)   # keep the default route in step with role+lease
             self._arp_nudge(master=master)
         return not self._signals.stop
 
@@ -632,6 +670,9 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         the link-return fast path cuts either wait short."""
         self._ensure_sniffer()  # a dead sniffer would silently fail every DORA
         self._hb()  # active but not holding yet -> publish bound=-
+        # Unbound: a former master that lost its lease must withdraw its default
+        # (want is False while yiaddr is None); the bound-path tick never runs here.
+        self._reconcile_default_route()
 
         # No point broadcasting DISCOVERs on a dead link (native dhclient
         # does not either): wait for the carrier instead of burning DORA

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -5,7 +5,7 @@ role and whether it currently holds a DHCP lease: only the CARP-master node that
 actually holds a lease keeps a default in the FIB; every other state has none. A
 node with no default advertises none (via os-frr redistribute kernel), so the
 failure mode is a withdrawn default, never a black-holed one. See
-docs/default-route-carp-ownership.md.
+docs/single-ip-wan-carp.md.
 
 Concurrency: reconcile() must be called only from the keeper's main loop thread;
 the caller is Keeper._reconcile_default_route (the per-tick poll, the unbound
@@ -23,6 +23,7 @@ import subprocess
 from enum import StrEnum
 
 from .constants import LOGGER_NAME
+from .util import _sane_ipv4
 
 LOG = logging.getLogger(LOGGER_NAME)
 
@@ -33,10 +34,9 @@ LOG = logging.getLogger(LOGGER_NAME)
 
 class DefaultRouteMode(StrEnum):
     """Per-keeper default-route mode (the values the model's defaultRouteMode
-    field will carry). StrEnum (like constants.Phase) so a member both is its
-    config string and compares by value -- the value flows in from the model
-    verbatim. off:
-    inert (default). observe: log what it would do, no FIB write. enforce:
+    field carries). StrEnum (like constants.Phase) so a member both is its config
+    string and compares by value -- the value flows in from the model verbatim.
+    off: inert (default). observe: log what it would do, no FIB write. enforce:
     actually install/withdraw."""
     OFF = "off"
     OBSERVE = "observe"
@@ -53,8 +53,8 @@ class RouteCommand(StrEnum):
     GET = "get"
 
 
-# The IPv4 default. IPv6 is out of scope (docs section 12): no v6 BGP fw<->pve,
-# so no v6 default leak to gate.
+# The IPv4 default. IPv6 is out of scope: no v6 BGP fw<->pve, so no v6 default
+# leak to gate.
 _DEFAULT = "default"
 
 # Consecutive unreadable CARP-role probes tolerated while we still hold a
@@ -84,26 +84,35 @@ class DefaultRouteReconciler:
     def __init__(self, mode: "str | DefaultRouteMode" = DefaultRouteMode.OFF, *,
                  unreadable_role_strikes=DEFAULT_UNREADABLE_ROLE_STRIKES,
                  liveness_probe=None):
-        # mode flows in from the model verbatim (keeper.conf -> rc.d -> argparse) as
-        # a plain string; coerce it, and treat any unrecognised value as inert OFF.
+        # mode flows in from the model verbatim (keeper.conf -> rc.d -> argparse)
+        # as a plain string; coerce it, and treat any unrecognised value as inert
+        # OFF. Set-once: exposed read-only via the `mode` property.
         try:
-            self.mode = DefaultRouteMode(mode)
+            self._mode = DefaultRouteMode(mode)
         except ValueError:
             LOG.warning("unknown default-route mode %r -- treating as off", mode)
-            self.mode = DefaultRouteMode.OFF  # never guess an active mode
+            self._mode = DefaultRouteMode.OFF  # never guess an active mode
+        if unreadable_role_strikes < 1:
+            raise ValueError("unreadable_role_strikes must be >= 1")
         self._strike_limit = unreadable_role_strikes
-        # liveness_probe: optional callable() -> bool|None gating the INSTALL
-        # side (the split-brain guard). None (no callable) or a None result means
-        # "no opinion" and never blocks; only an explicit False blocks. It must
-        # be debounced by the caller -- a single transient miss must not read
-        # False, or a healthy master would flap its default. See docs section 2.
+        # liveness_probe: optional callable() -> bool|None gating the INSTALL side
+        # (the split-brain guard). None (no callable) or a None result means "no
+        # opinion" and never blocks; only an explicit False blocks. It must be
+        # debounced by the caller -- a single transient miss must not read False,
+        # or a healthy master would flap its default (see the README).
         self._liveness_probe = liveness_probe
         self._strikes = 0
+        self._unreadable_warned = False   # rising-edge gate for the fail-closed warning
+
+    @property
+    def mode(self):
+        """The active mode, set once at construction (coerced/validated)."""
+        return self._mode
 
     @property
     def enabled(self):
         """True in observe/enforce (off is inert); see DefaultRouteMode."""
-        return self.mode in (DefaultRouteMode.OBSERVE, DefaultRouteMode.ENFORCE)
+        return self._mode in (DefaultRouteMode.OBSERVE, DefaultRouteMode.ENFORCE)
 
     def reconcile(self, is_master, bound, gateway):
         """Drive the FIB default toward the desired state for the current
@@ -125,8 +134,14 @@ class DefaultRouteReconciler:
             self._on_unknown_role()
             return
         self._strikes = 0
+        self._unreadable_warned = False   # role readable again -> re-arm the warning
 
-        want = is_master and bound and gateway is not None
+        # A sane, non-zero unicast gateway is required to install (rejects a
+        # 0.0.0.0 / malformed option-3 from a rogue or broken DHCP server); an
+        # unusable gateway falls through to the withdraw arm rather than
+        # installing a default that leads nowhere.
+        want = is_master and bound and _sane_ipv4(gateway)
+
         if want and self._liveness_blocks():
             # Master with a lease but liveness is explicitly not confirmed
             # (possible split-brain / dead WAN with a stale lease): do not keep a
@@ -149,15 +164,19 @@ class DefaultRouteReconciler:
         """An unreadable (is_master is None) probe: do not install when unsure,
         but after a bounded number of consecutive unknown probes, withdraw any
         default we still hold so a former master stops advertising once its role
-        can no longer be confirmed."""
+        can no longer be confirmed. The warning fires once per unreadable episode
+        (re-armed when the role reads definite again), not every tick."""
         self._strikes += 1
         if self._strikes < self._strike_limit:
             return
         have = self._fib_default_gateway()
-        if have is not None:
-            LOG.warning("CARP role unreadable for %d checks -- withdrawing default "
+        if have is None:
+            return
+        if not self._unreadable_warned:
+            LOG.warning("CARP role unreadable for %d checks -- dropping the default "
                         "(fail-closed)", self._strikes)
-            self._withdraw(have)
+            self._unreadable_warned = True
+        self._withdraw(have)
 
     def _liveness_blocks(self):
         """True only when the liveness probe is present and returns an explicit
@@ -173,29 +192,47 @@ class DefaultRouteReconciler:
     # ---- FIB operations (idempotent, error-tolerant, main-loop only) ----
 
     def _install(self, gateway, replacing=None):
-        if self.mode == DefaultRouteMode.OBSERVE:
+        if self._mode == DefaultRouteMode.OBSERVE:
             LOG.info("[observe] would install default via %s%s", gateway,
                      "" if replacing is None else f" (replacing {replacing})")
             return
-        # Match the base's set-default idiom (delete then add) so a wrong gateway
-        # is corrected; the delete is tolerated when there is nothing to remove.
+        # Set-default idiom: delete then add, so a wrong gateway is replaced (a
+        # plain `route add default` fails when one is already present). Then
+        # CONFIRM the FIB actually reached the desired state -- reading the result
+        # back is wording-independent, unlike parsing route(8)'s exit/stderr, and
+        # it catches a stuck delete that left the old gateway in place.
         if replacing is not None:
             self._route(RouteCommand.DELETE, _DEFAULT)
-        if self._route(RouteCommand.ADD, _DEFAULT, gateway):
+        self._route(RouteCommand.ADD, _DEFAULT, gateway)
+        have = self._fib_default_gateway()
+        if have == gateway:
             LOG.info("installed default via %s%s", gateway,
                      "" if replacing is None else f" (was {replacing})")
+        else:
+            LOG.error("failed to install default via %s (the FIB default is now %s)",
+                      gateway, have or "absent")
 
     def _withdraw(self, current):
-        if self.mode == DefaultRouteMode.OBSERVE:
+        if self._mode == DefaultRouteMode.OBSERVE:
             LOG.info("[observe] would withdraw default (currently via %s)", current)
             return
-        if self._route(RouteCommand.DELETE, _DEFAULT):
+        self._route(RouteCommand.DELETE, _DEFAULT)
+        # Confirm the FIB, not the exit code: a silently failed delete would leave
+        # a backup advertising a black-hole default -- the one outcome this feature
+        # exists to prevent -- so surface it at ERROR. The level-triggered
+        # reconcile retries the withdraw next tick.
+        if self._fib_default_gateway() is None:
             LOG.info("withdrew default (was via %s)", current)
+        else:
+            LOG.error("failed to withdraw default (still via %s) -- this node keeps "
+                      "advertising it", current)
 
     def _fib_default_gateway(self):
-        """Current IPv4 default gateway, or None when there is no default. A
-        query error (`route get` on an empty table exits non-zero with 'not in
-        table') is treated as 'no default', not as a probe failure."""
+        """Current IPv4 default gateway, or None when there is no default. Any
+        `route get` failure (an empty table exits non-zero) reads as 'no default'
+        -- the common, quiet steady state on a backup -- rather than an error; a
+        genuinely stuck route op is surfaced by the install/withdraw confirm, not
+        by second-guessing this read."""
         res = self._run([_ROUTE, _NUMERIC, RouteCommand.GET, _AF_INET, _DEFAULT])
         if res is None or res.returncode != 0:
             return None
@@ -206,27 +243,22 @@ class DefaultRouteReconciler:
         return None
 
     def _route(self, command, dest, gateway=None):
-        """Issue a `/sbin/route` command; return True on success. A non-zero exit
-        (route already present on add, or absent on delete) is tolerated and
-        logged at debug -- the reconcile is idempotent, so a redundant op is
-        expected, not an error."""
+        """Issue a `/sbin/route` command (best effort). The caller confirms the
+        resulting FIB state, so a non-zero exit -- an idempotent no-op or a real
+        failure alike -- is only debug-logged and left for that confirm to judge,
+        rather than guessed from route(8)'s wording here."""
         cmd = [_ROUTE, _NUMERIC, command, _AF_INET, dest]
         if gateway is not None:
             cmd.append(gateway)
         res = self._run(cmd)
-        if res is None:
-            return False
-        if res.returncode != 0:
-            LOG.debug("route %s %s exit %d (tolerated): %s", command, dest,
-                      res.returncode, (res.stderr or "").strip())
-            return False
-        return True
+        if res is not None and res.returncode != 0:
+            LOG.debug("route %s %s exit %d: %s", command, dest, res.returncode,
+                      (res.stderr or "").strip())
 
     def _run(self, cmd):
         """Run a `/sbin/route` argv, capturing output and bounded by a timeout;
-        return the CompletedProcess, or None if it could not be executed at all.
-        A non-zero exit is a normal, tolerated outcome (idempotent ops), so it is
-        left for the caller to interpret rather than folded into None here."""
+        return the CompletedProcess, or None if it could not be executed at all
+        (logged)."""
         try:
             return subprocess.run(cmd, capture_output=True, errors="replace",
                                   timeout=_SUBPROC_TIMEOUT, check=False)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -8,8 +8,8 @@ failure mode is a withdrawn default, never a black-holed one. See
 docs/default-route-carp-ownership.md.
 
 Concurrency: reconcile() must be called only from the keeper's main loop thread;
-the intended caller is Keeper._poll_carp_role (the per-tick poll and the SIGUSR2
-CARP / route_reload edge), wired in a later change. Signal handlers and the capture thread never
+the caller is Keeper._reconcile_default_route (the per-tick poll, the unbound
+acquire arm, and the SIGUSR2 CARP edge). Signal handlers and the capture thread never
 touch the FIB -- they only set flags / hand off observations, exactly as the
 lease path does. So there is no in-process route race; the only shared mutable
 state is the kernel FIB, and cross-process / cross-subsystem contention is
@@ -99,6 +99,7 @@ class DefaultRouteReconciler:
 
     @property
     def enabled(self):
+        """True in observe/enforce (off is inert); see DefaultRouteMode."""
         return self.mode in (DefaultRouteMode.OBSERVE, DefaultRouteMode.ENFORCE)
 
     def reconcile(self, is_master, bound, gateway):
@@ -171,7 +172,7 @@ class DefaultRouteReconciler:
     def _install(self, gateway, replacing=None):
         if self.mode == DefaultRouteMode.OBSERVE:
             LOG.info("[observe] would install default via %s%s", gateway,
-                     "" if replacing is None else " (replacing %s)" % replacing)
+                     "" if replacing is None else f" (replacing {replacing})")
             return
         # Match the base's set-default idiom (delete then add) so a wrong gateway
         # is corrected; the delete is tolerated when there is nothing to remove.
@@ -179,7 +180,7 @@ class DefaultRouteReconciler:
             self._route(RouteCommand.DELETE, _DEFAULT)
         if self._route(RouteCommand.ADD, _DEFAULT, gateway):
             LOG.info("installed default via %s%s", gateway,
-                     "" if replacing is None else " (was %s)" % replacing)
+                     "" if replacing is None else f" (was {replacing})")
 
     def _withdraw(self, current):
         if self.mode == DefaultRouteMode.OBSERVE:
@@ -225,7 +226,7 @@ class DefaultRouteReconciler:
         left for the caller to interpret rather than folded into None here."""
         try:
             return subprocess.run(cmd, capture_output=True, errors="replace",
-                                  timeout=_SUBPROC_TIMEOUT)
+                                  timeout=_SUBPROC_TIMEOUT, check=False)
         except (OSError, subprocess.SubprocessError) as e:
             LOG.warning("route command failed to run (%s): %s", " ".join(cmd), e)
             return None

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -81,13 +81,16 @@ class DefaultRouteReconciler:
     All methods run on the keeper's main loop thread only; the class holds no
     lock because nothing else in the keeper mutates routes."""
 
-    def __init__(self, mode=DefaultRouteMode.OFF, *,
+    def __init__(self, mode: "str | DefaultRouteMode" = DefaultRouteMode.OFF, *,
                  unreadable_role_strikes=DEFAULT_UNREADABLE_ROLE_STRIKES,
                  liveness_probe=None):
+        # mode flows in from the model verbatim (keeper.conf -> rc.d -> argparse) as
+        # a plain string; coerce it, and treat any unrecognised value as inert OFF.
         try:
             self.mode = DefaultRouteMode(mode)
         except ValueError:
-            self.mode = DefaultRouteMode.OFF  # unknown mode string -> inert, never guess
+            LOG.warning("unknown default-route mode %r -- treating as off", mode)
+            self.mode = DefaultRouteMode.OFF  # never guess an active mode
         self._strike_limit = unreadable_role_strikes
         # liveness_probe: optional callable() -> bool|None gating the INSTALL
         # side (the split-brain guard). None (no callable) or a None result means

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -1,0 +1,231 @@
+"""Default-route ownership keyed on CARP role.
+
+The keeper owns the IPv4 WAN default route (0.0.0.0/0) as a function of its CARP
+role and whether it currently holds a DHCP lease: only the CARP-master node that
+actually holds a lease keeps a default in the FIB; every other state has none. A
+node with no default advertises none (via os-frr redistribute kernel), so the
+failure mode is a withdrawn default, never a black-holed one. See
+docs/default-route-carp-ownership.md.
+
+Concurrency: reconcile() must be called only from the keeper's main loop thread;
+the intended caller is Keeper._poll_carp_role (the per-tick poll and the SIGUSR2
+CARP / route_reload edge), wired in a later change. Signal handlers and the capture thread never
+touch the FIB -- they only set flags / hand off observations, exactly as the
+lease path does. So there is no in-process route race; the only shared mutable
+state is the kernel FIB, and cross-process / cross-subsystem contention is
+handled outside this module (a single managing keeper, and force_down so
+OPNsense does not also manage the default). Every route operation is idempotent
+and error-tolerant, so a redundant add/delete -- or a burst of coalesced signals
+collapsed onto one boolean flag -- converges quietly rather than raising.
+"""
+import logging
+import subprocess
+from enum import StrEnum
+
+from .constants import LOGGER_NAME
+
+LOG = logging.getLogger(LOGGER_NAME)
+
+# Daemon log-and-continue posture: broad catch-alls are deliberate (see the
+# package docstring / module docstrings).
+# pylint: disable=broad-exception-caught
+
+
+class DefaultRouteMode(StrEnum):
+    """Per-keeper default-route mode (the values the model's defaultRouteMode
+    field will carry). StrEnum (like constants.Phase) so a member both is its
+    config string and compares by value -- the value flows in from the model
+    verbatim. off:
+    inert (default). observe: log what it would do, no FIB write. enforce:
+    actually install/withdraw."""
+    OFF = "off"
+    OBSERVE = "observe"
+    ENFORCE = "enforce"
+
+
+class RouteCommand(StrEnum):
+    """The `/sbin/route` commands we issue (route(8) calls add/delete/get
+    'commands'). StrEnum so a member drops straight into the argv list and logs
+    as its bare value (a plain Enum would render 'RouteCommand.ADD' and need
+    .value)."""
+    ADD = "add"
+    DELETE = "delete"
+    GET = "get"
+
+
+# The IPv4 default. IPv6 is out of scope (docs section 12): no v6 BGP fw<->pve,
+# so no v6 default leak to gate.
+_DEFAULT = "default"
+
+# Consecutive unreadable CARP-role probes tolerated while we still hold a
+# default before we withdraw it. An unreadable probe (ifconfig failed) is
+# fail-safe on the INSTALL side (do nothing) but must fail *closed* on the
+# WITHDRAW side, or a former master with a flaky ifconfig keeps advertising a
+# default it should have dropped. A genuine role loss reads as False within a
+# tick; only a stuck probe reaches this ceiling.
+DEFAULT_UNREADABLE_ROLE_STRIKES = 3
+
+_ROUTE = "/sbin/route"
+_NUMERIC = "-n"              # numeric output, no name resolution
+_AF_INET = "-inet"          # IPv4 address family modifier; the v6 twin: -inet6
+_GATEWAY_FIELD = "gateway:"  # the field label parsed from `route get` output
+_SUBPROC_TIMEOUT = 5
+
+
+class DefaultRouteReconciler:
+    """Reconciles the IPv4 default route against (CARP role, lease-held,
+    gateway). Level-triggered and idempotent: reconcile() may be called as often
+    as the loop likes (edge or poll) and converges to the desired state,
+    emitting a route change only when the FIB actually differs.
+
+    All methods run on the keeper's main loop thread only; the class holds no
+    lock because nothing else in the keeper mutates routes."""
+
+    def __init__(self, mode=DefaultRouteMode.OFF, *,
+                 unreadable_role_strikes=DEFAULT_UNREADABLE_ROLE_STRIKES,
+                 liveness_probe=None):
+        try:
+            self.mode = DefaultRouteMode(mode)
+        except ValueError:
+            self.mode = DefaultRouteMode.OFF  # unknown mode string -> inert, never guess
+        self._strike_limit = unreadable_role_strikes
+        # liveness_probe: optional callable() -> bool|None gating the INSTALL
+        # side (the split-brain guard). None (no callable) or a None result means
+        # "no opinion" and never blocks; only an explicit False blocks. It must
+        # be debounced by the caller -- a single transient miss must not read
+        # False, or a healthy master would flap its default. See docs section 2.
+        self._liveness_probe = liveness_probe
+        self._strikes = 0
+
+    @property
+    def enabled(self):
+        return self.mode in (DefaultRouteMode.OBSERVE, DefaultRouteMode.ENFORCE)
+
+    def reconcile(self, is_master, bound, gateway):
+        """Drive the FIB default toward the desired state for the current
+        (is_master, bound, gateway). Call from the main loop thread only.
+
+        is_master: True / False, or None when the CARP probe itself failed.
+        bound:     True iff a lease is currently held (binding.yiaddr set). This
+                   is the lease-held signal; do NOT infer it from `gateway`,
+                   which is a sticky last-known hint that survives a lease loss.
+        gateway:   the lease gateway (binding.router), used as the route's
+                   gateway and only when bound.
+        """
+        if not self.enabled:
+            return
+
+        # Guard the unreadable-role case first, before any FIB read: fail-safe on
+        # install, fail-closed (bounded) on withdraw.
+        if is_master is None:
+            self._on_unknown_role()
+            return
+        self._strikes = 0
+
+        want = is_master and bound and gateway is not None
+        if want and self._liveness_blocks():
+            # Master with a lease but liveness is explicitly not confirmed
+            # (possible split-brain / dead WAN with a stale lease): do not keep a
+            # default we may be unable to honour. Fall through to the withdraw arm.
+            want = False
+
+        have = self._fib_default_gateway()
+        if want:
+            if have == gateway:
+                return  # already correct -- silent, no route change, no churn
+            self._install(gateway, replacing=have)
+        else:
+            if have is None:
+                return  # already absent -- silent
+            self._withdraw(have)
+
+    # ---- role-unknown handling ----
+
+    def _on_unknown_role(self):
+        """An unreadable (is_master is None) probe: do not install when unsure,
+        but after a bounded number of consecutive unknown probes, withdraw any
+        default we still hold so a former master stops advertising once its role
+        can no longer be confirmed."""
+        self._strikes += 1
+        if self._strikes < self._strike_limit:
+            return
+        have = self._fib_default_gateway()
+        if have is not None:
+            LOG.warning("CARP role unreadable for %d checks -- withdrawing default "
+                        "(fail-closed)", self._strikes)
+            self._withdraw(have)
+
+    def _liveness_blocks(self):
+        """True only when the liveness probe is present and returns an explicit
+        False. A missing probe or a None result never blocks."""
+        if self._liveness_probe is None:
+            return False
+        try:
+            return self._liveness_probe() is False
+        except Exception:
+            # A broken liveness probe must not block routing.
+            return False
+
+    # ---- FIB operations (idempotent, error-tolerant, main-loop only) ----
+
+    def _install(self, gateway, replacing=None):
+        if self.mode == DefaultRouteMode.OBSERVE:
+            LOG.info("[observe] would install default via %s%s", gateway,
+                     "" if replacing is None else " (replacing %s)" % replacing)
+            return
+        # Match the base's set-default idiom (delete then add) so a wrong gateway
+        # is corrected; the delete is tolerated when there is nothing to remove.
+        if replacing is not None:
+            self._route(RouteCommand.DELETE, _DEFAULT)
+        if self._route(RouteCommand.ADD, _DEFAULT, gateway):
+            LOG.info("installed default via %s%s", gateway,
+                     "" if replacing is None else " (was %s)" % replacing)
+
+    def _withdraw(self, current):
+        if self.mode == DefaultRouteMode.OBSERVE:
+            LOG.info("[observe] would withdraw default (currently via %s)", current)
+            return
+        if self._route(RouteCommand.DELETE, _DEFAULT):
+            LOG.info("withdrew default (was via %s)", current)
+
+    def _fib_default_gateway(self):
+        """Current IPv4 default gateway, or None when there is no default. A
+        query error (`route get` on an empty table exits non-zero with 'not in
+        table') is treated as 'no default', not as a probe failure."""
+        res = self._run([_ROUTE, _NUMERIC, RouteCommand.GET, _AF_INET, _DEFAULT])
+        if res is None or res.returncode != 0:
+            return None
+        for line in res.stdout.splitlines():
+            stripped = line.strip()
+            if stripped.startswith(_GATEWAY_FIELD):
+                return stripped[len(_GATEWAY_FIELD):].strip() or None
+        return None
+
+    def _route(self, command, dest, gateway=None):
+        """Issue a `/sbin/route` command; return True on success. A non-zero exit
+        (route already present on add, or absent on delete) is tolerated and
+        logged at debug -- the reconcile is idempotent, so a redundant op is
+        expected, not an error."""
+        cmd = [_ROUTE, _NUMERIC, command, _AF_INET, dest]
+        if gateway is not None:
+            cmd.append(gateway)
+        res = self._run(cmd)
+        if res is None:
+            return False
+        if res.returncode != 0:
+            LOG.debug("route %s %s exit %d (tolerated): %s", command, dest,
+                      res.returncode, (res.stderr or "").strip())
+            return False
+        return True
+
+    def _run(self, cmd):
+        """Run a `/sbin/route` argv, capturing output and bounded by a timeout;
+        return the CompletedProcess, or None if it could not be executed at all.
+        A non-zero exit is a normal, tolerated outcome (idempotent ops), so it is
+        left for the caller to interpret rather than folded into None here."""
+        try:
+            return subprocess.run(cmd, capture_output=True, errors="replace",
+                                  timeout=_SUBPROC_TIMEOUT)
+        except (OSError, subprocess.SubprocessError) as e:
+            LOG.warning("route command failed to run (%s): %s", " ".join(cmd), e)
+            return None

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -116,6 +116,19 @@ class DefaultRouteReconciler:
         """True in observe/enforce (off is inert); see DefaultRouteMode."""
         return self._mode in (DefaultRouteMode.OBSERVE, DefaultRouteMode.ENFORCE)
 
+    @classmethod
+    def withdraw_if_enabled(cls, mode):
+        """Construct a reconciler for `mode` and drive it to the withdrawn state (no
+        lease, non-master), dropping a default a crashed predecessor left in the FIB.
+        Pure route(8) with no capture backend, so the daemon entry point runs it as a
+        startup fail-stop BEFORE the Keeper / capture backend exist and ahead of any
+        arg/backend early-exit that would skip Keeper.run(). off is a no-op; observe
+        logs a would-withdraw without touching the FIB; enforce actually withdraws.
+        The caller gates on having a CARP vhid (nothing owns a default without one)."""
+        reconciler = cls(mode)
+        if reconciler.enabled:
+            reconciler.reconcile(is_master=False, bound=False, gateway=None)
+
     def reconcile(self, is_master, bound, gateway):
         """Drive the FIB default toward the desired state for the current
         (is_master, bound, gateway). Call from the main loop thread only.

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -50,6 +50,7 @@ class RouteCommand(StrEnum):
     as its bare value (a plain Enum would render 'RouteCommand.ADD' and need
     .value)."""
     ADD = "add"
+    CHANGE = "change"
     DELETE = "delete"
     GET = "get"
 
@@ -208,14 +209,19 @@ class DefaultRouteReconciler:
             LOG.info("[observe] would install default via %s%s", gateway,
                      "" if replacing is None else f" (replacing {replacing})")
             return
-        # Set-default idiom: delete then add, so a wrong gateway is replaced (a
-        # plain `route add default` fails when one is already present). Then
-        # CONFIRM the FIB actually reached the desired state -- reading the result
-        # back is wording-independent, unlike parsing route(8)'s exit/stderr, and
-        # it catches a stuck delete that left the old gateway in place.
-        if replacing is not None:
-            self._route(RouteCommand.DELETE, _DEFAULT)
-        self._route(RouteCommand.ADD, _DEFAULT, gateway)
+        # Replace atomically with `route change`, not delete-then-add. A bench
+        # check on FreeBSD 14.3 confirmed both halves: `route change` to an on-link
+        # gateway swaps in place (no momentary no-default gap for FRR
+        # redistribute-kernel to flap on), and to an off-link gateway it fails
+        # ("Invalid argument") and leaves the old default intact -- so a still-usable
+        # default is never torn down for one we cannot install (e.g. a cross-subnet
+        # lease whose new gateway is not on-link until the interface moves). A first
+        # install (no prior default) uses `add`: `change` requires the route to
+        # exist. Then CONFIRM the FIB reached the desired state -- reading the result
+        # back is wording-independent, unlike parsing route(8)'s exit/stderr, and a
+        # rejected change simply reads back as the old gateway (surfaced below).
+        verb = RouteCommand.ADD if replacing is None else RouteCommand.CHANGE
+        self._route(verb, _DEFAULT, gateway)
         have = self._fib_default_gateway()
         if have == gateway:
             LOG.info("installed default via %s%s", gateway,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -8,8 +8,9 @@ failure mode is a withdrawn default, never a black-holed one. See
 docs/single-ip-wan-carp.md.
 
 Concurrency: reconcile() must be called only from the keeper's main loop thread;
-the caller is Keeper._reconcile_default_route (the per-tick poll, the unbound
-acquire arm, and the SIGUSR2 CARP edge). Signal handlers and the capture thread never
+the caller is Keeper._reconcile_default_route -- the per-tick poll, the acquire
+arm (unbound and just after a successful acquire) and the SIGUSR2 CARP edge, plus
+a fail-stop non-master withdraw at startup and on shutdown. Signal handlers and the capture thread never
 touch the FIB -- they only set flags / hand off observations, exactly as the
 lease path does. So there is no in-process route race; the only shared mutable
 state is the kernel FIB, and cross-process / cross-subsystem contention is
@@ -121,9 +122,10 @@ class DefaultRouteReconciler:
         is_master: True / False, or None when the CARP probe itself failed.
         bound:     True iff a lease is currently held (binding.yiaddr set). This
                    is the lease-held signal; do NOT infer it from `gateway`,
-                   which is a sticky last-known hint that survives a lease loss.
-        gateway:   the lease gateway (binding.router), used as the route's
-                   gateway and only when bound.
+                   which can linger non-None after a lease loss (expire() clears
+                   only yiaddr).
+        gateway:   the current lease's own gateway (binding.lease_router), used
+                   as the route's gateway and only when bound.
         """
         if not self.enabled:
             return
@@ -154,8 +156,18 @@ class DefaultRouteReconciler:
                 return  # already correct -- silent, no route change, no churn
             self._install(gateway, replacing=have)
         else:
+            # A route-get failure (for any reason) also reads as None here, so we
+            # skip the withdraw. Treating an unreadable table as "absent" is a
+            # deliberate trade-off: an empty table -- the common quiet state on a
+            # backup -- is the overwhelming case, route(8)'s empty-table wording
+            # varies by platform/version, and warning on every empty read would be
+            # noise. The genuine stuck case (a default present while route get
+            # fails) is rare (get and delete share one routing socket) and
+            # self-corrects: the reconcile re-reads every tick, and once the read
+            # succeeds the withdraw runs and confirms the FIB. A bounded delay
+            # beats a per-tick false alarm.
             if have is None:
-                return  # already absent -- silent
+                return  # already absent (or unreadable -- see above)
             self._withdraw(have)
 
     # ---- role-unknown handling ----

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -131,19 +131,26 @@ class DefaultRouteReconciler:
         if not self.enabled:
             return
 
-        # Guard the unreadable-role case first, before any FIB read: fail-safe on
-        # install, fail-closed (bounded) on withdraw.
-        if is_master is None:
+        # A live binding plus a sane, non-zero unicast gateway is a usable lease
+        # (rejects a 0.0.0.0 / malformed option-3 from a rogue or broken DHCP
+        # server, and a gateway that lingers after a lease loss -- expire() clears
+        # only yiaddr). Role-independent: without a usable lease there is nothing to
+        # be master OF, so the default must go regardless of the CARP role.
+        holds_lease = bound and _sane_ipv4(gateway)
+
+        # Role unreadable AND a lease is held: we might still legitimately be
+        # master, so tolerate a bounded number of unreadable probes (fail-safe on
+        # install, fail-closed on withdraw) rather than flapping the default on a
+        # transient ifconfig failure. Every other state -- role readable, or no
+        # usable lease -- is decided normally below, so an unreadable role on an
+        # unbound node withdraws at once instead of holding for the strike limit.
+        if is_master is None and holds_lease:
             self._on_unknown_role()
             return
         self._strikes = 0
-        self._unreadable_warned = False   # role readable again -> re-arm the warning
+        self._unreadable_warned = False   # not in an unreadable-while-bound episode -> re-arm
 
-        # A sane, non-zero unicast gateway is required to install (rejects a
-        # 0.0.0.0 / malformed option-3 from a rogue or broken DHCP server); an
-        # unusable gateway falls through to the withdraw arm rather than
-        # installing a default that leads nowhere.
-        want = is_master and bound and _sane_ipv4(gateway)
+        want = (is_master is True) and holds_lease
 
         if want and self._liveness_blocks():
             # Master with a lease but liveness is explicitly not confirmed

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -185,8 +185,8 @@ class DefaultRouteReconciler:
         if have is None:
             return
         if not self._unreadable_warned:
-            LOG.warning("CARP role unreadable for %d checks -- dropping the default "
-                        "(fail-closed)", self._strikes)
+            LOG.warning("CARP role unreadable for %d checks -- failing closed on "
+                        "the default", self._strikes)
             self._unreadable_warned = True
         self._withdraw(have)
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -132,10 +132,10 @@ class DefaultRouteReconciler:
             return
 
         # A live binding plus a sane, non-zero unicast gateway is a usable lease
-        # (rejects a 0.0.0.0 / malformed option-3 from a rogue or broken DHCP
-        # server, and a gateway that lingers after a lease loss -- expire() clears
-        # only yiaddr). Role-independent: without a usable lease there is nothing to
-        # be master OF, so the default must go regardless of the CARP role.
+        # (the guard rejects a 0.0.0.0 / malformed option-3, and a stale gateway
+        # lingering past a lease loss -- see the bound/gateway contract above).
+        # Role-independent: without a usable lease there is nothing to be master OF,
+        # so the default must go regardless of the CARP role.
         holds_lease = bound and _sane_ipv4(gateway)
 
         # Role unreadable AND a lease is held: we might still legitimately be

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/wire.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/wire.py
@@ -122,8 +122,11 @@ def _parse_reply(frame) -> DhcpReply:
     gi = frame.giaddr   # relay agent; 0.0.0.0 = directly attached
     if gi in (None, "0.0.0.0", 0):
         gi = None
+    yi = frame.yiaddr   # 0.0.0.0 (a NAK, or a broken/rogue reply) = no address,
+    if yi in (None, "0.0.0.0", 0):  # normalized to None like giaddr so "bound"
+        yi = None                   # (truthy yiaddr) can never latch onto 0.0.0.0
     return DhcpReply(
-        mtype=opts.get(DhcpOptName.MESSAGE_TYPE), yiaddr=frame.yiaddr,
+        mtype=opts.get(DhcpOptName.MESSAGE_TYPE), yiaddr=yi,
         server_id=opts.get(DhcpOptName.SERVER_ID), lease=opts.get(DhcpOptName.LEASE_TIME),
         t1=opts.get(DhcpOptName.RENEWAL_TIME), t2=opts.get(DhcpOptName.REBINDING_TIME),
         router=opts.get(DhcpOptName.ROUTER), message=opts.get(DhcpOptName.MESSAGE),

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/wire.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/wire.py
@@ -108,6 +108,12 @@ def _fmt_reply(rx) -> str:
             f"gw={rx.router or '-'} mask={rx.subnet_mask or '-'}{msg}")
 
 
+def _zero_ip_to_none(addr):
+    """A BOOTP address field of 0.0.0.0 (or unset) means 'no address'; map it to
+    None so it is falsy, not the truthy string "0.0.0.0"."""
+    return None if addr in (None, "0.0.0.0", 0) else addr
+
+
 def _parse_reply(frame) -> DhcpReply:
     """Snapshot only the handful of DHCP options the keeper acts on from a
     BootpFrame into a DhcpReply; the rest of the reply's option data --
@@ -119,12 +125,12 @@ def _parse_reply(frame) -> DhcpReply:
     # rather than dict(frame.options) so a multi-value option that decodes to a
     # 3+-tuple is still read by its first value (o[1]) instead of raising.
     opts = {o[0]: o[1] for o in frame.options if isinstance(o, tuple)}
-    gi = frame.giaddr   # relay agent; 0.0.0.0 = directly attached
-    if gi in (None, "0.0.0.0", 0):
-        gi = None
-    yi = frame.yiaddr   # 0.0.0.0 (a NAK, or a broken/rogue reply) = no address,
-    if yi in (None, "0.0.0.0", 0):  # normalized to None like giaddr so "bound"
-        yi = None                   # (truthy yiaddr) can never latch onto 0.0.0.0
+    # An unset BOOTP address is 0.0.0.0 on the wire; normalize both to None so a
+    # relay-less reply (giaddr) and a "no address" reply (yiaddr on a NAK, or a
+    # broken/rogue reply) read as absent rather than as a truthy "0.0.0.0" -- in
+    # particular so the yiaddr-derived "bound" signal can never latch onto 0.0.0.0.
+    gi = _zero_ip_to_none(frame.giaddr)   # relay agent; absent = directly attached
+    yi = _zero_ip_to_none(frame.yiaddr)
     return DhcpReply(
         mtype=opts.get(DhcpOptName.MESSAGE_TYPE), yiaddr=yi,
         server_id=opts.get(DhcpOptName.SERVER_ID), lease=opts.get(DhcpOptName.LEASE_TIME),

--- a/net/os-carp-vip-dhcp/src/opnsense/service/templates/OPNsense/CarpVipDhcp/keeper.conf
+++ b/net/os-carp-vip-dhcp/src/opnsense/service/templates/OPNsense/CarpVipDhcp/keeper.conf
@@ -1,7 +1,7 @@
 {#
     Rendered keeper table for lease_keeper.py (one line per enabled keeper).
 
-    Format per line:  REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE|ARP_LISTEN_PROMISC|CAPTURE_BACKEND
+    Format per line:  REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE|ARP_LISTEN_PROMISC|CAPTURE_BACKEND|DEFAULT_ROUTE_MODE
     Everything is derived from each keeper's referenced CARP VirtualIP: we look
     the VIP up in the legacy virtualip list to get its interface (-> physical
     device) and VHID (-> chaddr 00:00:5e:00:01:VHID). chaddrOverride wins when set.
@@ -26,7 +26,7 @@
 {%       set chaddr = '' %}
 {%     endif %}
 {%     if vip.iface and chaddr %}
-{{ k.carpVip }}|{{ vip.iface }}|{{ chaddr }}|{{ k.demoteOnLeaseLoss|default('0') }}|{{ vip.vhid }}|{{ k.followIp|default('0') }}|{{ k.vendorClass|default('') }}|{{ k.clientId|default('') }}|{{ k.hostname|default('') }}|{{ k.arpNudgeInterval|default('0') }}|{{ k.arpListenPromisc|default('0') }}|{{ k.captureBackend|default('') }}
+{{ k.carpVip }}|{{ vip.iface }}|{{ chaddr }}|{{ k.demoteOnLeaseLoss|default('0') }}|{{ vip.vhid }}|{{ k.followIp|default('0') }}|{{ k.vendorClass|default('') }}|{{ k.clientId|default('') }}|{{ k.hostname|default('') }}|{{ k.arpNudgeInterval|default('0') }}|{{ k.arpListenPromisc|default('0') }}|{{ k.captureBackend|default('') }}|{{ k.defaultRouteMode|default('off') }}
 {%     endif %}
 {%   endif %}
 {% endfor %}

--- a/net/os-carp-vip-dhcp/tests/conftest.py
+++ b/net/os-carp-vip-dhcp/tests/conftest.py
@@ -76,7 +76,7 @@ def _load(filename, modname):
 
 
 @pytest.fixture(scope="session")
-def lk():
+def lk():  # pylint: disable=too-many-locals
     """Facade over the leasekeeper package: every public name from the submodules
     under one namespace, so the tests reach them as lk.* without the daemon
     entry point (../lease_keeper.py) re-exporting its whole API. Also exposes the

--- a/net/os-carp-vip-dhcp/tests/conftest.py
+++ b/net/os-carp-vip-dhcp/tests/conftest.py
@@ -88,11 +88,11 @@ def lk():
     import time  # pylint: disable=import-outside-toplevel
     from leasekeeper import (  # pylint: disable=import-outside-toplevel
         capture, capture_bpf, capture_scapy, codec, constants, dhcpclient,
-        keeper, policy, util, wire)
+        keeper, policy, route, util, wire)
 
     ns = types.SimpleNamespace()
     for mod in (constants, util, wire, codec, capture, capture_scapy,
-                capture_bpf, dhcpclient, policy, keeper):
+                capture_bpf, dhcpclient, policy, route, keeper):
         for name in dir(mod):
             if not name.startswith("__"):
                 setattr(ns, name, getattr(mod, name))

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -216,14 +216,14 @@ def test_check_link_returned_edge(lk):
     # initial unknown -> up is NOT a trigger (we were already up)
     seq[:] = [True]
     assert k._check_link_returned() is False
-    assert k._link_up is True
+    assert k._link.up is True
     # up -> up: no trigger
     seq[:] = [True]
     assert k._check_link_returned() is False
     # up -> down: recorded, no trigger
     seq[:] = [False]
     assert k._check_link_returned() is False
-    assert k._link_up is False
+    assert k._link.up is False
     # down -> up: TRIGGER
     seq[:] = [True]
     assert k._check_link_returned() is True
@@ -249,7 +249,7 @@ def test_maintain_holds_acquire_without_carrier(lk, caplog):
         k._maintain_step()
         k._maintain_step()
     assert k.acquired == []                  # no DISCOVER burned on a dead link
-    assert k._link_up is False
+    assert k._link.up is False
     # one INFO per down-episode, not per loop pass
     waits = [r for r in caplog.records if "no carrier" in r.getMessage()]
     assert len(waits) == 1
@@ -271,10 +271,10 @@ def test_bound_marks_carrier_up(lk):
     # A completed DORA proves carrier: the last-carrier-state invariant stays
     # honest so the next down-episode always logs its hold line.
     k = _gate_keeper(lk, carrier=True)
-    k._link_up = False                       # stale from an earlier down-episode
+    k._link.up = False                       # stale from an earlier down-episode
     k._dhcp.acquire = lambda rip: True
     k._maintain_step()
-    assert k._link_up is True
+    assert k._link.up is True
 
 
 def test_carrier_wait_resumes_via_link_return(lk, caplog):
@@ -282,7 +282,7 @@ def test_carrier_wait_resumes_via_link_return(lk, caplog):
     k.redora_wait = 40
 
     def sleep_with_return(_secs):
-        k._link_returned = True              # what the fast path sets on the edge
+        k._link.returned = True              # what the fast path sets on the edge
         return True
     k._sleep_interruptible = sleep_with_return
     with caplog.at_level("INFO", logger="lease-keeper"):
@@ -295,9 +295,9 @@ def test_check_link_returned_debounce(lk, monkeypatch):
     k = _link_keeper(lk)
     monkeypatch.setattr(lk.time, "time", lambda: 1000.0)
     k._iface_link_up = lambda: True
-    k._link_up = False   # pretend we saw the link go down
+    k._link.up = False   # pretend we saw the link go down
     assert k._check_link_returned() is True   # first down->up fires (kick_at was 0.0)
-    k._link_up = False   # another down at the same instant
+    k._link.up = False   # another down at the same instant
     assert k._check_link_returned() is False  # debounced (now - kick_at = 0 < LINK_KICK_DEBOUNCE)
 
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -793,10 +793,10 @@ def test_hold_returns_early_for_asap_renew(lk):
 
 def test_sigusr1_flag_services_nudge_within_a_second(lk, caplog):
     keeper = _nudge_keeper(lk)
-    keeper._signals.nudge = True   # what the SIGUSR1 handler sets
+    keeper._signals.request_nudge()   # what the SIGUSR1 handler sets
     with caplog.at_level("INFO", logger="lease-keeper"):
         keeper._sleep_interruptible(1)
-    assert keeper._signals.nudge is False
+    assert keeper._signals.take_nudge() is False   # loop already drained it
     assert keeper._nudge.last_nudge > 0
     # Operator-triggered nudges must be visible in the log (the README says so).
     assert any("manual ARP nudge" in r.getMessage() for r in caplog.records)
@@ -812,9 +812,9 @@ def test_sigusr2_flag_rechecks_carp_role_within_a_second(lk):
     keeper._probe_carp_master = probe
     keeper._poll_carp_role()   # first observation: records backup
     assert keeper._renew_asap is False
-    keeper._signals.recheck_role = True          # what the SIGUSR2 handler sets on a CARP event
+    keeper._signals.request_recheck_role()       # what the SIGUSR2 handler sets on a CARP event
     keeper._sleep_interruptible(1)   # services the flag -> re-check -> transition
-    assert keeper._signals.recheck_role is False
+    assert keeper._signals.take_recheck_role() is False   # loop already drained it
     assert keeper._renew_asap is True     # backup->master: renew early
     assert keeper._nudge.last_nudge > 0         # and nudge immediately
 
@@ -1159,3 +1159,51 @@ def test_default_route_needs_vhid(lk):
     k._probe_carp_master = lambda: True
     k._reconcile_default_route(master=True)
     assert not rec.calls
+
+
+# ---- the reconcile is actually driven from all three main-loop call-sites ----
+
+def test_sigusr2_edge_drives_default_route_reconcile(lk):
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    probes = {"n": 0}
+
+    def probe():
+        probes["n"] += 1
+        return True
+    k._probe_carp_master = probe
+    k._dhcp.binding.yiaddr = "100.64.4.7"
+    k._dhcp.binding.router = "100.64.4.1"
+    k._signals.request_recheck_role()          # what the CARP syshook's SIGUSR2 sets
+    k._sleep_interruptible(1)
+    assert rec.calls == [(True, True, "100.64.4.1")]   # reconciled on the failover edge
+    assert probes["n"] == 1                             # one shared probe feeds poll + reconcile
+
+
+def test_hold_lease_tick_drives_default_route_reconcile(lk):
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    k._probe_carp_master = lambda: True
+    k._sleep_interruptible = lambda _s: True   # one chunk, no real sleep
+    k._dhcp.binding.yiaddr = "100.64.4.7"
+    k._dhcp.binding.router = "100.64.4.1"
+    k._hold_lease(1)
+    assert (True, True, "100.64.4.1") in rec.calls
+
+
+def test_acquire_step_reconciles_when_unbound(lk):
+    # A former master that lost its lease withdraws on the unbound arm (bound=False);
+    # the bound-path tick never runs there.
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    k._ensure_sniffer = lambda: None
+    k._probe_carp_master = lambda: True
+    k._iface_link_up = lambda: None            # unreadable carrier -> straight to the acquire
+    k._dhcp.acquire = lambda _rip: False
+    k._sleep_interruptible = lambda _s: True
+    k._dhcp.binding.yiaddr = None              # unbound
+    k._acquire_step()
+    assert rec.calls == [(True, False, k._dhcp.binding.router)]   # bound=False

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1294,3 +1294,81 @@ def test_failed_dora_clears_unconfirmed_offer(lk):
     c._wait_for_dhcp_reply = lambda want, timeout: next(replies, None)
     assert c.dora("100.64.4.7") is False
     assert c.binding.yiaddr is None   # cleared -> re-acquire, never a phantom bound
+
+
+def test_failed_dora_after_offer_timeout_clears_yiaddr(lk, monkeypatch):
+    # The timeout branch (OFFER received, then no ACK at all) reaches the same
+    # unconfirmed-offer clear as the NAK branch via a different control path, so
+    # a REQUEST that simply times out cannot leave a phantom bound yiaddr either.
+    monkeypatch.setattr(lk.time, "sleep", lambda *_a, **_k: None)
+    c = _client(lk)
+    c._ensure_sniffer = lambda: None
+    calls = {"n": 0}
+
+    def reply(_want, _timeout):
+        calls["n"] += 1
+        # the first wait is the DISCOVER's OFFER; every REQUEST wait after it times out
+        if calls["n"] == 1:
+            return lk.DhcpReply(lk.OFFER, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1")
+        return None
+    c._wait_for_dhcp_reply = reply
+    assert c.dora("100.64.4.7") is False
+    assert c.binding.yiaddr is None
+
+
+def test_renew_keeps_lease_router_when_ack_omits_option3(lk):
+    # renew() must absorb with fresh_bind=False, so a RENEW of the SAME lease whose
+    # ACK omits option 3 keeps the current gateway. A regression to fresh_bind=True
+    # would clear lease_router mid-lease -> reconcile sees gateway None -> withdraws
+    # the default under a still-healthy master. Drives renew(), not _absorb_reply.
+    c = _client(lk)
+    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1"))
+    assert c.binding.lease_router == "100.64.4.1"
+    c._ensure_sniffer = lambda: None
+    c._wait_for_dhcp_reply = lambda _want, _timeout: lk.DhcpReply(
+        lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, None)   # same lease, no opt 3
+    assert c.renew() is True
+    assert c.binding.lease_router == "100.64.4.1"
+
+
+def test_parse_reply_normalizes_zero_yiaddr_to_none(lk):
+    # A 0.0.0.0 yiaddr (a NAK, or a broken/rogue reply) decodes to None like giaddr,
+    # so a truthy "0.0.0.0" can never be read as a held lease ("bound").
+    frame = _dhcp_frame(lk, 0x1234, [("message-type", lk.NAK), "end"], yiaddr="0.0.0.0")
+    assert lk._parse_reply(frame).yiaddr is None
+
+
+def test_rebind_loop_drives_default_route_reconcile(lk):
+    # The REBIND loop (T1..T2, after a failed RENEW) reconciles the default per
+    # iteration too -- the periodic fallback _hold_lease has -- so a failover during
+    # that degraded window converges even if its SIGUSR2 edge is missed.
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    k._probe_carp_master = lambda: True
+    k._hb = lambda: None
+    k._arp_nudge = lambda *_a, **_k: None
+    k._hold_lease = lambda _s: True             # skip the T1 wait (its own reconcile too)
+    k._sleep_interruptible = lambda _s: True     # one REBIND step, no real sleep
+    k._dhcp.timing = lambda: (0, 100, "test")
+    k._dhcp.binding.yiaddr = "100.64.4.7"
+    k._dhcp.binding.lease_router = "100.64.4.1"
+    k._dhcp.renew = lambda rebind=False: bool(rebind)  # RENEW fails; first REBIND attempt succeeds
+    k._maintain_step()
+    assert (True, True, "100.64.4.1") in rec.calls   # reconciled inside the REBIND loop
+
+
+def test_startup_and_shutdown_drive_a_real_route_withdraw(lk, monkeypatch):
+    # End to end through the REAL DefaultRouteReconciler (not the recording stub):
+    # a stale default in the FIB is actually deleted via route(8), exercising the
+    # mode plumbing (default_route_mode -> constructed reconciler) and the withdraw.
+    from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
+    monkeypatch.setattr(lk.time, "sleep", lambda *_a, **_k: None)
+    fake = FakeRoute(initial=RGW)
+    monkeypatch.setattr(lk.subprocess, "run", fake.run)
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    k._capture.start = lambda: True
+    k._capture.stop = lambda: None
+    k._signals.request_stop()          # exit at once -> startup + shutdown non-master withdraw
+    assert k.run() == 0
+    assert "delete" in fake.verbs and fake.gw is None

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1358,6 +1358,29 @@ def test_rebind_loop_drives_default_route_reconcile(lk):
     assert (True, True, "100.64.4.1") in rec.calls   # reconciled inside the REBIND loop
 
 
+def test_renew_success_reconciles_changed_gateway_immediately(lk):
+    # A same-address renew that carries a new option-3 gateway must hit the FIB at
+    # once, not at the next per-tick poll: otherwise the default keeps routing via
+    # the old gateway for up to HB_REFRESH after the lease already changed.
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    k._probe_carp_master = lambda: True
+    k._hb = lambda: None
+    k._arp_nudge = lambda *_a, **_k: None
+    k._hold_lease = lambda _s: True             # skip the T1 wait (its own reconcile too)
+    k._dhcp.timing = lambda: (0, 100, "test")
+    k._dhcp.binding.yiaddr = "100.64.4.7"
+    k._dhcp.binding.lease_router = "100.64.4.1"
+
+    def fake_renew(_rebind=False):
+        k._dhcp.binding.lease_router = "100.64.4.9"   # the renewal carries a new gateway
+        return True
+    k._dhcp.renew = fake_renew
+    k._maintain_step()
+    assert (True, True, "100.64.4.9") in rec.calls   # reconciled with the NEW gateway at once
+
+
 def test_startup_and_shutdown_drive_a_real_route_withdraw(lk, monkeypatch):
     # End to end through the REAL DefaultRouteReconciler (not the recording stub):
     # a stale default in the FIB is actually deleted via route(8), exercising the

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1091,3 +1091,71 @@ def test_backoff_jitter(lk):
     vals = [lk._jittered(8) for _ in range(200)]
     assert all(6.0 <= v <= 10.0 for v in vals)   # 8 * [0.75, 1.25]
     assert len(set(vals)) > 1
+
+
+# ---- default-route ownership wiring (keeper <-> DefaultRouteReconciler) ----
+
+class _RecordingReconciler:
+    """Stand-in for DefaultRouteReconciler that records reconcile() args, so the
+    keeper-side wiring can be asserted without a real route(8) probe."""
+    def __init__(self, enabled=True):
+        self.enabled = enabled
+        self.calls = []
+
+    def reconcile(self, is_master, bound, gateway):
+        self.calls.append((is_master, bound, gateway))
+
+
+def test_default_route_mode_off_is_inert(lk):
+    # The default keeper is mode=off: the reconciler reports itself disabled and
+    # the keeper never calls it (no CARP probe, no FIB write).
+    k = _keeper(lk, vhid=254)
+    assert k._defroute.enabled is False
+    k._defroute = _RecordingReconciler(enabled=False)
+    k._probe_carp_master = lambda: True
+    k._reconcile_default_route()
+    assert k._defroute.calls == []
+
+
+def test_default_route_forwards_role_bound_gateway(lk):
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    k._dhcp.binding.yiaddr = "100.64.4.7"
+    k._dhcp.binding.router = "100.64.4.1"
+    k._reconcile_default_route(master=True)
+    assert rec.calls == [(True, True, "100.64.4.1")]
+
+
+def test_default_route_bound_keyed_on_yiaddr_not_router(lk):
+    # binding.router is a sticky hint that survives a lease loss; bound must be
+    # keyed on yiaddr, so a lost lease (yiaddr None, router still set) reconciles
+    # as unbound and the reconciler withdraws.
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    k._dhcp.binding.yiaddr = None
+    k._dhcp.binding.router = "100.64.4.1"    # stale last-known gateway
+    k._reconcile_default_route(master=True)
+    assert rec.calls == [(True, False, "100.64.4.1")]
+
+
+def test_default_route_probes_role_when_not_supplied(lk):
+    k = _keeper(lk, vhid=254, default_route_mode="observe")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    k._probe_carp_master = lambda: False
+    k._dhcp.binding.yiaddr = "100.64.4.7"
+    k._dhcp.binding.router = "100.64.4.1"
+    k._reconcile_default_route()             # no master arg -> probe it
+    assert rec.calls == [(False, True, "100.64.4.1")]
+
+
+def test_default_route_needs_vhid(lk):
+    # No vhid -> no CARP role to key on -> reconcile is a no-op even in enforce.
+    k = _keeper(lk, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    k._probe_carp_master = lambda: True
+    k._reconcile_default_route(master=True)
+    assert rec.calls == []

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1194,41 +1194,33 @@ def test_hold_lease_tick_drives_default_route_reconcile(lk):
     assert (True, True, "100.64.4.1") in rec.calls
 
 
-def test_acquire_step_reconciles_when_unbound(lk):
-    # A former master that lost its lease withdraws on the unbound arm (bound=False);
-    # the bound-path tick never runs there.
+def test_maintain_step_head_withdraws_when_unbound(lk):
+    # The loop head withdraws any owned default whenever unbound (the role is
+    # irrelevant, so master=False, no probe) before the acquire arm runs.
     k = _keeper(lk, vhid=254, default_route_mode="enforce")
     rec = _RecordingReconciler()
     k._defroute = rec
-    k._ensure_sniffer = lambda: None
-    k._probe_carp_master = lambda: True
-    k._iface_link_up = lambda: None            # unreadable carrier -> straight to the acquire
-    k._dhcp.acquire = lambda _rip: False
-    k._sleep_interruptible = lambda _s: True
+    k._acquire_step = lambda: None             # isolate the head reconcile
     k._dhcp.binding.yiaddr = None              # unbound
-    k._acquire_step()
-    # unbound -> withdraw regardless of role, so the arm passes master=False (no probe)
-    assert rec.calls == [(False, False, k._dhcp.binding.lease_router)]   # bound=False
+    k._dhcp.binding.lease_router = "100.64.4.1"
+    k._maintain_step()
+    assert rec.calls == [(False, False, "100.64.4.1")]   # withdraw at the head, no probe
 
 
-def test_acquire_success_reconciles_immediately(lk):
-    # A fresh acquire owns the default at once, not after the first HB_REFRESH tick.
+def test_maintain_step_head_installs_when_bound(lk):
+    # Once bound, the loop head installs the default by role. A fresh acquire's
+    # immediacy comes from run() re-entering _maintain_step at once after the bind,
+    # so no separate per-acquire reconcile is needed.
     k = _keeper(lk, vhid=254, default_route_mode="enforce")
     rec = _RecordingReconciler()
     k._defroute = rec
-    k._ensure_sniffer = lambda: None
     k._probe_carp_master = lambda: True
-    k._iface_link_up = lambda: True
-    k._dhcp.binding.yiaddr = None
+    k._dhcp.timing = lambda: (0, 100, "test")
+    k._hold_lease = lambda _s: False           # stop right after the head reconcile
+    k._dhcp.binding.yiaddr = "100.64.4.7"      # bound (as if the acquire just completed)
     k._dhcp.binding.lease_router = "100.64.4.1"
-
-    def fake_acquire(_rip):
-        k._dhcp.binding.yiaddr = "100.64.4.7"   # the acquire binds
-        return True
-    k._dhcp.acquire = fake_acquire
-    k._acquire_step()
-    # pre-acquire reconcile saw unbound (master=False, no probe); the post-acquire one installs
-    assert rec.calls == [(False, False, "100.64.4.1"), (True, True, "100.64.4.1")]
+    k._maintain_step()
+    assert rec.calls == [(True, True, "100.64.4.1")]   # installed by role at the head
 
 
 def test_shutdown_withdraws_owned_default(lk, monkeypatch):
@@ -1245,26 +1237,24 @@ def test_shutdown_withdraws_owned_default(lk, monkeypatch):
     assert (False, False, None) in rec.calls   # reconcile as non-master -> withdraw
 
 
-def test_fail_stop_withdraw_default_removes_stale_default(lk, monkeypatch):
-    # The startup fail-stop path is a standalone staticmethod (no Keeper, no capture
-    # backend) so main() runs it BEFORE the backend preflight / arg checks -- any of
-    # which can exit before Keeper.run(). A crashed enforcing predecessor's default
-    # is withdrawn here even when the backend can no longer load.
+def test_withdraw_if_enabled_removes_stale_default(lk, monkeypatch):
+    # The startup fail-stop lives on the reconciler (no Keeper, no capture backend),
+    # so main() runs it BEFORE the backend preflight / arg checks -- any of which can
+    # exit before Keeper.run(). A crashed enforcing predecessor's default is
+    # withdrawn here even when the backend can no longer load.
     from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
     fake = FakeRoute(initial=RGW)
     monkeypatch.setattr(lk.subprocess, "run", fake.run)
-    lk.Keeper.fail_stop_withdraw_default("enforce", vhid=254)
+    lk.DefaultRouteReconciler.withdraw_if_enabled("enforce")
     assert "delete" in fake.verbs and fake.gw is None
 
 
-def test_fail_stop_withdraw_default_inert_when_off_or_no_vhid(lk, monkeypatch):
-    # Gated exactly like _reconcile_default_route: off mode and no-vhid never touch
-    # the FIB (off is inert; no vhid means no CARP role to own a default by).
+def test_withdraw_if_enabled_off_is_inert(lk, monkeypatch):
+    # off mode never touches the FIB (the vhid gate is main()'s, not the entry point's).
     from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
     fake = FakeRoute(initial=RGW)
     monkeypatch.setattr(lk.subprocess, "run", fake.run)
-    lk.Keeper.fail_stop_withdraw_default("off", vhid=254)       # off -> inert
-    lk.Keeper.fail_stop_withdraw_default("enforce", vhid=None)   # no vhid -> inert
+    lk.DefaultRouteReconciler.withdraw_if_enabled("off")
     assert fake.gw == RGW and not fake.calls
 
 
@@ -1379,9 +1369,10 @@ def test_renew_nak_forgets_binding(lk):
     assert c.binding.server == "100.64.4.1"  # hint kept
 
 
-def test_renew_nak_withdraws_default_and_reacquires(lk):
-    # A DHCPNAK at T1 withdraws the default at once (bound=False) and drops to the
-    # unbound arm -- it must NOT enter the REBIND loop still advertising the default.
+def test_renew_nak_leaves_binding_for_head_to_withdraw(lk):
+    # A DHCPNAK at T1 forgets the binding and must NOT enter the REBIND loop still
+    # advertising the default; the next _maintain_step is then unbound and its loop
+    # head withdraws.
     k = _keeper(lk, vhid=254, default_route_mode="enforce")
     rec = _RecordingReconciler()
     k._defroute = rec
@@ -1389,6 +1380,7 @@ def test_renew_nak_withdraws_default_and_reacquires(lk):
     k._hb = lambda: None
     k._arp_nudge = lambda *_a, **_k: None
     k._hold_lease = lambda _s: True
+    k._acquire_step = lambda: None              # isolate the head on the unbound re-entry
     k._dhcp.timing = lambda: (0, 100, "test")
     k._dhcp.binding.yiaddr = "100.64.4.7"
     k._dhcp.binding.lease_router = "100.64.4.1"
@@ -1401,14 +1393,17 @@ def test_renew_nak_withdraws_default_and_reacquires(lk):
         k._dhcp.expire()   # a NAK forgets the binding
         return False
     k._dhcp.renew = fake_renew
-    k._maintain_step()
-    assert (True, False, "100.64.4.1") in rec.calls   # withdrew (bound=False)
-    assert rebinds["n"] == 0                            # never entered the REBIND loop
+    k._maintain_step()                          # bound: head installs, then RENEW NAK
+    assert k._dhcp.binding.yiaddr is None        # NAK cleared it
+    assert rebinds["n"] == 0                      # never entered the REBIND loop
+    k._maintain_step()                          # unbound: head withdraws
+    assert (False, False, "100.64.4.1") in rec.calls
 
 
-def test_rebind_nak_withdraws_default_and_reacquires(lk):
-    # A NAK during the REBIND window is likewise a revoke: withdraw and re-acquire
-    # instead of spinning REBIND to T2 with the default still installed.
+def test_rebind_nak_leaves_binding_for_head_to_withdraw(lk):
+    # A NAK during the REBIND window likewise forgets the binding; the next
+    # _maintain_step is unbound and its loop head withdraws, rather than spinning
+    # REBIND to T2 with the default still installed.
     k = _keeper(lk, vhid=254, default_route_mode="enforce")
     rec = _RecordingReconciler()
     k._defroute = rec
@@ -1417,6 +1412,7 @@ def test_rebind_nak_withdraws_default_and_reacquires(lk):
     k._arp_nudge = lambda *_a, **_k: None
     k._hold_lease = lambda _s: True
     k._sleep_interruptible = lambda _s: True
+    k._acquire_step = lambda: None              # isolate the head on the unbound re-entry
     k._dhcp.timing = lambda: (0, 100, "test")
     k._dhcp.binding.yiaddr = "100.64.4.7"
     k._dhcp.binding.lease_router = "100.64.4.1"
@@ -1427,21 +1423,23 @@ def test_rebind_nak_withdraws_default_and_reacquires(lk):
         k._dhcp.expire()       # the first REBIND attempt gets a NAK
         return False
     k._dhcp.renew = fake_renew
-    k._maintain_step()
-    assert (True, False, "100.64.4.1") in rec.calls   # withdrew after the REBIND NAK
+    k._maintain_step()                          # bound -> REBIND -> NAK forgets the binding
+    assert k._dhcp.binding.yiaddr is None
+    k._maintain_step()                          # unbound: head withdraws
+    assert (False, False, "100.64.4.1") in rec.calls
 
 
-def test_renew_success_reconciles_changed_gateway_immediately(lk):
-    # A same-address renew that carries a new option-3 gateway must hit the FIB at
-    # once, not at the next per-tick poll: otherwise the default keeps routing via
-    # the old gateway for up to HB_REFRESH after the lease already changed.
+def test_renew_changed_gateway_reconciled_by_next_head(lk):
+    # A renew that carries a new option-3 gateway is picked up by the loop-head
+    # reconcile on the next _maintain_step entry (run() re-enters at once), so a
+    # gateway change hits the FIB promptly, not only at the next per-tick poll.
     k = _keeper(lk, vhid=254, default_route_mode="enforce")
     rec = _RecordingReconciler()
     k._defroute = rec
     k._probe_carp_master = lambda: True
     k._hb = lambda: None
     k._arp_nudge = lambda *_a, **_k: None
-    k._hold_lease = lambda _s: True             # skip the T1 wait (its own reconcile too)
+    k._hold_lease = lambda _s: True
     k._dhcp.timing = lambda: (0, 100, "test")
     k._dhcp.binding.yiaddr = "100.64.4.7"
     k._dhcp.binding.lease_router = "100.64.4.1"
@@ -1450,15 +1448,16 @@ def test_renew_success_reconciles_changed_gateway_immediately(lk):
         k._dhcp.binding.lease_router = "100.64.4.9"   # the renewal carries a new gateway
         return True
     k._dhcp.renew = fake_renew
-    k._maintain_step()
-    assert (True, True, "100.64.4.9") in rec.calls   # reconciled with the NEW gateway at once
+    k._maintain_step()   # head reconciles the OLD gw; renew then changes it to NEW
+    k._maintain_step()   # head reconciles the NEW gw
+    assert (True, True, "100.64.4.9") in rec.calls
 
 
 def test_shutdown_drives_a_real_route_withdraw(lk, monkeypatch):
     # End to end through the REAL DefaultRouteReconciler (not the recording stub):
     # on shutdown an owned default is actually deleted via route(8), exercising the
     # mode plumbing (default_route_mode -> constructed reconciler) and the withdraw.
-    # (The startup counterpart is Keeper.fail_stop_withdraw_default, tested above.)
+    # (The startup counterpart is DefaultRouteReconciler.withdraw_if_enabled, tested above.)
     from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
     monkeypatch.setattr(lk.time, "sleep", lambda *_a, **_k: None)
     fake = FakeRoute(initial=RGW)

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1258,6 +1258,29 @@ def test_withdraw_if_enabled_off_is_inert(lk, monkeypatch):
     assert fake.gw == RGW and not fake.calls
 
 
+def test_duplicate_start_guards_before_any_withdraw(lk, monkeypatch):
+    # Regression: the startup fail-stop withdraw must run AFTER the single-instance
+    # guard, so a duplicate start (pidfile held by the live owner) exits "already
+    # running" WITHOUT deleting the owner's live default. Assert the guard fires and
+    # no withdraw happens before it.
+    import lease_keeper  # noqa: E402  # pylint: disable=import-outside-toplevel
+    calls = []
+
+    def fake_guard(_path):
+        calls.append("guard")
+        raise SystemExit(4)   # another live instance holds the pidfile
+    monkeypatch.setattr(lease_keeper, "_setup_logging", lambda _logfile: None)
+    monkeypatch.setattr(lease_keeper, "acquire_pidfile", fake_guard)
+    monkeypatch.setattr(lk.DefaultRouteReconciler, "withdraw_if_enabled",
+                        lambda _mode: calls.append("withdraw"))
+    monkeypatch.setattr("sys.argv", [
+        "lease_keeper", "--iface", "eth0", "--chaddr", CHADDR_STR, "--request",
+        "100.64.4.7", "--vhid", "254", "--default-route-mode", "enforce"])
+    with pytest.raises(SystemExit):
+        lease_keeper.main()
+    assert calls == ["guard"]   # guarded first; the live default was never touched
+
+
 def test_lease_router_reset_on_fresh_bind_without_option3(lk):
     # A new lease that omits option 3 must not inherit the previous lease's gateway
     # (the route reconciler installs from lease_router; a stale value would route

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1207,7 +1207,8 @@ def test_acquire_step_reconciles_when_unbound(lk):
     k._sleep_interruptible = lambda _s: True
     k._dhcp.binding.yiaddr = None              # unbound
     k._acquire_step()
-    assert rec.calls == [(True, False, k._dhcp.binding.lease_router)]   # bound=False
+    # unbound -> withdraw regardless of role, so the arm passes master=False (no probe)
+    assert rec.calls == [(False, False, k._dhcp.binding.lease_router)]   # bound=False
 
 
 def test_acquire_success_reconciles_immediately(lk):
@@ -1226,8 +1227,8 @@ def test_acquire_success_reconciles_immediately(lk):
         return True
     k._dhcp.acquire = fake_acquire
     k._acquire_step()
-    # pre-acquire reconcile saw unbound; the post-acquire one installs
-    assert rec.calls == [(True, False, "100.64.4.1"), (True, True, "100.64.4.1")]
+    # pre-acquire reconcile saw unbound (master=False, no probe); the post-acquire one installs
+    assert rec.calls == [(False, False, "100.64.4.1"), (True, True, "100.64.4.1")]
 
 
 def test_shutdown_withdraws_owned_default(lk, monkeypatch):

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1244,21 +1244,27 @@ def test_shutdown_withdraws_owned_default(lk, monkeypatch):
     assert (False, False, None) in rec.calls   # reconcile as non-master -> withdraw
 
 
-def test_startup_withdraws_stale_default_before_capture(lk, monkeypatch):
-    # A crashed predecessor's default is withdrawn at startup even if capture
-    # cannot (re)open -- the reconcile runs before the capture-retry loop.
-    monkeypatch.setattr(lk.time, "sleep", lambda *_a, **_k: None)
-    k = _keeper(lk, vhid=254, default_route_mode="enforce")
-    rec = _RecordingReconciler()
-    k._defroute = rec
+def test_fail_stop_withdraw_default_removes_stale_default(lk, monkeypatch):
+    # The startup fail-stop path is a standalone staticmethod (no Keeper, no capture
+    # backend) so main() runs it BEFORE the backend preflight / arg checks -- any of
+    # which can exit before Keeper.run(). A crashed enforcing predecessor's default
+    # is withdrawn here even when the backend can no longer load.
+    from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
+    fake = FakeRoute(initial=RGW)
+    monkeypatch.setattr(lk.subprocess, "run", fake.run)
+    lk.Keeper.fail_stop_withdraw_default("enforce", vhid=254)
+    assert "delete" in fake.verbs and fake.gw is None
 
-    def failing_start():
-        k._signals.request_stop()   # stop after the first failed attempt
-        return False                # capture never opens
-    k._capture.start = failing_start
-    k._capture.stop = lambda: None
-    assert k.run() == 0
-    assert rec.calls[0] == (False, False, None)   # the startup reconcile ran first
+
+def test_fail_stop_withdraw_default_inert_when_off_or_no_vhid(lk, monkeypatch):
+    # Gated exactly like _reconcile_default_route: off mode and no-vhid never touch
+    # the FIB (off is inert; no vhid means no CARP role to own a default by).
+    from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
+    fake = FakeRoute(initial=RGW)
+    monkeypatch.setattr(lk.subprocess, "run", fake.run)
+    lk.Keeper.fail_stop_withdraw_default("off", vhid=254)       # off -> inert
+    lk.Keeper.fail_stop_withdraw_default("enforce", vhid=None)   # no vhid -> inert
+    assert fake.gw == RGW and not fake.calls
 
 
 def test_lease_router_reset_on_fresh_bind_without_option3(lk):
@@ -1447,10 +1453,11 @@ def test_renew_success_reconciles_changed_gateway_immediately(lk):
     assert (True, True, "100.64.4.9") in rec.calls   # reconciled with the NEW gateway at once
 
 
-def test_startup_and_shutdown_drive_a_real_route_withdraw(lk, monkeypatch):
+def test_shutdown_drives_a_real_route_withdraw(lk, monkeypatch):
     # End to end through the REAL DefaultRouteReconciler (not the recording stub):
-    # a stale default in the FIB is actually deleted via route(8), exercising the
+    # on shutdown an owned default is actually deleted via route(8), exercising the
     # mode plumbing (default_route_mode -> constructed reconciler) and the withdraw.
+    # (The startup counterpart is Keeper.fail_stop_withdraw_default, tested above.)
     from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
     monkeypatch.setattr(lk.time, "sleep", lambda *_a, **_k: None)
     fake = FakeRoute(initial=RGW)
@@ -1458,6 +1465,6 @@ def test_startup_and_shutdown_drive_a_real_route_withdraw(lk, monkeypatch):
     k = _keeper(lk, vhid=254, default_route_mode="enforce")
     k._capture.start = lambda: True
     k._capture.stop = lambda: None
-    k._signals.request_stop()          # exit at once -> startup + shutdown non-master withdraw
+    k._signals.request_stop()          # exit at once -> the shutdown non-master withdraw
     assert k.run() == 0
     assert "delete" in fake.verbs and fake.gw is None

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -793,10 +793,10 @@ def test_hold_returns_early_for_asap_renew(lk):
 
 def test_sigusr1_flag_services_nudge_within_a_second(lk, caplog):
     keeper = _nudge_keeper(lk)
-    keeper._nudge_now = True   # what the SIGUSR1 handler sets
+    keeper._signals.nudge = True   # what the SIGUSR1 handler sets
     with caplog.at_level("INFO", logger="lease-keeper"):
         keeper._sleep_interruptible(1)
-    assert keeper._nudge_now is False
+    assert keeper._signals.nudge is False
     assert keeper._nudge.last_nudge > 0
     # Operator-triggered nudges must be visible in the log (the README says so).
     assert any("manual ARP nudge" in r.getMessage() for r in caplog.records)
@@ -812,9 +812,9 @@ def test_sigusr2_flag_rechecks_carp_role_within_a_second(lk):
     keeper._probe_carp_master = probe
     keeper._poll_carp_role()   # first observation: records backup
     assert keeper._renew_asap is False
-    keeper._poll_role_now = True          # what the SIGUSR2 handler sets on a CARP event
+    keeper._signals.recheck_role = True          # what the SIGUSR2 handler sets on a CARP event
     keeper._sleep_interruptible(1)   # services the flag -> re-check -> transition
-    assert keeper._poll_role_now is False
+    assert keeper._signals.recheck_role is False
     assert keeper._renew_asap is True     # backup->master: renew early
     assert keeper._nudge.last_nudge > 0         # and nudge immediately
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1095,7 +1095,7 @@ def test_backoff_jitter(lk):
 
 # ---- default-route ownership wiring (keeper <-> DefaultRouteReconciler) ----
 
-class _RecordingReconciler:
+class _RecordingReconciler:  # pylint: disable=too-few-public-methods
     """Stand-in for DefaultRouteReconciler that records reconcile() args, so the
     keeper-side wiring can be asserted without a real route(8) probe."""
     def __init__(self, enabled=True):
@@ -1114,7 +1114,7 @@ def test_default_route_mode_off_is_inert(lk):
     k._defroute = _RecordingReconciler(enabled=False)
     k._probe_carp_master = lambda: True
     k._reconcile_default_route()
-    assert k._defroute.calls == []
+    assert not k._defroute.calls
 
 
 def test_default_route_forwards_role_bound_gateway(lk):
@@ -1158,4 +1158,4 @@ def test_default_route_needs_vhid(lk):
     k._defroute = rec
     k._probe_carp_master = lambda: True
     k._reconcile_default_route(master=True)
-    assert rec.calls == []
+    assert not rec.calls

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1122,20 +1122,20 @@ def test_default_route_forwards_role_bound_gateway(lk):
     rec = _RecordingReconciler()
     k._defroute = rec
     k._dhcp.binding.yiaddr = "100.64.4.7"
-    k._dhcp.binding.router = "100.64.4.1"
+    k._dhcp.binding.lease_router = "100.64.4.1"
     k._reconcile_default_route(master=True)
     assert rec.calls == [(True, True, "100.64.4.1")]
 
 
 def test_default_route_bound_keyed_on_yiaddr_not_router(lk):
-    # binding.router is a sticky hint that survives a lease loss; bound must be
-    # keyed on yiaddr, so a lost lease (yiaddr None, router still set) reconciles
-    # as unbound and the reconciler withdraws.
+    # lease_router lingers after a lease loss (expire() clears only yiaddr); bound
+    # must be keyed on yiaddr, so a lost lease (yiaddr None, gateway still set)
+    # reconciles as unbound and the reconciler withdraws.
     k = _keeper(lk, vhid=254, default_route_mode="enforce")
     rec = _RecordingReconciler()
     k._defroute = rec
     k._dhcp.binding.yiaddr = None
-    k._dhcp.binding.router = "100.64.4.1"    # stale last-known gateway
+    k._dhcp.binding.lease_router = "100.64.4.1"    # lingering gateway from the lost lease
     k._reconcile_default_route(master=True)
     assert rec.calls == [(True, False, "100.64.4.1")]
 
@@ -1146,7 +1146,7 @@ def test_default_route_probes_role_when_not_supplied(lk):
     k._defroute = rec
     k._probe_carp_master = lambda: False
     k._dhcp.binding.yiaddr = "100.64.4.7"
-    k._dhcp.binding.router = "100.64.4.1"
+    k._dhcp.binding.lease_router = "100.64.4.1"
     k._reconcile_default_route()             # no master arg -> probe it
     assert rec.calls == [(False, True, "100.64.4.1")]
 
@@ -1161,7 +1161,8 @@ def test_default_route_needs_vhid(lk):
     assert not rec.calls
 
 
-# ---- the reconcile is actually driven from all three main-loop call-sites ----
+# ---- the reconcile is driven from every call-site (startup, bound tick, unbound
+# acquire arm, SIGUSR2 edge, post-acquire, and shutdown) ----
 
 def test_sigusr2_edge_drives_default_route_reconcile(lk):
     k = _keeper(lk, vhid=254, default_route_mode="enforce")
@@ -1174,7 +1175,7 @@ def test_sigusr2_edge_drives_default_route_reconcile(lk):
         return True
     k._probe_carp_master = probe
     k._dhcp.binding.yiaddr = "100.64.4.7"
-    k._dhcp.binding.router = "100.64.4.1"
+    k._dhcp.binding.lease_router = "100.64.4.1"
     k._signals.request_recheck_role()          # what the CARP syshook's SIGUSR2 sets
     k._sleep_interruptible(1)
     assert rec.calls == [(True, True, "100.64.4.1")]   # reconciled on the failover edge
@@ -1188,7 +1189,7 @@ def test_hold_lease_tick_drives_default_route_reconcile(lk):
     k._probe_carp_master = lambda: True
     k._sleep_interruptible = lambda _s: True   # one chunk, no real sleep
     k._dhcp.binding.yiaddr = "100.64.4.7"
-    k._dhcp.binding.router = "100.64.4.1"
+    k._dhcp.binding.lease_router = "100.64.4.1"
     k._hold_lease(1)
     assert (True, True, "100.64.4.1") in rec.calls
 
@@ -1206,4 +1207,90 @@ def test_acquire_step_reconciles_when_unbound(lk):
     k._sleep_interruptible = lambda _s: True
     k._dhcp.binding.yiaddr = None              # unbound
     k._acquire_step()
-    assert rec.calls == [(True, False, k._dhcp.binding.router)]   # bound=False
+    assert rec.calls == [(True, False, k._dhcp.binding.lease_router)]   # bound=False
+
+
+def test_acquire_success_reconciles_immediately(lk):
+    # A fresh acquire owns the default at once, not after the first HB_REFRESH tick.
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    k._ensure_sniffer = lambda: None
+    k._probe_carp_master = lambda: True
+    k._iface_link_up = lambda: True
+    k._dhcp.binding.yiaddr = None
+    k._dhcp.binding.lease_router = "100.64.4.1"
+
+    def fake_acquire(_rip):
+        k._dhcp.binding.yiaddr = "100.64.4.7"   # the acquire binds
+        return True
+    k._dhcp.acquire = fake_acquire
+    k._acquire_step()
+    # pre-acquire reconcile saw unbound; the post-acquire one installs
+    assert rec.calls == [(True, False, "100.64.4.1"), (True, True, "100.64.4.1")]
+
+
+def test_shutdown_withdraws_owned_default(lk, monkeypatch):
+    # Stopping an enforcing keeper relinquishes its default so it is not left in
+    # the FIB (and redistributed by FRR) with nothing managing it.
+    monkeypatch.setattr(lk.time, "sleep", lambda *_a, **_k: None)
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    k._capture.start = lambda: True
+    k._capture.stop = lambda: None
+    k._signals.request_stop()          # exit at once -> straight to the shutdown path
+    assert k.run() == 0
+    assert (False, False, None) in rec.calls   # reconcile as non-master -> withdraw
+
+
+def test_startup_withdraws_stale_default_before_capture(lk, monkeypatch):
+    # A crashed predecessor's default is withdrawn at startup even if capture
+    # cannot (re)open -- the reconcile runs before the capture-retry loop.
+    monkeypatch.setattr(lk.time, "sleep", lambda *_a, **_k: None)
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+
+    def failing_start():
+        k._signals.request_stop()   # stop after the first failed attempt
+        return False                # capture never opens
+    k._capture.start = failing_start
+    k._capture.stop = lambda: None
+    assert k.run() == 0
+    assert rec.calls[0] == (False, False, None)   # the startup reconcile ran first
+
+
+def test_lease_router_reset_on_fresh_bind_without_option3(lk):
+    # A new lease that omits option 3 must not inherit the previous lease's gateway
+    # (the route reconciler installs from lease_router; a stale value would route
+    # the new lease via the old, possibly wrong-subnet, gateway).
+    c = _client(lk)
+    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1"))
+    assert c.binding.lease_router == "100.64.4.1"
+    c.adopt(lk.DhcpReply(lk.ACK, "100.64.5.7", "100.64.5.1", 1800, None, None, None))  # new addr, no opt 3
+    assert c.binding.lease_router is None      # reset -> reconciler withdraws, does not install stale
+    assert c.binding.router == "100.64.4.1"    # the sticky nudge/log hint is untouched
+
+
+def test_lease_router_kept_across_option3_less_renew(lk):
+    # A RENEW of the SAME lease that omits option 3 keeps the current gateway.
+    c = _client(lk)
+    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1"))
+    c._absorb_reply(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, None), 1800)
+    assert c.binding.lease_router == "100.64.4.1"
+
+
+def test_failed_dora_clears_unconfirmed_offer(lk):
+    # A NAK after the OFFER must not leave the offered address in yiaddr: the
+    # maintain loop reads a set yiaddr as bound and would then renew -- and the
+    # route reconciler install a default for -- a lease that was never confirmed.
+    c = _client(lk)
+    c._ensure_sniffer = lambda: None
+    replies = iter([
+        lk.DhcpReply(lk.OFFER, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1"),  # OFFER
+        lk.DhcpReply(lk.NAK, None, "100.64.4.1", None, None, None, None),                     # REQUEST -> NAK
+    ])
+    c._wait_for_dhcp_reply = lambda want, timeout: next(replies, None)
+    assert c.dora("100.64.4.7") is False
+    assert c.binding.yiaddr is None   # cleared -> re-acquire, never a phantom bound

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1358,6 +1358,72 @@ def test_rebind_loop_drives_default_route_reconcile(lk):
     assert (True, True, "100.64.4.1") in rec.calls   # reconciled inside the REBIND loop
 
 
+def test_renew_nak_forgets_binding(lk):
+    # A DHCPNAK on renew revokes the lease (RFC 2131 4.4.5 -> INIT): the binding is
+    # forgotten so the caller withdraws the default and re-acquires, rather than
+    # REBINDing an address the server refused. Hints stay for the re-DORA (expire()).
+    c = _client(lk)
+    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1"))
+    c._ensure_sniffer = lambda: None
+    c._wait_for_dhcp_reply = lambda _want, _timeout: lk.DhcpReply(
+        lk.NAK, None, "100.64.4.1", None, None, None, None)
+    assert c.renew() is False
+    assert c.binding.yiaddr is None          # forgotten -> reconcile withdraws, next step re-acquires
+    assert c.binding.server == "100.64.4.1"  # hint kept
+
+
+def test_renew_nak_withdraws_default_and_reacquires(lk):
+    # A DHCPNAK at T1 withdraws the default at once (bound=False) and drops to the
+    # unbound arm -- it must NOT enter the REBIND loop still advertising the default.
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    k._probe_carp_master = lambda: True
+    k._hb = lambda: None
+    k._arp_nudge = lambda *_a, **_k: None
+    k._hold_lease = lambda _s: True
+    k._dhcp.timing = lambda: (0, 100, "test")
+    k._dhcp.binding.yiaddr = "100.64.4.7"
+    k._dhcp.binding.lease_router = "100.64.4.1"
+    rebinds = {"n": 0}
+
+    def fake_renew(rebind=False):
+        if rebind:
+            rebinds["n"] += 1
+            return False
+        k._dhcp.expire()   # a NAK forgets the binding
+        return False
+    k._dhcp.renew = fake_renew
+    k._maintain_step()
+    assert (True, False, "100.64.4.1") in rec.calls   # withdrew (bound=False)
+    assert rebinds["n"] == 0                            # never entered the REBIND loop
+
+
+def test_rebind_nak_withdraws_default_and_reacquires(lk):
+    # A NAK during the REBIND window is likewise a revoke: withdraw and re-acquire
+    # instead of spinning REBIND to T2 with the default still installed.
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    k._probe_carp_master = lambda: True
+    k._hb = lambda: None
+    k._arp_nudge = lambda *_a, **_k: None
+    k._hold_lease = lambda _s: True
+    k._sleep_interruptible = lambda _s: True
+    k._dhcp.timing = lambda: (0, 100, "test")
+    k._dhcp.binding.yiaddr = "100.64.4.7"
+    k._dhcp.binding.lease_router = "100.64.4.1"
+
+    def fake_renew(rebind=False):
+        if not rebind:
+            return False       # RENEW at T1 times out -> enter the REBIND loop
+        k._dhcp.expire()       # the first REBIND attempt gets a NAK
+        return False
+    k._dhcp.renew = fake_renew
+    k._maintain_step()
+    assert (True, False, "100.64.4.1") in rec.calls   # withdrew after the REBIND NAK
+
+
 def test_renew_success_reconciles_changed_gateway_immediately(lk):
     # A same-address renew that carries a new option-3 gateway must hit the FIB at
     # once, not at the next per-tick poll: otherwise the default keeps routing via

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -25,30 +25,33 @@ class FakeRoute:
         self.lying = set(lying)    # verbs that exit 0 but do NOT mutate the FIB
 
     def run(self, cmd, **_kwargs):  # capture_output / errors / timeout -- ignored
+        # One return (accumulate rc/out/err) to keep the verb branches readable
+        # without tripping too-many-return-statements.
         self.calls.append(list(cmd))
         verb = cmd[2]  # ["/sbin/route","-n",verb,"-inet","default"[,gw]]
+        rc, out, err = 0, "", ""
         if verb in self.broken:  # a real failure: stuck route / bad socket, not a no-op
-            return types.SimpleNamespace(
-                returncode=1, stdout="", stderr="route: writing to routing socket: permission denied")
-        if verb == "get":
-            has = self.gw is not None  # empty table exits non-zero (one return keeps pylint happy)
-            return types.SimpleNamespace(
-                returncode=0 if has else 1,
-                stdout=f"   gateway: {self.gw}\n   flags: <UP,GATEWAY>\n" if has else "",
-                stderr="" if has else "route: not in table")
-        if verb == "add":
+            rc, err = 1, "route: writing to routing socket: permission denied"
+        elif verb == "get":
+            has = self.gw is not None  # empty table exits non-zero
+            rc = 0 if has else 1
+            out = f"   gateway: {self.gw}\n   flags: <UP,GATEWAY>\n" if has else ""
+            err = "" if has else "route: not in table"
+        elif verb == "add":
             if self.gw is not None:  # FreeBSD: add fails when a default already exists
-                return types.SimpleNamespace(
-                    returncode=1, stdout="", stderr="route: writing to routing socket: File exists")
-            if verb not in self.lying:  # a lying add exits 0 but leaves the FIB unchanged
+                rc, err = 1, "route: writing to routing socket: File exists"
+            elif verb not in self.lying:  # a lying add exits 0 but leaves the FIB unchanged
                 self.gw = cmd[-1]
-            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
-        if verb == "delete":
+        elif verb == "change":
+            if self.gw is None:  # FreeBSD: change fails when no route exists to change
+                rc, err = 1, "route: change net default: not in table"
+            else:
+                self.gw = cmd[-1]  # an on-link gateway swaps in place; off-link is broken={"change"}
+        elif verb == "delete":
             existed = self.gw is not None
             self.gw = None
-            return types.SimpleNamespace(
-                returncode=0 if existed else 1, stdout="", stderr="" if existed else "not in table")
-        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+            rc, err = (0, "") if existed else (1, "not in table")
+        return types.SimpleNamespace(returncode=rc, stdout=out, stderr=err)
 
     @property
     def verbs(self):
@@ -132,7 +135,8 @@ def test_enforce_corrects_wrong_nexthop(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW2)
     rec.reconcile(True, True, GW)
     assert fake.gw == GW
-    assert "delete" in fake.verbs and "add" in fake.verbs
+    # atomic replace via `route change`: no delete-then-add, so no no-default gap
+    assert fake.verbs == ["get", "change", "get"]
 
 
 def test_enforce_backup_withdraws(lk, monkeypatch):
@@ -331,14 +335,16 @@ def test_failed_withdraw_is_logged_and_default_stays(lk, monkeypatch, caplog):
     assert not any("withdrew default" in r.getMessage() for r in caplog.records)
 
 
-def test_stuck_delete_on_replace_keeps_old_and_errors(lk, monkeypatch, caplog):
-    # the delete of the old default is stuck, so the add of the new one fails
-    # "already in table" and the FIB keeps the OLD gateway -- the confirm catches
-    # what a non-zero exit alone could not tell from a benign no-op.
-    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, broken={"delete"})
+def test_rejected_change_on_replace_keeps_old_and_errors(lk, monkeypatch, caplog):
+    # the atomic `route change` is rejected (bench-confirmed on FreeBSD 14.3 when
+    # the new gateway is not on-link, e.g. a cross-subnet lease whose interface has
+    # not moved yet): the FIB keeps the OLD default -- never torn down or
+    # black-holed -- and the confirm read-back surfaces that the new one is not in.
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, broken={"change"})
     with caplog.at_level("ERROR", logger="lease-keeper"):
-        rec.reconcile(True, True, GW2)  # replace GW -> GW2
-    assert fake.gw == GW  # old gateway kept, not silently overwritten
+        rec.reconcile(True, True, GW2)  # replace GW -> GW2, but the change is rejected
+    assert fake.gw == GW  # old gateway kept intact, not withdrawn
+    assert "delete" not in fake.verbs  # the working default is never removed on a failed replace
     assert any("failed to install default via " + GW2 in r.getMessage() for r in caplog.records)
 
 

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -19,14 +19,14 @@ class FakeRoute:
         self.gw = initial
         self.calls = []
 
-    def run(self, cmd, **kwargs):  # capture_output / errors / timeout -- ignored
+    def run(self, cmd, **_kwargs):  # capture_output / errors / timeout -- ignored
         self.calls.append(list(cmd))
         verb = cmd[2]  # ["/sbin/route","-n",verb,"-inet","default"[,gw]]
         if verb == "get":
             if self.gw is None:
                 return types.SimpleNamespace(returncode=1, stdout="", stderr="not in table")
             return types.SimpleNamespace(
-                returncode=0, stdout="   gateway: %s\n   flags: <UP,GATEWAY>\n" % self.gw, stderr="")
+                returncode=0, stdout=f"   gateway: {self.gw}\n   flags: <UP,GATEWAY>\n", stderr="")
         if verb == "add":
             self.gw = cmd[-1]
             return types.SimpleNamespace(returncode=0, stdout="", stderr="")
@@ -54,7 +54,7 @@ def test_off_never_touches_fib(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "off")
     rec.reconcile(True, True, GW)
     assert fake.gw is None
-    assert fake.calls == []  # off short-circuits before any route call
+    assert not fake.calls  # off short-circuits before any route call
 
 
 def test_observe_reads_but_does_not_mutate(lk, monkeypatch):

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -1,0 +1,181 @@
+"""Unit tests for leasekeeper.route.DefaultRouteReconciler.
+
+A FakeRoute stands in for /sbin/route (monkeypatched onto subprocess.run) and
+tracks a single default nexthop plus the verbs issued, so tests assert both the
+resulting FIB and that idempotent / observe / off paths issue no mutation.
+
+Tests reach into private state by design; comments over per-test docstrings."""
+# pylint: disable=protected-access, missing-function-docstring
+import types
+
+GW = "185.41.66.1"
+GW2 = "185.41.66.9"
+
+
+class FakeRoute:
+    """In-memory stand-in for `/sbin/route`: one default nexthop, verb log."""
+
+    def __init__(self, initial=None):
+        self.gw = initial
+        self.calls = []
+
+    def run(self, cmd, **kwargs):  # capture_output / errors / timeout -- ignored
+        self.calls.append(list(cmd))
+        verb = cmd[2]  # ["/sbin/route","-n",verb,"-inet","default"[,gw]]
+        if verb == "get":
+            if self.gw is None:
+                return types.SimpleNamespace(returncode=1, stdout="", stderr="not in table")
+            return types.SimpleNamespace(
+                returncode=0, stdout="   gateway: %s\n   flags: <UP,GATEWAY>\n" % self.gw, stderr="")
+        if verb == "add":
+            self.gw = cmd[-1]
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        if verb == "delete":
+            existed = self.gw is not None
+            self.gw = None
+            return types.SimpleNamespace(
+                returncode=0 if existed else 1, stdout="", stderr="" if existed else "not in table")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    @property
+    def verbs(self):
+        return [c[2] for c in self.calls]
+
+
+def _rec(lk, monkeypatch, mode, initial=None, **kw):
+    fake = FakeRoute(initial)
+    monkeypatch.setattr(lk.subprocess, "run", fake.run)
+    return lk.DefaultRouteReconciler(mode=mode, **kw), fake
+
+
+# ---- off / observe never mutate ----
+
+def test_off_never_touches_fib(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "off")
+    rec.reconcile(True, True, GW)
+    assert fake.gw is None
+    assert fake.calls == []  # off short-circuits before any route call
+
+
+def test_observe_reads_but_does_not_mutate(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "observe")
+    rec.reconcile(True, True, GW)          # would-install
+    assert fake.gw is None                 # no mutation
+    assert "add" not in fake.verbs and "delete" not in fake.verbs
+    rec2, fake2 = _rec(lk, monkeypatch, "observe", initial=GW)
+    rec2.reconcile(False, False, None)     # would-withdraw
+    assert fake2.gw == GW
+    assert "delete" not in fake2.verbs
+
+
+# ---- enforce: install / withdraw / correct / idempotent ----
+
+def test_enforce_master_installs(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce")
+    rec.reconcile(True, True, GW)
+    assert fake.gw == GW
+    assert "add" in fake.verbs
+
+
+def test_enforce_idempotent_no_change_when_correct(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW)
+    rec.reconcile(True, True, GW)
+    assert fake.gw == GW
+    assert fake.verbs == ["get"]  # compare-then-act: no add/delete, no churn
+
+
+def test_enforce_corrects_wrong_nexthop(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW2)
+    rec.reconcile(True, True, GW)
+    assert fake.gw == GW
+    assert "delete" in fake.verbs and "add" in fake.verbs
+
+
+def test_enforce_backup_withdraws(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW)
+    rec.reconcile(False, False, None)
+    assert fake.gw is None
+    assert "delete" in fake.verbs
+
+
+def test_enforce_backup_absent_is_noop(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce")
+    rec.reconcile(False, False, None)
+    assert fake.gw is None
+    assert fake.verbs == ["get"]  # nothing to withdraw
+
+
+def test_master_without_lease_withdraws_despite_sticky_gateway(lk, monkeypatch):
+    # bound=False even though a (sticky) gateway is still known: must not keep
+    # the default -- this is the MasterNoLease fail-stop.
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW)
+    rec.reconcile(True, False, GW)
+    assert fake.gw is None
+    assert "delete" in fake.verbs
+
+
+# ---- unreadable role: fail-safe install, fail-closed withdraw ----
+
+def test_unreadable_role_never_installs(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", unreadable_role_strikes=3)
+    for _ in range(10):
+        rec.reconcile(None, True, GW)
+    assert fake.gw is None
+    assert "add" not in fake.verbs
+
+
+def test_unreadable_role_withdraws_after_strike_limit(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, unreadable_role_strikes=3)
+    rec.reconcile(None, True, GW)
+    rec.reconcile(None, True, GW)
+    assert fake.gw == GW              # held for the first strike_limit-1 checks
+    assert "delete" not in fake.verbs
+    rec.reconcile(None, True, GW)     # third strike -> fail closed
+    assert fake.gw is None
+    assert "delete" in fake.verbs
+
+
+def test_definite_role_resets_strikes(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, unreadable_role_strikes=3)
+    rec.reconcile(None, True, GW)
+    rec.reconcile(None, True, GW)
+    rec.reconcile(True, True, GW)     # definite read resets the counter
+    rec.reconcile(None, True, GW)     # strike 1 again, not 4
+    assert fake.gw == GW              # still held, not withdrawn
+
+
+# ---- liveness gate (split-brain guard) ----
+
+def test_liveness_false_blocks_install(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", liveness_probe=lambda: False)
+    rec.reconcile(True, True, GW)
+    assert fake.gw is None
+    assert "add" not in fake.verbs
+
+
+def test_liveness_false_withdraws_existing(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, liveness_probe=lambda: False)
+    rec.reconcile(True, True, GW)
+    assert fake.gw is None            # dead-WAN master stops advertising
+
+
+def test_liveness_none_does_not_block(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", liveness_probe=lambda: None)
+    rec.reconcile(True, True, GW)
+    assert fake.gw == GW
+
+
+def test_liveness_exception_does_not_block(lk, monkeypatch):
+    def boom():
+        raise RuntimeError("probe broke")
+    rec, fake = _rec(lk, monkeypatch, "enforce", liveness_probe=boom)
+    rec.reconcile(True, True, GW)
+    assert fake.gw == GW              # a broken probe must not block routing
+
+
+# ---- get-parsing edge cases ----
+
+def test_empty_table_reads_as_no_default(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce")
+    assert rec._fib_default_gateway() is None  # returncode 1 -> None, not a raise
+    assert fake.verbs == ["get"]

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -8,6 +8,8 @@ Tests reach into private state by design; comments over per-test docstrings."""
 # pylint: disable=protected-access, missing-function-docstring
 import types
 
+import pytest
+
 GW = "185.41.66.1"
 GW2 = "185.41.66.9"
 
@@ -15,19 +17,27 @@ GW2 = "185.41.66.9"
 class FakeRoute:
     """In-memory stand-in for `/sbin/route`: one default nexthop, verb log."""
 
-    def __init__(self, initial=None):
+    def __init__(self, initial=None, broken=()):
         self.gw = initial
         self.calls = []
+        self.broken = set(broken)  # verbs that fail with a genuine (non-benign) error
 
     def run(self, cmd, **_kwargs):  # capture_output / errors / timeout -- ignored
         self.calls.append(list(cmd))
         verb = cmd[2]  # ["/sbin/route","-n",verb,"-inet","default"[,gw]]
-        if verb == "get":
-            if self.gw is None:
-                return types.SimpleNamespace(returncode=1, stdout="", stderr="not in table")
+        if verb in self.broken:  # a real failure: stuck route / bad socket, not a no-op
             return types.SimpleNamespace(
-                returncode=0, stdout=f"   gateway: {self.gw}\n   flags: <UP,GATEWAY>\n", stderr="")
+                returncode=1, stdout="", stderr="route: writing to routing socket: permission denied")
+        if verb == "get":
+            has = self.gw is not None  # empty table exits non-zero (one return keeps pylint happy)
+            return types.SimpleNamespace(
+                returncode=0 if has else 1,
+                stdout=f"   gateway: {self.gw}\n   flags: <UP,GATEWAY>\n" if has else "",
+                stderr="" if has else "route: not in table")
         if verb == "add":
+            if self.gw is not None:  # FreeBSD: add fails when a default already exists
+                return types.SimpleNamespace(
+                    returncode=1, stdout="", stderr="route: writing to routing socket: File exists")
             self.gw = cmd[-1]
             return types.SimpleNamespace(returncode=0, stdout="", stderr="")
         if verb == "delete":
@@ -42,8 +52,8 @@ class FakeRoute:
         return [c[2] for c in self.calls]
 
 
-def _rec(lk, monkeypatch, mode, initial=None, **kw):
-    fake = FakeRoute(initial)
+def _rec(lk, monkeypatch, mode, initial=None, broken=(), **kw):
+    fake = FakeRoute(initial, broken=broken)
     monkeypatch.setattr(lk.subprocess, "run", fake.run)
     return lk.DefaultRouteReconciler(mode=mode, **kw), fake
 
@@ -179,3 +189,105 @@ def test_empty_table_reads_as_no_default(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "enforce")
     assert rec._fib_default_gateway() is None  # returncode 1 -> None, not a raise
     assert fake.verbs == ["get"]
+
+
+def test_get_without_gateway_line_reads_absent(lk, monkeypatch):
+    # route get succeeds (rc 0) for an interface-scoped default with no gateway
+    # field (e.g. a point-to-point/PPP default) -- parses as "no default".
+    monkeypatch.setattr(lk.subprocess, "run", lambda *a, **k: types.SimpleNamespace(
+        returncode=0, stdout="   interface: pppoe0\n   flags: <UP>\n", stderr=""))
+    rec = lk.DefaultRouteReconciler(mode="enforce")
+    assert rec._fib_default_gateway() is None
+
+
+def test_get_failure_reads_absent_quietly(lk, monkeypatch, caplog):
+    # a failed / empty-table `route get` is the quiet steady state on a backup:
+    # read as "no default" with NO warning -- route(8) wording varies by
+    # platform, so a stuck op is caught by the install/withdraw confirm instead.
+    monkeypatch.setattr(lk.subprocess, "run", lambda *a, **k: types.SimpleNamespace(
+        returncode=1, stdout="", stderr="route: not in table"))
+    rec = lk.DefaultRouteReconciler(mode="enforce")
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        assert rec._fib_default_gateway() is None
+    assert not [r for r in caplog.records if r.levelname in ("WARNING", "ERROR")]
+
+
+def test_run_swallows_subprocess_exception(lk, monkeypatch):
+    def boom(*_a, **_k):
+        raise OSError("route binary missing")
+    monkeypatch.setattr(lk.subprocess, "run", boom)
+    rec = lk.DefaultRouteReconciler(mode="enforce")
+    assert rec._fib_default_gateway() is None
+    rec.reconcile(True, True, GW)  # must not raise out of the maintain loop
+
+
+# ---- unknown / invalid construction ----
+
+def test_unknown_mode_coerces_to_off_and_warns(lk, monkeypatch, caplog):
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec, fake = _rec(lk, monkeypatch, "bogus")
+    assert rec.mode is lk.DefaultRouteMode.OFF and rec.enabled is False
+    assert any("unknown default-route mode" in r.getMessage() for r in caplog.records)
+    rec.reconcile(True, True, GW)
+    assert not fake.calls  # off is inert: never even reads the FIB
+
+
+def test_valid_mode_maps_through_verbatim(lk, monkeypatch):
+    rec, _ = _rec(lk, monkeypatch, "enforce")
+    assert rec.mode is lk.DefaultRouteMode.ENFORCE and rec.enabled is True
+
+
+def test_mode_is_read_only(lk, monkeypatch):
+    rec, _ = _rec(lk, monkeypatch, "observe")
+    with pytest.raises(AttributeError):
+        rec.mode = lk.DefaultRouteMode.ENFORCE  # set-once, no setter
+
+
+def test_strike_limit_must_be_positive(lk):
+    with pytest.raises(ValueError):
+        lk.DefaultRouteReconciler(mode="enforce", unreadable_role_strikes=0)
+
+
+# ---- a bogus / rogue option-3 gateway is never installed ----
+
+def test_bogus_gateway_is_not_installed(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce")
+    rec.reconcile(True, True, "0.0.0.0")  # rogue / malformed option 3
+    assert fake.gw is None and "add" not in fake.verbs
+
+
+def test_bogus_gateway_withdraws_existing(lk, monkeypatch):
+    # master+bound but an unusable gateway must not KEEP a default it can't honour.
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW)
+    rec.reconcile(True, True, "0.0.0.0")
+    assert fake.gw is None and "delete" in fake.verbs
+
+
+def test_bound_without_gateway_withdraws(lk, monkeypatch):
+    # a lease with no router option (gateway None) cannot back a default -> withdraw,
+    # and _sane_ipv4(None) must be handled, not raise.
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW)
+    rec.reconcile(True, True, None)
+    assert fake.gw is None and "delete" in fake.verbs
+
+
+# ---- a genuine route-command failure is surfaced, not buried as a no-op ----
+
+def test_failed_withdraw_is_logged_and_default_stays(lk, monkeypatch, caplog):
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, broken={"delete"})
+    with caplog.at_level("ERROR", logger="lease-keeper"):
+        rec.reconcile(False, False, None)  # backup -> should withdraw, but delete is stuck
+    assert fake.gw == GW  # the default is still in the FIB (the fail-stop breach we must SEE)
+    assert any("failed to withdraw default" in r.getMessage() for r in caplog.records)
+    assert not any("withdrew default" in r.getMessage() for r in caplog.records)
+
+
+def test_stuck_delete_on_replace_keeps_old_and_errors(lk, monkeypatch, caplog):
+    # the delete of the old default is stuck, so the add of the new one fails
+    # "already in table" and the FIB keeps the OLD gateway -- the confirm catches
+    # what a non-zero exit alone could not tell from a benign no-op.
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, broken={"delete"})
+    with caplog.at_level("ERROR", logger="lease-keeper"):
+        rec.reconcile(True, True, GW2)  # replace GW -> GW2
+    assert fake.gw == GW  # old gateway kept, not silently overwritten
+    assert any("failed to install default via " + GW2 in r.getMessage() for r in caplog.records)

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -183,6 +183,24 @@ def test_unreadable_role_withdraws_after_strike_limit(lk, monkeypatch):
     assert "delete" in fake.verbs
 
 
+def test_unreadable_role_but_unbound_withdraws_immediately(lk, monkeypatch):
+    # Role unreadable AND no lease held: nothing to be master of, so withdraw at
+    # once instead of holding the default through the strike tolerance (which is
+    # reserved for a bound node that might still legitimately be master).
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, unreadable_role_strikes=3)
+    rec.reconcile(None, False, None)   # probe failed, but we hold no lease
+    assert fake.gw is None             # withdrawn on the first call, not after 3 strikes
+    assert "delete" in fake.verbs
+
+
+def test_unreadable_role_with_unusable_gateway_withdraws_immediately(lk, monkeypatch):
+    # Same: an unusable (0.0.0.0) gateway is not a lease to be master of, so an
+    # unreadable role does not earn the strike tolerance -- withdraw now.
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, unreadable_role_strikes=3)
+    rec.reconcile(None, True, "0.0.0.0")
+    assert fake.gw is None and "delete" in fake.verbs
+
+
 def test_definite_role_resets_strikes(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, unreadable_role_strikes=3)
     rec.reconcile(None, True, GW)

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -12,15 +12,17 @@ import pytest
 
 GW = "185.41.66.1"
 GW2 = "185.41.66.9"
+CGNAT_GW = "100.64.4.1"   # the production case: a 100.64/10 single-IP CGNAT WAN
 
 
 class FakeRoute:
     """In-memory stand-in for `/sbin/route`: one default nexthop, verb log."""
 
-    def __init__(self, initial=None, broken=()):
+    def __init__(self, initial=None, broken=(), lying=()):
         self.gw = initial
         self.calls = []
         self.broken = set(broken)  # verbs that fail with a genuine (non-benign) error
+        self.lying = set(lying)    # verbs that exit 0 but do NOT mutate the FIB
 
     def run(self, cmd, **_kwargs):  # capture_output / errors / timeout -- ignored
         self.calls.append(list(cmd))
@@ -38,7 +40,8 @@ class FakeRoute:
             if self.gw is not None:  # FreeBSD: add fails when a default already exists
                 return types.SimpleNamespace(
                     returncode=1, stdout="", stderr="route: writing to routing socket: File exists")
-            self.gw = cmd[-1]
+            if verb not in self.lying:  # a lying add exits 0 but leaves the FIB unchanged
+                self.gw = cmd[-1]
             return types.SimpleNamespace(returncode=0, stdout="", stderr="")
         if verb == "delete":
             existed = self.gw is not None
@@ -52,8 +55,9 @@ class FakeRoute:
         return [c[2] for c in self.calls]
 
 
-def _rec(lk, monkeypatch, mode, initial=None, broken=(), **kw):
-    fake = FakeRoute(initial, broken=broken)
+def _rec(lk, monkeypatch, mode, initial=None, *,  # pylint: disable=too-many-arguments
+         broken=(), lying=(), **kw):
+    fake = FakeRoute(initial, broken=broken, lying=lying)
     monkeypatch.setattr(lk.subprocess, "run", fake.run)
     return lk.DefaultRouteReconciler(mode=mode, **kw), fake
 
@@ -92,6 +96,36 @@ def test_enforce_idempotent_no_change_when_correct(lk, monkeypatch):
     rec.reconcile(True, True, GW)
     assert fake.gw == GW
     assert fake.verbs == ["get"]  # compare-then-act: no add/delete, no churn
+
+
+def test_install_reads_the_fib_back_to_confirm(lk, monkeypatch, caplog):
+    # the success path must CONFIRM the FIB (a second get after the add), not
+    # trust the add's exit code -- the read-back is what test_lying_add relies on.
+    rec, fake = _rec(lk, monkeypatch, "enforce")
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        rec.reconcile(True, True, GW)
+    assert fake.verbs == ["get", "add", "get"]  # top read, install, confirm read-back
+    assert any(r.getMessage() == f"installed default via {GW}" for r in caplog.records)
+
+
+def test_lying_add_success_is_caught_by_confirm(lk, monkeypatch, caplog):
+    # route(8) exits 0 but the FIB did not actually take the default (a "lying"
+    # success): the confirm read-back, not the exit code, catches it. An
+    # implementation that trusted the add's returncode would falsely log success.
+    rec, fake = _rec(lk, monkeypatch, "enforce", lying={"add"})
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        rec.reconcile(True, True, GW)
+    assert fake.gw is None  # never actually installed despite the rc 0
+    assert any(f"failed to install default via {GW}" in r.getMessage() for r in caplog.records)
+    assert not any(r.getMessage().startswith("installed default via") for r in caplog.records)
+
+
+def test_enforce_installs_cgnat_gateway(lk, monkeypatch):
+    # the plugin exists for a CGNAT single-IP WAN; a 100.64/10 gateway is the
+    # production case, so exercise the install through one end to end.
+    rec, fake = _rec(lk, monkeypatch, "enforce")
+    rec.reconcile(True, True, CGNAT_GW)
+    assert fake.gw == CGNAT_GW and "add" in fake.verbs
 
 
 def test_enforce_corrects_wrong_nexthop(lk, monkeypatch):
@@ -152,6 +186,21 @@ def test_definite_role_resets_strikes(lk, monkeypatch):
     rec.reconcile(True, True, GW)     # definite read resets the counter
     rec.reconcile(None, True, GW)     # strike 1 again, not 4
     assert fake.gw == GW              # still held, not withdrawn
+
+
+def test_unreadable_role_warns_once_per_episode_and_rearms(lk, monkeypatch, caplog):
+    # the fail-closed warning fires once per unreadable EPISODE (not per tick, and
+    # not once ever): a definite read re-arms it so a later episode warns again.
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, unreadable_role_strikes=2)
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        for _ in range(5):            # first episode, well past the strike limit
+            rec.reconcile(None, True, GW)
+        assert len([r for r in caplog.records if "failing closed" in r.getMessage()]) == 1
+        rec.reconcile(True, True, GW)  # definite: resets strikes, re-arms, reinstalls
+        assert fake.gw == GW
+        for _ in range(5):            # second episode -> a second, distinct warning
+            rec.reconcile(None, True, GW)
+    assert len([r for r in caplog.records if "failing closed" in r.getMessage()]) == 2
 
 
 # ---- liveness gate (split-brain guard) ----
@@ -291,3 +340,15 @@ def test_stuck_delete_on_replace_keeps_old_and_errors(lk, monkeypatch, caplog):
         rec.reconcile(True, True, GW2)  # replace GW -> GW2
     assert fake.gw == GW  # old gateway kept, not silently overwritten
     assert any("failed to install default via " + GW2 in r.getMessage() for r in caplog.records)
+
+
+def test_fresh_install_add_failure_is_logged_absent(lk, monkeypatch, caplog):
+    # first install (no prior default) and the add itself fails: the replacing=None
+    # arm skips the delete, the add fails, and the confirm reads the FIB as absent
+    # -> a surfaced ERROR naming the empty FIB, not a silent claim of success.
+    rec, fake = _rec(lk, monkeypatch, "enforce", broken={"add"})
+    with caplog.at_level("ERROR", logger="lease-keeper"):
+        rec.reconcile(True, True, GW)
+    assert fake.gw is None
+    assert any(f"failed to install default via {GW}" in r.getMessage()
+               and "absent" in r.getMessage() for r in caplog.records)

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -10,6 +10,8 @@ import types
 
 import pytest
 
+from leasekeeper.route import RouteCommand
+
 GW = "185.41.66.1"
 GW2 = "185.41.66.9"
 CGNAT_GW = "100.64.4.1"   # the production case: a 100.64/10 single-IP CGNAT WAN
@@ -32,22 +34,22 @@ class FakeRoute:
         rc, out, err = 0, "", ""
         if verb in self.broken:  # a real failure: stuck route / bad socket, not a no-op
             rc, err = 1, "route: writing to routing socket: permission denied"
-        elif verb == "get":
+        elif verb == RouteCommand.GET:
             has = self.gw is not None  # empty table exits non-zero
             rc = 0 if has else 1
             out = f"   gateway: {self.gw}\n   flags: <UP,GATEWAY>\n" if has else ""
             err = "" if has else "route: not in table"
-        elif verb == "add":
+        elif verb == RouteCommand.ADD:
             if self.gw is not None:  # FreeBSD: add fails when a default already exists
                 rc, err = 1, "route: writing to routing socket: File exists"
             elif verb not in self.lying:  # a lying add exits 0 but leaves the FIB unchanged
                 self.gw = cmd[-1]
-        elif verb == "change":
+        elif verb == RouteCommand.CHANGE:
             if self.gw is None:  # FreeBSD: change fails when no route exists to change
                 rc, err = 1, "route: change net default: not in table"
             else:
-                self.gw = cmd[-1]  # an on-link gateway swaps in place; off-link is broken={"change"}
-        elif verb == "delete":
+                self.gw = cmd[-1]  # on-link swaps in place; off-link is broken={RouteCommand.CHANGE}
+        elif verb == RouteCommand.DELETE:
             existed = self.gw is not None
             self.gw = None
             rc, err = (0, "") if existed else (1, "not in table")
@@ -74,15 +76,20 @@ def test_off_never_touches_fib(lk, monkeypatch):
     assert not fake.calls  # off short-circuits before any route call
 
 
-def test_observe_reads_but_does_not_mutate(lk, monkeypatch):
+def test_observe_would_install_does_not_mutate(lk, monkeypatch):
+    # observe master+bound: logs a would-install but never writes the FIB.
     rec, fake = _rec(lk, monkeypatch, "observe")
-    rec.reconcile(True, True, GW)          # would-install
-    assert fake.gw is None                 # no mutation
-    assert "add" not in fake.verbs and "delete" not in fake.verbs
-    rec2, fake2 = _rec(lk, monkeypatch, "observe", initial=GW)
-    rec2.reconcile(False, False, None)     # would-withdraw
-    assert fake2.gw == GW
-    assert "delete" not in fake2.verbs
+    rec.reconcile(True, True, GW)
+    assert fake.gw is None
+    assert RouteCommand.ADD not in fake.verbs and RouteCommand.DELETE not in fake.verbs
+
+
+def test_observe_would_withdraw_does_not_mutate(lk, monkeypatch):
+    # observe backup with an existing default: logs a would-withdraw but leaves it.
+    rec, fake = _rec(lk, monkeypatch, "observe", initial=GW)
+    rec.reconcile(False, False, None)
+    assert fake.gw == GW
+    assert RouteCommand.DELETE not in fake.verbs
 
 
 # ---- enforce: install / withdraw / correct / idempotent ----
@@ -91,14 +98,14 @@ def test_enforce_master_installs(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "enforce")
     rec.reconcile(True, True, GW)
     assert fake.gw == GW
-    assert "add" in fake.verbs
+    assert RouteCommand.ADD in fake.verbs
 
 
 def test_enforce_idempotent_no_change_when_correct(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW)
     rec.reconcile(True, True, GW)
     assert fake.gw == GW
-    assert fake.verbs == ["get"]  # compare-then-act: no add/delete, no churn
+    assert fake.verbs == [RouteCommand.GET]  # compare-then-act: no add/delete, no churn
 
 
 def test_install_reads_the_fib_back_to_confirm(lk, monkeypatch, caplog):
@@ -107,7 +114,7 @@ def test_install_reads_the_fib_back_to_confirm(lk, monkeypatch, caplog):
     rec, fake = _rec(lk, monkeypatch, "enforce")
     with caplog.at_level("INFO", logger="lease-keeper"):
         rec.reconcile(True, True, GW)
-    assert fake.verbs == ["get", "add", "get"]  # top read, install, confirm read-back
+    assert fake.verbs == [RouteCommand.GET, RouteCommand.ADD, RouteCommand.GET]  # top read, install, confirm read-back
     assert any(r.getMessage() == f"installed default via {GW}" for r in caplog.records)
 
 
@@ -115,7 +122,7 @@ def test_lying_add_success_is_caught_by_confirm(lk, monkeypatch, caplog):
     # route(8) exits 0 but the FIB did not actually take the default (a "lying"
     # success): the confirm read-back, not the exit code, catches it. An
     # implementation that trusted the add's returncode would falsely log success.
-    rec, fake = _rec(lk, monkeypatch, "enforce", lying={"add"})
+    rec, fake = _rec(lk, monkeypatch, "enforce", lying={RouteCommand.ADD})
     with caplog.at_level("INFO", logger="lease-keeper"):
         rec.reconcile(True, True, GW)
     assert fake.gw is None  # never actually installed despite the rc 0
@@ -128,7 +135,7 @@ def test_enforce_installs_cgnat_gateway(lk, monkeypatch):
     # production case, so exercise the install through one end to end.
     rec, fake = _rec(lk, monkeypatch, "enforce")
     rec.reconcile(True, True, CGNAT_GW)
-    assert fake.gw == CGNAT_GW and "add" in fake.verbs
+    assert fake.gw == CGNAT_GW and RouteCommand.ADD in fake.verbs
 
 
 def test_enforce_corrects_wrong_nexthop(lk, monkeypatch):
@@ -136,21 +143,21 @@ def test_enforce_corrects_wrong_nexthop(lk, monkeypatch):
     rec.reconcile(True, True, GW)
     assert fake.gw == GW
     # atomic replace via `route change`: no delete-then-add, so no no-default gap
-    assert fake.verbs == ["get", "change", "get"]
+    assert fake.verbs == [RouteCommand.GET, RouteCommand.CHANGE, RouteCommand.GET]
 
 
 def test_enforce_backup_withdraws(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW)
     rec.reconcile(False, False, None)
     assert fake.gw is None
-    assert "delete" in fake.verbs
+    assert RouteCommand.DELETE in fake.verbs
 
 
 def test_enforce_backup_absent_is_noop(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "enforce")
     rec.reconcile(False, False, None)
     assert fake.gw is None
-    assert fake.verbs == ["get"]  # nothing to withdraw
+    assert fake.verbs == [RouteCommand.GET]  # nothing to withdraw
 
 
 def test_master_without_lease_withdraws_despite_sticky_gateway(lk, monkeypatch):
@@ -159,7 +166,7 @@ def test_master_without_lease_withdraws_despite_sticky_gateway(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW)
     rec.reconcile(True, False, GW)
     assert fake.gw is None
-    assert "delete" in fake.verbs
+    assert RouteCommand.DELETE in fake.verbs
 
 
 # ---- unreadable role: fail-safe install, fail-closed withdraw ----
@@ -169,7 +176,7 @@ def test_unreadable_role_never_installs(lk, monkeypatch):
     for _ in range(10):
         rec.reconcile(None, True, GW)
     assert fake.gw is None
-    assert "add" not in fake.verbs
+    assert RouteCommand.ADD not in fake.verbs
 
 
 def test_unreadable_role_withdraws_after_strike_limit(lk, monkeypatch):
@@ -177,10 +184,10 @@ def test_unreadable_role_withdraws_after_strike_limit(lk, monkeypatch):
     rec.reconcile(None, True, GW)
     rec.reconcile(None, True, GW)
     assert fake.gw == GW              # held for the first strike_limit-1 checks
-    assert "delete" not in fake.verbs
+    assert RouteCommand.DELETE not in fake.verbs
     rec.reconcile(None, True, GW)     # third strike -> fail closed
     assert fake.gw is None
-    assert "delete" in fake.verbs
+    assert RouteCommand.DELETE in fake.verbs
 
 
 def test_unreadable_role_but_unbound_withdraws_immediately(lk, monkeypatch):
@@ -190,7 +197,7 @@ def test_unreadable_role_but_unbound_withdraws_immediately(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, unreadable_role_strikes=3)
     rec.reconcile(None, False, None)   # probe failed, but we hold no lease
     assert fake.gw is None             # withdrawn on the first call, not after 3 strikes
-    assert "delete" in fake.verbs
+    assert RouteCommand.DELETE in fake.verbs
 
 
 def test_unreadable_role_with_unusable_gateway_withdraws_immediately(lk, monkeypatch):
@@ -198,7 +205,7 @@ def test_unreadable_role_with_unusable_gateway_withdraws_immediately(lk, monkeyp
     # unreadable role does not earn the strike tolerance -- withdraw now.
     rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, unreadable_role_strikes=3)
     rec.reconcile(None, True, "0.0.0.0")
-    assert fake.gw is None and "delete" in fake.verbs
+    assert fake.gw is None and RouteCommand.DELETE in fake.verbs
 
 
 def test_definite_role_resets_strikes(lk, monkeypatch):
@@ -231,7 +238,7 @@ def test_liveness_false_blocks_install(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "enforce", liveness_probe=lambda: False)
     rec.reconcile(True, True, GW)
     assert fake.gw is None
-    assert "add" not in fake.verbs
+    assert RouteCommand.ADD not in fake.verbs
 
 
 def test_liveness_false_withdraws_existing(lk, monkeypatch):
@@ -259,7 +266,7 @@ def test_liveness_exception_does_not_block(lk, monkeypatch):
 def test_empty_table_reads_as_no_default(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "enforce")
     assert rec._fib_default_gateway() is None  # returncode 1 -> None, not a raise
-    assert fake.verbs == ["get"]
+    assert fake.verbs == [RouteCommand.GET]
 
 
 def test_get_without_gateway_line_reads_absent(lk, monkeypatch):
@@ -324,14 +331,14 @@ def test_strike_limit_must_be_positive(lk):
 def test_bogus_gateway_is_not_installed(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "enforce")
     rec.reconcile(True, True, "0.0.0.0")  # rogue / malformed option 3
-    assert fake.gw is None and "add" not in fake.verbs
+    assert fake.gw is None and RouteCommand.ADD not in fake.verbs
 
 
 def test_bogus_gateway_withdraws_existing(lk, monkeypatch):
     # master+bound but an unusable gateway must not KEEP a default it can't honour.
     rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW)
     rec.reconcile(True, True, "0.0.0.0")
-    assert fake.gw is None and "delete" in fake.verbs
+    assert fake.gw is None and RouteCommand.DELETE in fake.verbs
 
 
 def test_bound_without_gateway_withdraws(lk, monkeypatch):
@@ -339,13 +346,13 @@ def test_bound_without_gateway_withdraws(lk, monkeypatch):
     # and _sane_ipv4(None) must be handled, not raise.
     rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW)
     rec.reconcile(True, True, None)
-    assert fake.gw is None and "delete" in fake.verbs
+    assert fake.gw is None and RouteCommand.DELETE in fake.verbs
 
 
 # ---- a genuine route-command failure is surfaced, not buried as a no-op ----
 
 def test_failed_withdraw_is_logged_and_default_stays(lk, monkeypatch, caplog):
-    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, broken={"delete"})
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, broken={RouteCommand.DELETE})
     with caplog.at_level("ERROR", logger="lease-keeper"):
         rec.reconcile(False, False, None)  # backup -> should withdraw, but delete is stuck
     assert fake.gw == GW  # the default is still in the FIB (the fail-stop breach we must SEE)
@@ -358,11 +365,11 @@ def test_rejected_change_on_replace_keeps_old_and_errors(lk, monkeypatch, caplog
     # the new gateway is not on-link, e.g. a cross-subnet lease whose interface has
     # not moved yet): the FIB keeps the OLD default -- never torn down or
     # black-holed -- and the confirm read-back surfaces that the new one is not in.
-    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, broken={"change"})
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, broken={RouteCommand.CHANGE})
     with caplog.at_level("ERROR", logger="lease-keeper"):
         rec.reconcile(True, True, GW2)  # replace GW -> GW2, but the change is rejected
     assert fake.gw == GW  # old gateway kept intact, not withdrawn
-    assert "delete" not in fake.verbs  # the working default is never removed on a failed replace
+    assert RouteCommand.DELETE not in fake.verbs  # the working default is never removed on a failed replace
     assert any("failed to install default via " + GW2 in r.getMessage() for r in caplog.records)
 
 
@@ -370,7 +377,7 @@ def test_fresh_install_add_failure_is_logged_absent(lk, monkeypatch, caplog):
     # first install (no prior default) and the add itself fails: the replacing=None
     # arm skips the delete, the add fails, and the confirm reads the FIB as absent
     # -> a surfaced ERROR naming the empty FIB, not a silent claim of success.
-    rec, fake = _rec(lk, monkeypatch, "enforce", broken={"add"})
+    rec, fake = _rec(lk, monkeypatch, "enforce", broken={RouteCommand.ADD})
     with caplog.at_level("ERROR", logger="lease-keeper"):
         rec.reconcile(True, True, GW)
     assert fake.gw is None


### PR DESCRIPTION
The keeper owns the IPv4 WAN default route (0.0.0.0/0) as a function of CARP role and lease, so on a single-IP CARP WAN a backup (or a master without a lease) advertises no default (fail-stop) instead of black-holing traffic. Off by default, inert on existing installs.

## What it does

Per-keeper `defaultRouteMode`: `off` (default, inert) / `observe` (logs the decision it would make, no routing-table write) / `enforce` (installs and withdraws). Only the CARP master that holds this keeper's lease keeps a default via the lease gateway (DHCP option 3); every other state keeps none. Level-triggered and idempotent, and a failover moves the default with the role within ~1s because it reacts to the CARP transition, not a slow poll. With os-frr, `redistribute kernel` makes the advertised default follow the role for free (the backup stops advertising 0/0); it also works without FRR. Only one keeper may enforce, and it pairs with marking the WAN gateway down (`force_down`) so OPNsense does not install a competing default.

## What is in this PR

- **`leasekeeper/route.py`: `DefaultRouteReconciler`** - the level-reconciler. It confirms the FIB state after each op (reads the default back, so it is route(8)-wording independent), which surfaces a genuinely stuck route op at ERROR instead of burying it. A changed gateway is replaced atomically with `route change` (no momentary no-default gap for FRR to flap on; an off-link new gateway is rejected cleanly and the working default stays in place). Unreadable-role handling is fail-safe on install and bounded fail-closed on withdraw, but only while a lease is held - with no usable lease it withdraws at once (nothing to be master of). Plus a sane-gateway guard (rejects a 0.0.0.0 / malformed option-3) and an optional liveness gate for split-brain (left unwired for now). The startup fail-stop is `withdraw_if_enabled` (below).
- **`keeper.py`** - the reconcile is driven from one point per loop: at the head of `_maintain_step`, which `run()` re-enters after every state transition, so a single reconcile there tracks an acquire, a renew that changed the option-3 gateway, a NAK or an expiry (unbound it withdraws; bound it installs by role). The long blocking waits that do not return to the loop head keep their own periodic reconcile - the bound heartbeat tick, the REBIND loop, and the SIGUSR2 CARP edge (the syshook already signals every keeper, so a failover reconciles at once) - and shutdown withdraws. A renew/rebind NAK forgets the binding (RFC 2131 4.4.5: back to INIT, not keep REBINDing a refused address), so the next loop head withdraws. Plus a state refactor: `_SignalFlags` (a request/take protocol so a signal handler can only set a flag and the loop clears it), and the frozen `_Config` / `_LinkState` holders.
- **Startup fail-stop** - `DefaultRouteReconciler.withdraw_if_enabled`, run from `main()` to drop a crashed predecessor's stale default even when the replacement can no longer load its capture backend (it is pure route(8), no backend). It runs after the pidfile single-instance guard (so a duplicate start exits "already running" without deleting the live owner's default) and before the backend preflight.
- **Config plumbing** - the `defaultRouteMode` model OptionField, the keeper.conf template column, the rc.d parse-and-validate, and the lease_keeper argparse.
- **`CarpVipDhcp.php`** - a single-enforce validator (two enforcing keepers would fight over the one default).
- The **GUI form field** and the **README** section, plus a `defaultRouteMode` note in the single-IP WAN guide.
- **Version** - bumped to 1.11.0 so existing 1.10.x installs see the feature as an upgrade.
- **Tests** - `tests/test_route.py` (reconciler branch coverage: genuine route failures, the confirm-not-exit-code model, the atomic-change replace, the FIB read/parse edges, the sane-gateway guard, the role-vs-lease ordering, the unknown-mode coercion) and `tests/test_daemon.py` (the loop-head reconcile and the per-wait periodics, the renew/rebind and NAK re-acquire and gateway-change behaviors, and the startup fail-stop with its single-instance guard, driven end to end).

## Testing

191 unit tests; pylint 10.00 (with `useless-suppression`) and pyright clean; flake8, shellcheck and XML all green. Bench-validated on a real two-node OPNsense 26.1 / FreeBSD 14.3 CARP pair: observe writes nothing, enforce install/withdraw (the FIB-confirm reads back correctly after `route add`/`change`/`delete`), the backup withdraws its default, and a failover moves the default with the role in ~60ms via the CARP edge. The `route change` replace was checked separately on FreeBSD 14.3: an on-link swap is atomic, and an off-link change is rejected ("Invalid argument") leaving the old default in place.

## Deferred follow-ups

These optional hardening steps are intentionally left out; the feature is complete and safe without them.

- **`route_reload` plugin-hook poke.** Register `carpvipdhcp_configure()` to return `['route_reload' => ['carpvipdhcp_route_reassert']]` plus a small function that sends the keepers a SIGUSR2, so an OPNsense routing reapply (`system_routing_configure`) nudges the reconciler at once rather than at the next tick. Deferred because the per-tick heartbeat poll and the CARP SIGUSR2 edge already guarantee convergence: the hook would only tighten the window for a *non-CARP* routing reapply (an operator gateway change, a service-triggered apply) between ticks. It also fires before core (plugins run in alphabetical name order, `carpvipdhcp` before `core`), so it is a best-effort async poke, not an ordering guarantee; and in the recommended `enforce` + `force_down` config OPNsense installs no competing default for it to correct. It touches configd action dispatch (historically the arity-bug-prone part of this plugin) and would want a bench run to confirm it fires. Low value for the added surface.

- **A debounced liveness signal for the split-brain install gate.** `DefaultRouteReconciler` already accepts a `liveness_probe` and blocks the install side when it returns an explicit `False` (do not keep a default this node may be unable to honour: a split-brain backup, or a master on a dead WAN with a stale lease). It ships wired to `None` (never blocks) because the reconciler's contract requires the probe to be *debounced* - a single transient miss must not read `False`, or a healthy master would flap its default - and the raw carrier probe is an instantaneous read. The open question is the signal: carrier-up does not catch a split-brain where both nodes still have carrier, so gateway reachability (the ARP nudge's confirmed-reply freshness) is likely the better source, which overlaps the separate "WAN link up but ISP upstream dead" (mode-D) case. So this is a small design pass - pick the signal, add the debounce threshold, and choose it from how the signal actually reads across a real failover on the bench - not a one-line wire. Worth noting: in the single-IP topology both nodes hold the same lease, so a split-brain double-announce is the same still-valid default via the same WAN (harmless); the case worth gating is the stale-lease / mode-D one.

- **A CARP edge that lands during a blocking `renew()`/`reboot()`.** The failover reconcile is serviced from the interruptible sleep, so a CARP transition that arrives while the loop is inside a DHCP reply wait (which polls only the stop flag) is reconciled when that call returns - delayed by at most one renew/rebind attempt, not lost. In the meantime, on a single-IP WAN both nodes advertise the same default via the same gateway (harmless). Making the DHCP wait itself wake on the CARP flag crosses the DhcpClient/Keeper boundary and would want a bench run; the in-code `_SignalFlags` note documents this as the one place the periodic-fallback interval is longer than a tick.

Off by default, so inert on existing installs.
