### PR TITLE
os-carp-vip-dhcp 1.11.2: re-acquire before withdraw (no 0/0 flap on master restart)

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -212,7 +212,6 @@ def main():
             LOG.critical("capture backend %r cannot run: %s -- the lease keeper cannot start",
                          a.capture_backend, reason)
             return 3
-        LOG.info("capture backend: %s", a.capture_backend)
 
         for label, mac in (("chaddr", a.chaddr), ("eth-src", a.eth_src)):
             if mac and not MAC_RE.match(mac):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
@@ -18,4 +18,4 @@ wires up and runs the Keeper defined here. Modules, leaf-first:
 # PLUGIN_VERSION from this line (so the package version and the daemon's own
 # reported version can never drift). Keep the assignment on one line as
 # __version__ = "X.Y.Z" so the Makefile's sed can read it.
-__version__ = "1.11.1"
+__version__ = "1.11.2"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -146,6 +146,7 @@ class _Config:
     hbfile: "str | None"
     release_on_exit: bool
     vhid: "str | None"
+    capture_backend: str
 
 
 @dataclass
@@ -182,7 +183,8 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             eth_src=(eth_src or chaddr).lower(),
             hbfile=hbfile,
             release_on_exit=release_on_exit,
-            vhid=str(vhid) if vhid else None)
+            vhid=str(vhid) if vhid else None,
+            capture_backend=capture_backend)
 
         # Capture backend component: owns the capture socket/thread and the
         # wire codec on both directions, and hands decoded neutral frames
@@ -653,9 +655,10 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             self._sleep(SNIFFER_RETRY)
 
         # eth-src matters for L2 debugging but only when it differs from the chaddr.
-        ethsrc = f" eth-src={self._cfg.eth_src}" if self._cfg.eth_src != self._cfg.chaddr else ""
-        LOG.info("lease-keeper %s active on %s: chaddr=%s%s request=%s",
-                 __version__, self._cfg.iface, self._cfg.chaddr, ethsrc, self._follow.target or "any")
+        ethsrc = f", eth-src {self._cfg.eth_src}" if self._cfg.eth_src != self._cfg.chaddr else ""
+        LOG.info("lease-keeper %s up on %s via %s backend: CARP MAC %s%s, requesting %s",
+                 __version__, self._cfg.iface, self._cfg.capture_backend, self._cfg.chaddr,
+                 ethsrc, self._follow.target or "any")
         time.sleep(SNIFFER_WARMUP)
 
         while not self._signals.stopping:
@@ -704,11 +707,15 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         retried, so a transient fault can never terminate the keeper."""
         b = self._dhcp.binding
         if not b.yiaddr:
-            # Unbound: withdraw any default we still own (the role is irrelevant when
-            # unbound -- every value withdraws -- so master=False, no ifconfig), then
-            # try to (re)acquire.
-            self._reconcile_default_route(master=False)
+            # Unbound: (re)acquire FIRST, then withdraw only if that did not bind. A
+            # keeper restart re-adopts its still-valid lease here (INIT-REBOOT, a few
+            # ms), so a master keeps its inherited default -- no 0/0 flap -- instead of
+            # tearing it down and reinstalling. Only when the acquire cannot bind (a
+            # lost lease, or a dead WAN: mode-D) do we withdraw, so a node that cannot
+            # route stops advertising 0/0. Role-independent, no ifconfig probe.
             self._acquire_step()
+            if not b.yiaddr:
+                self._reconcile_default_route(master=False)
             return
         # Bound: own the default by CARP role, here at the loop head. _maintain_step
         # is re-entered after every transition (a just-acquired lease, a renew that

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1194,17 +1194,34 @@ def test_hold_lease_tick_drives_default_route_reconcile(lk):
     assert (True, True, "100.64.4.1") in rec.calls
 
 
-def test_maintain_step_head_withdraws_when_unbound(lk):
-    # The loop head withdraws any owned default whenever unbound (the role is
-    # irrelevant, so master=False, no probe) before the acquire arm runs.
+def test_unbound_withdraws_when_acquire_does_not_bind(lk):
+    # Unbound and the (re)acquire did not bind (a lost lease, or a dead WAN: mode-D):
+    # withdraw, so a node that cannot route stops advertising 0/0. Role-independent.
     k = _keeper(lk, vhid=254, default_route_mode="enforce")
     rec = _RecordingReconciler()
     k._defroute = rec
-    k._acquire_step = lambda: None             # isolate the head reconcile
+    k._acquire_step = lambda: None             # the acquire does not bind
     k._dhcp.binding.yiaddr = None              # unbound
     k._dhcp.binding.lease_router = "100.64.4.1"
     k._maintain_step()
-    assert rec.calls == [(False, False, "100.64.4.1")]   # withdraw at the head, no probe
+    assert rec.calls == [(False, False, "100.64.4.1")]   # withdrew after the failed acquire
+
+
+def test_unbound_keeps_default_when_acquire_binds(lk):
+    # A keeper restart re-adopts its still-valid lease in the acquire (INIT-REBOOT),
+    # so the unbound branch must NOT withdraw first -- the inherited default stays, no
+    # 0/0 flap. This is the whole point: acquire-then-withdraw-only-if-still-unbound.
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+
+    def fake_acquire():
+        k._dhcp.binding.yiaddr = "100.64.4.7"   # the acquire re-adopts the lease
+    k._acquire_step = fake_acquire
+    k._dhcp.binding.yiaddr = None
+    k._dhcp.binding.lease_router = "100.64.4.1"
+    k._maintain_step()
+    assert not rec.calls                         # no withdraw: the re-acquire kept it
 
 
 def test_maintain_step_head_installs_when_bound(lk):


### PR DESCRIPTION
## Problem

1.11.1 made the startup and shutdown default-route withdraws role-aware, but a **master restart still flapped 0/0**. On m34 the master kept logging `[observe] would withdraw default (currently via 185.41.66.1)` on every keeper restart.

Root cause: the withdraw class had a **third site** that stayed role-blind. The unbound loop head of `_maintain_step` ran `self._reconcile_default_route(master=False)` (an unconditional withdraw) *before* the acquire arm. On a restart the keeper starts unbound, so it withdrew the inherited default first, then re-adopted its still-valid lease a few ms later via INIT-REBOOT and reinstalled, a needless down/up.

## Fix

Reorder the unbound branch to **acquire first, then withdraw only if that did not bind**:

- A keeper restart re-adopts its still-valid lease in the acquire (INIT-REBOOT, a few ms), so a master keeps its inherited default. No 0/0 flap.
- A node that genuinely cannot bind (a lost lease, or a dead WAN: mode-D) still withdraws, so the fail-stop is preserved.
- Role-independent, no ifconfig probe, same as before.

This is the last of three role-blind withdraw sites (startup and shutdown were fixed in 1.11.1).

## Whole-class check

| Withdraw site | 1.11.1 | 1.11.2 |
|---|---|---|
| startup `withdraw_unless_master` | role-aware (probe, skip on master) | unchanged |
| shutdown `withdraw_unless_master` | role-aware (probe, skip on master) | unchanged |
| unbound loop-head reconcile | role-blind, ran before acquire (the flap) | acquire first, withdraw only if still unbound |
| bound loop-head + periodic reconciles | probe, keep-on-master | unchanged |

## End-to-end (master restart, enforce)

1. Old proc shutdown `withdraw_unless_master`: master → skip.
2. New proc startup `withdraw_unless_master`: master → skip.
3. New proc unbound branch: `_acquire_step()` binds (INIT-REBOOT) → `if not yiaddr` false → **no withdraw**.
4. Next `_maintain_step` bound loop head: master, FIB already correct → silent.

Zero withdraws on the master path.

## Also

- Consolidate the two startup log lines (`capture backend: bpf` + `lease-keeper ... active`) into one human-readable line: `lease-keeper 1.11.2 up on lagg1 via bpf backend: CARP MAC 00:00:5e:00:01:c7, requesting 185.41.66.101`.
- Bump 1.11.1 to 1.11.2.

## Tests

- `test_unbound_withdraws_when_acquire_does_not_bind` (reworked): acquire fails to bind → withdraw (fail-stop preserved).
- `test_unbound_keeps_default_when_acquire_binds` (new): acquire re-adopts the lease → no withdraw (the flap is gone).

flake8 / pylint (exit 0) / pyright / pytest all green.