### PR TITLE
os-carp-vip-dhcp: keep a master's default route across a keeper restart

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -63,7 +63,7 @@ from logging.handlers import RotatingFileHandler
 
 from leasekeeper.capture import CAPTURE_BACKENDS
 from leasekeeper.constants import LOGGER_NAME
-from leasekeeper.keeper import Keeper
+from leasekeeper.keeper import Keeper, carp_master
 from leasekeeper.route import DefaultRouteMode, DefaultRouteReconciler
 from leasekeeper.util import MAC_RE
 
@@ -194,14 +194,15 @@ def main():
     # test: no guard and no FIB mutation, so it takes neither (pf stays None).
     pf = None if a.once else acquire_pidfile(a.pidfile)
     try:
-        # Fail-stop: a crashed predecessor (whose backend is now missing, or that
-        # was restarted with a bad arg) may have left a default in the FIB, still
-        # redistributed by FRR. Withdraw it as non-master here -- pure route(8), no
-        # capture backend -- BEFORE the backend preflight and the arg checks, each
-        # of which can return before Keeper.run() would otherwise do it. Skipped for
-        # --once, and when no CARP vhid owns a default route by role.
+        # Fail-stop: a crashed predecessor (backend now missing, or a bad arg) may
+        # have left a default in the FIB, still redistributed by FRR. Drop it here --
+        # pure route(8), no capture backend -- BEFORE the backend preflight and the
+        # arg checks, each of which can return before Keeper.run() would. The gate
+        # (a master keeps its default, a backup withdraws; probe only when the mode
+        # acts) lives in withdraw_unless_master. Skipped for --once and no vhid.
         if not a.once and a.vhid:
-            DefaultRouteReconciler.withdraw_if_enabled(a.default_route_mode)
+            DefaultRouteReconciler(a.default_route_mode).withdraw_unless_master(
+                lambda: carp_master(a.iface, a.vhid))
 
         # Fail fast (with a logged reason) if the selected backend cannot run on
         # this host -- checked uniformly through the registry so a future backend

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
@@ -18,4 +18,4 @@ wires up and runs the Keeper defined here. Modules, leaf-first:
 # PLUGIN_VERSION from this line (so the package version and the daemon's own
 # reported version can never drift). Keep the assignment on one line as
 # __version__ = "X.Y.Z" so the Makefile's sed can read it.
-__version__ = "1.11.0"
+__version__ = "1.11.1"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -42,6 +42,35 @@ IFCONFIG_STATUS = "status: "                 # any status line present (up or do
 _UNSET = object()
 
 
+def _ifconfig_text(iface):
+    """Raw `ifconfig <iface>` text, or None if it could not run (no logging -- each
+    caller adds its own error policy)."""
+    try:
+        out = subprocess.check_output(["/sbin/ifconfig", iface], errors="replace")
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.decode(errors="replace") if isinstance(out, bytes) else out
+
+
+def _carp_master(ifconfig_text, vhid):
+    """CARP-master decision from ifconfig text: True/False for the vhid, None when
+    the text is missing (probe failed), True when no vhid (nothing to gate on)."""
+    if not vhid:
+        return True
+    if ifconfig_text is None:
+        return None
+    return CARP_MASTER_FMT.format(vhid=vhid) in ifconfig_text
+
+
+def carp_master(iface, vhid):
+    """CARP-master role for `vhid` on `iface` (True/False, None on probe failure).
+    Standalone -- no Keeper -- so the daemon entry point can gate its startup
+    fail-stop default withdraw on the role before the Keeper / capture backend
+    exist; the Keeper's per-tick probe (_probe_carp_master) shares CARP_MASTER_FMT
+    through _carp_master."""
+    return _carp_master(_ifconfig_text(iface), vhid)
+
+
 @dataclass
 class _SignalFlags:
     """The only shared state a signal handler may write, behind a tiny protocol
@@ -110,19 +139,13 @@ class _SignalFlags:
 @dataclass(frozen=True)
 class _Config:
     """The keeper's fixed identity/config, set once from the constructor and
-    never mutated -- so a frozen dataclass. master_marker is derived from vhid
-    (the ifconfig CARP-master line for this vhid)."""
+    never mutated -- so a frozen dataclass."""
     iface: str
     chaddr: str
     eth_src: str
     hbfile: "str | None"
     release_on_exit: bool
     vhid: "str | None"
-
-    @property
-    def master_marker(self):
-        """The ifconfig CARP-master line to grep for this vhid (None if unset)."""
-        return CARP_MASTER_FMT.format(vhid=self.vhid) if self.vhid else None
 
 
 @dataclass
@@ -340,30 +363,25 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         nudge fails closed, the transition poll skips), so warn once per failure
         episode -- otherwise a wrong --iface or a broken ifconfig looks identical
         to a healthy backup in the log."""
-        try:
-            out = subprocess.check_output(["/sbin/ifconfig", self._cfg.iface], errors="replace")
-        except (OSError, subprocess.SubprocessError) as e:
+        out = _ifconfig_text(self._cfg.iface)
+        if out is None:
             if not self._link.ifconfig_failed:
-                LOG.warning("ifconfig %s probe failed (%s) -- CARP role and carrier "
-                            "state unknown until it recovers", self._cfg.iface, e)
+                LOG.warning("ifconfig %s probe failed -- CARP role and carrier "
+                            "state unknown until it recovers", self._cfg.iface)
                 self._link.ifconfig_failed = True
             return None
         if self._link.ifconfig_failed:
             LOG.info("ifconfig %s probe recovered", self._cfg.iface)
             self._link.ifconfig_failed = False
-        return out.decode(errors="replace") if isinstance(out, bytes) else out
+        return out
 
     def _probe_carp_master(self) -> "bool | None":
         """Raw CARP-role probe for our vhid: True/False from ifconfig, None when
         the probe itself fails; no vhid configured -> True (nothing to gate on).
         Callers apply their own policy on a None probe -- the ARP nudge fails closed
-        (no nudge unless a confirmed MASTER); the CARP-transition poll just skips."""
-        if self._cfg.master_marker is None:   # no vhid configured -> nothing to gate on
-            return True
-        out = self._ifconfig()
-        if out is None:
-            return None
-        return self._cfg.master_marker in out
+        (no nudge unless a confirmed MASTER); the CARP-transition poll just skips.
+        Uses the warn-once _ifconfig(), unlike the standalone carp_master()."""
+        return _carp_master(self._ifconfig(), self._cfg.vhid)
 
     def _carp_master_probe(self) -> "bool | None":
         """ArpNudge's is_master hook -> the CARP probe (late-bound through the
@@ -624,10 +642,10 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         stopped. Never raises; returns the process exit code.
 
         The startup fail-stop withdraw (a crashed predecessor's stale default) runs
-        in main() via DefaultRouteReconciler.withdraw_if_enabled (gated on a vhid)
-        BEFORE the backend preflight, so it happens even when a backend/arg
+        in main() before the backend preflight, so it happens even when a backend/arg
         early-exit means run() is never reached; the shutdown withdraw below is the
-        graceful counterpart."""
+        graceful counterpart. Both go through withdraw_unless_master (kept on a
+        master, so a keeper restart does not flap 0/0)."""
         # Start the packet capture, retrying forever: a keeper must self-heal, not
         # die, if the interface is briefly unavailable at startup.
         while not self._signals.stopping and not self._capture.start():
@@ -654,11 +672,10 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                     pass
                 self._sleep(LOOP_ERROR_BACKOFF)
 
-        # shutdown: relinquish an owned default so a stopped, disabled or
-        # mode-changed (enforce -> off) enforcing keeper does not leave 0/0 in the
-        # FIB, still redistributed by FRR, with nothing managing it. Reconcile as
-        # non-master -> withdraw; observe logs a would-withdraw and off is a no-op.
-        self._reconcile_default_route(master=False)
+        # shutdown: relinquish an owned default unless we are the CARP master, so a
+        # keeper restart on a master does not flap 0/0 (the rationale and the accepted
+        # trade-off live in withdraw_unless_master).
+        self._defroute.withdraw_unless_master(self._probe_carp_master)
         if self._cfg.release_on_exit:
             self._dhcp.release()
         self._capture.stop()

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -116,18 +116,32 @@ class DefaultRouteReconciler:
         """True in observe/enforce (off is inert); see DefaultRouteMode."""
         return self._mode in (DefaultRouteMode.OBSERVE, DefaultRouteMode.ENFORCE)
 
-    @classmethod
-    def withdraw_if_enabled(cls, mode):
-        """Construct a reconciler for `mode` and drive it to the withdrawn state (no
-        lease, non-master), dropping a default a crashed predecessor left in the FIB.
-        Pure route(8) with no capture backend, so the daemon entry point runs it as a
-        startup fail-stop BEFORE the Keeper / capture backend exist and ahead of any
-        arg/backend early-exit that would skip Keeper.run(). off is a no-op; observe
-        logs a would-withdraw without touching the FIB; enforce actually withdraws.
-        The caller gates on having a CARP vhid (nothing owns a default without one)."""
-        reconciler = cls(mode)
-        if reconciler.enabled:
-            reconciler.reconcile(is_master=False, bound=False, gateway=None)
+    def withdraw_unless_master(self, probe):
+        """Drop an owned default UNLESS this node is the CARP master. `probe` is a
+        callable() -> bool|None returning the CARP-master role; it runs only once the
+        mode would act, so off never spawns it. A confirmed master KEEPS its default
+        (a keeper restart -- a config change or an upgrade -- must not tear it down
+        and flap 0/0; the maintain loop re-adopts it). A backup or an unreadable role
+        (False / None) withdraws, fail-closed, so a stale default is never left for
+        FRR to keep advertising with nothing managing it.
+
+        Run at the two process boundaries: main()'s startup fail-stop (on a throwaway
+        reconciler, before the Keeper / capture backend exist and ahead of any
+        arg/backend early-exit that would skip Keeper.run()) and Keeper.run()'s
+        graceful shutdown. off is a no-op; observe logs a would-withdraw without
+        touching the FIB; enforce actually withdraws. The caller gates on a CARP vhid.
+
+        Trade-off: a GENUINE permanent stop (an operator disabling the plugin) on a
+        node that is still CARP master keeps the default in the FIB with nothing
+        managing it after -- the state this withdraw otherwise prevents. That window
+        is narrow (the node is still master, so the default is at least
+        static-correct) and telling it apart from a restart would need a fragile
+        stop-vs-restart signal, so it is accepted."""
+        if not self.enabled:
+            return
+        if probe() is True:
+            return
+        self.reconcile(is_master=False, bound=False, gateway=None)
 
     def reconcile(self, is_master, bound, gateway):
         """Drive the FIB default toward the desired state for the current

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1223,39 +1223,103 @@ def test_maintain_step_head_installs_when_bound(lk):
     assert rec.calls == [(True, True, "100.64.4.1")]   # installed by role at the head
 
 
-def test_shutdown_withdraws_owned_default(lk, monkeypatch):
-    # Stopping an enforcing keeper relinquishes its default so it is not left in
-    # the FIB (and redistributed by FRR) with nothing managing it.
+def _run_to_shutdown(lk, monkeypatch, *, master, initial):
+    # Run a stopped enforcing keeper straight to its shutdown path (real reconciler
+    # over a FakeRoute) with the CARP role stubbed; return the FakeRoute so the caller
+    # asserts whether the shutdown withdrew the default.
+    from test_route import FakeRoute  # noqa: E402  # pylint: disable=import-outside-toplevel
     monkeypatch.setattr(lk.time, "sleep", lambda *_a, **_k: None)
-    k = _keeper(lk, vhid=254, default_route_mode="enforce")
-    rec = _RecordingReconciler()
-    k._defroute = rec
+    fake = FakeRoute(initial=initial)
+    monkeypatch.setattr(lk.subprocess, "run", fake.run)
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")   # a real DefaultRouteReconciler
+    k._probe_carp_master = lambda: master
     k._capture.start = lambda: True
     k._capture.stop = lambda: None
     k._signals.request_stop()          # exit at once -> straight to the shutdown path
     assert k.run() == 0
-    assert (False, False, None) in rec.calls   # reconcile as non-master -> withdraw
+    return fake
 
 
-def test_withdraw_if_enabled_removes_stale_default(lk, monkeypatch):
-    # The startup fail-stop lives on the reconciler (no Keeper, no capture backend),
-    # so main() runs it BEFORE the backend preflight / arg checks -- any of which can
-    # exit before Keeper.run(). A crashed enforcing predecessor's default is
-    # withdrawn here even when the backend can no longer load.
-    from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
-    fake = FakeRoute(initial=RGW)
-    monkeypatch.setattr(lk.subprocess, "run", fake.run)
-    lk.DefaultRouteReconciler.withdraw_if_enabled("enforce")
+def test_shutdown_withdraws_default_when_not_master(lk, monkeypatch):
+    from test_route import GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
+    # Stopping a NON-master keeper relinquishes its default so it is not left in the
+    # FIB (and redistributed by FRR) with nothing managing it.
+    fake = _run_to_shutdown(lk, monkeypatch, master=False, initial=RGW)
     assert "delete" in fake.verbs and fake.gw is None
 
 
-def test_withdraw_if_enabled_off_is_inert(lk, monkeypatch):
-    # off mode never touches the FIB (the vhid gate is main()'s, not the entry point's).
+def test_shutdown_keeps_default_when_master(lk, monkeypatch):
+    from test_route import GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
+    # A master keeps its default across a keeper restart (config change / upgrade):
+    # shutdown must NOT withdraw, else redistribute-kernel flaps 0/0 and the WAN blips
+    # until the restarted keeper re-adopts the lease.
+    fake = _run_to_shutdown(lk, monkeypatch, master=True, initial=RGW)
+    assert fake.gw == RGW and "delete" not in fake.verbs
+
+
+def test_withdraw_unless_master_withdraws_when_not_master(lk, monkeypatch):
+    # The fail-stop lives on the reconciler (no Keeper, no capture backend), so main()
+    # runs it BEFORE the backend preflight / arg checks -- any of which can exit before
+    # Keeper.run(). A crashed non-master predecessor's default is withdrawn here even
+    # when the backend can no longer load.
     from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
     fake = FakeRoute(initial=RGW)
     monkeypatch.setattr(lk.subprocess, "run", fake.run)
-    lk.DefaultRouteReconciler.withdraw_if_enabled("off")
-    assert fake.gw == RGW and not fake.calls
+    lk.DefaultRouteReconciler("enforce").withdraw_unless_master(lambda: False)
+    assert "delete" in fake.verbs and fake.gw is None
+
+
+def test_withdraw_unless_master_skips_when_master(lk, monkeypatch):
+    # A CARP master owns the default and re-adopts it in the maintain loop, so the
+    # fail-stop must NOT withdraw -- otherwise a keeper restart tears the master's
+    # default down before it is re-installed.
+    from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
+    fake = FakeRoute(initial=RGW)
+    monkeypatch.setattr(lk.subprocess, "run", fake.run)
+    lk.DefaultRouteReconciler("enforce").withdraw_unless_master(lambda: True)
+    assert fake.gw == RGW and not fake.calls   # kept, no route(8) call at all
+
+
+def test_withdraw_unless_master_off_is_inert_without_probing(lk, monkeypatch):
+    # off never touches the FIB AND never even spawns the CARP probe (the reconciler
+    # short-circuits on `enabled` before calling `probe`).
+    from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
+    fake = FakeRoute(initial=RGW)
+    monkeypatch.setattr(lk.subprocess, "run", fake.run)
+    probed = []
+    lk.DefaultRouteReconciler("off").withdraw_unless_master(lambda: probed.append(1))
+    assert fake.gw == RGW and not fake.calls and not probed
+
+
+def test_carp_master_decision_from_ifconfig_text(lk):
+    # The pure decision: MASTER for the vhid -> True, BACKUP/absent -> False, missing
+    # text (probe failed) -> None, no vhid -> True (nothing to gate on).
+    m = "\tcarp: MASTER vhid 199 advbase 1 advskew 0\n"
+    b = "\tcarp: BACKUP vhid 199 advbase 1 advskew 100\n"
+    assert lk._carp_master(m, "199") is True
+    assert lk._carp_master(b, "199") is False
+    assert lk._carp_master("", "199") is False        # no carp line at all
+    assert lk._carp_master(None, "199") is None        # ifconfig probe failed
+    assert lk._carp_master(m, None) is True            # no vhid -> nothing to gate on
+
+
+def test_carp_master_vhid_is_word_bounded(lk):
+    # The trailing space in CARP_MASTER_FMT stops vhid 199 matching 19 or 1990.
+    assert lk._carp_master("carp: MASTER vhid 19 advbase 1\n", "199") is False
+    assert lk._carp_master("carp: MASTER vhid 1990 advbase 1\n", "199") is False
+
+
+def test_carp_master_standalone_probes_via_ifconfig(lk, monkeypatch):
+    # carp_master(iface, vhid) runs ifconfig itself (no Keeper) and applies the same
+    # decision; a probe failure reads as None.
+    monkeypatch.setattr(lk.subprocess, "check_output",
+                        lambda *_a, **_k: b"\tcarp: MASTER vhid 199 advbase 1 advskew 0\n")
+    assert lk.carp_master("lagg1", "199") is True
+
+    def boom(*_a, **_k):
+        raise OSError("no ifconfig")
+    monkeypatch.setattr(lk.subprocess, "check_output", boom)
+    assert lk.carp_master("lagg1", "199") is None
 
 
 def test_duplicate_start_guards_before_any_withdraw(lk, monkeypatch):
@@ -1271,8 +1335,8 @@ def test_duplicate_start_guards_before_any_withdraw(lk, monkeypatch):
         raise SystemExit(4)   # another live instance holds the pidfile
     monkeypatch.setattr(lease_keeper, "_setup_logging", lambda _logfile: None)
     monkeypatch.setattr(lease_keeper, "acquire_pidfile", fake_guard)
-    monkeypatch.setattr(lk.DefaultRouteReconciler, "withdraw_if_enabled",
-                        lambda _mode: calls.append("withdraw"))
+    monkeypatch.setattr(lk.DefaultRouteReconciler, "withdraw_unless_master",
+                        lambda _self, _probe: calls.append("withdraw"))
     monkeypatch.setattr("sys.argv", [
         "lease_keeper", "--iface", "eth0", "--chaddr", CHADDR_STR, "--request",
         "100.64.4.7", "--vhid", "254", "--default-route-mode", "enforce"])
@@ -1474,20 +1538,3 @@ def test_renew_changed_gateway_reconciled_by_next_head(lk):
     k._maintain_step()   # head reconciles the OLD gw; renew then changes it to NEW
     k._maintain_step()   # head reconciles the NEW gw
     assert (True, True, "100.64.4.9") in rec.calls
-
-
-def test_shutdown_drives_a_real_route_withdraw(lk, monkeypatch):
-    # End to end through the REAL DefaultRouteReconciler (not the recording stub):
-    # on shutdown an owned default is actually deleted via route(8), exercising the
-    # mode plumbing (default_route_mode -> constructed reconciler) and the withdraw.
-    # (The startup counterpart is DefaultRouteReconciler.withdraw_if_enabled, tested above.)
-    from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
-    monkeypatch.setattr(lk.time, "sleep", lambda *_a, **_k: None)
-    fake = FakeRoute(initial=RGW)
-    monkeypatch.setattr(lk.subprocess, "run", fake.run)
-    k = _keeper(lk, vhid=254, default_route_mode="enforce")
-    k._capture.start = lambda: True
-    k._capture.stop = lambda: None
-    k._signals.request_stop()          # exit at once -> the shutdown non-master withdraw
-    assert k.run() == 0
-    assert "delete" in fake.verbs and fake.gw is None


### PR DESCRIPTION
The startup and shutdown default-route withdraws were role-blind (always reconcile as non-master). In `enforce` mode that means a keeper restart on the CARP master deletes its FIB default and only reinstalls it after re-acquiring the lease. With the WAN gateway marked down (`force_down`) OPNsense does not backstop the default, and `redistribute kernel` withdraws `0/0` to the BGP peers in the meantime, so every planned keeper restart (a config change or an upgrade) is a few-second WAN outage.

Surfaced by the `observe` dry-run before enabling `enforce` on a live pair: a plugin restart logs `[observe] would withdraw` on both nodes, because both the startup fail-stop and the graceful shutdown withdraw run as non-master by design.

## The fix

Gate both withdraws on the live CARP role:

- A confirmed master KEEPS its default (the maintain loop re-adopts it idempotently, so `redistribute kernel` never withdraws `0/0`).
- A backup or an unreadable role (`False` / `None`) withdraws, fail-closed, so a stale default is never left for FRR to keep advertising with nothing managing it.

Both process boundaries route through one entry point, `DefaultRouteReconciler.withdraw_unless_master(probe)`, which invokes the probe only once the mode would act, so `off` (the default) never spawns an ifconfig. The CARP-master probe is factored into a standalone `keeper.carp_master(iface, vhid)` so `main()`'s startup fail-stop can gate on the role before the Keeper / capture backend exist. `route.py` stays CARP-mechanism-ignorant: it receives a resolved tri-state via the probe callable, never ifconfig / vhid.

## Trade-off (documented in `withdraw_unless_master`)

A genuine permanent stop (an operator disabling the plugin) on a node that is still CARP master now keeps the default in the FIB with nothing managing it afterward, the narrow case the old withdraw prevented. The node is still master, so the default is at least static-correct, and telling a permanent stop apart from a restart would need a fragile stop-vs-restart supervisor signal, so it is accepted.

## Tests

195 unit tests; pylint 10.00 (with `useless-suppression`) and pyright clean; flake8, shellcheck and XML green. New / updated: `carp_master` parsing (master / backup / probe-fail / no-vhid, and the vhid word-boundary), `withdraw_unless_master` skip-if-master / withdraw-if-not / off-never-probes, and real-route shutdown keeps-if-master vs withdraws-if-backup.

## Validation

The probe parsing matches the running `_probe_carp_master` (same marker + ifconfig) and was confirmed against a live `ifconfig lagg1` on the target. The end-to-end restart-no-flap on real FreeBSD folds into the enforce activation bench rehearsal (which sets up `force_down` + `redistribute kernel`), before this is used in `enforce`.

Bumps to 1.11.1.
