### PR TITLE
os-carp-vip-dhcp 1.11.3: logging overhaul (level re-tiering, steady-state heartbeats, throttles)

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -107,11 +107,13 @@ def acquire_pidfile(path):
                               "owner) -- exiting", path, old)
                     sys.exit(4)
                 else:
-                    LOG.error("already running (pid %d) -- exiting", old)
+                    LOG.error("already running (pid %d, %s) -- exiting", old, path)
                     sys.exit(4)
             # Stale (dead pid or unreadable content): remove it and retry the create.
             try:
                 os.unlink(path)
+                LOG.info("replaced stale pidfile %s (dead pid %s)",
+                         path, old if old is not None else "unreadable")
             except OSError as e:
                 # If the stale file cannot be removed (e.g. a permission problem
                 # that will not self-heal), exit instead of spinning the
@@ -119,7 +121,7 @@ def acquire_pidfile(path):
                 LOG.error("cannot remove stale pidfile %s: %s -- exiting", path, e)
                 sys.exit(5)
         except OSError as e:
-            LOG.error("cannot write pidfile %s: %s", path, e)
+            LOG.critical("cannot write pidfile %s: %s -- exiting", path, e)
             sys.exit(5)
 
 
@@ -215,7 +217,7 @@ def main():
 
         for label, mac in (("chaddr", a.chaddr), ("eth-src", a.eth_src)):
             if mac and not MAC_RE.match(mac):
-                LOG.error("invalid %s MAC address: %r", label, mac)
+                LOG.critical("invalid %s MAC address %r -- the lease keeper cannot start", label, mac)
                 return 2
 
         k = Keeper(a.iface, a.chaddr, a.request, a.eth_src,

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
@@ -18,4 +18,4 @@ wires up and runs the Keeper defined here. Modules, leaf-first:
 # PLUGIN_VERSION from this line (so the package version and the daemon's own
 # reported version can never drift). Keep the assignment on one line as
 # __version__ = "X.Y.Z" so the Makefile's sed can read it.
-__version__ = "1.11.2"
+__version__ = "1.11.3"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/capture_bpf.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/capture_bpf.py
@@ -13,13 +13,15 @@ from typing import Any
 
 from .constants import (
     LOGGER_NAME,
-    DHCP_CLIENT_PORT, DHCP_SERVER_PORT, ETHER_BROADCAST, THREAD_JOIN_TIMEOUT)
+    DHCP_CLIENT_PORT, DHCP_SERVER_PORT, ETHER_BROADCAST, PARSE_ERROR_LOG_INTERVAL,
+    THREAD_JOIN_TIMEOUT)
 from .codec import (BIOCGBLEN, BIOCGDLT, BIOCIMMEDIATE, BIOCPROMISC, BIOCSETF,
                     BIOCSETIF, BIOCSHDRCMPLT, DLT_EN10MB, ETHER_HDR_LEN,
                     ETHER_MIN_FRAME, ETHERTYPE_ARP, ETHERTYPE_IPV4, ETHERTYPE_OFF,
                     _BPF_FILTER, _bpf_frames, _decode_arp, _decode_ipv4_bootp,
                     _encode_arp_request, _encode_bootp_request, _encode_ether,
                     _encode_ipv4_udp)
+from .util import _RateLimit
 from .wire import _deliver
 
 LOG = logging.getLogger(LOGGER_NAME)
@@ -66,6 +68,9 @@ class BpfCapture:  # pylint: disable=too-many-instance-attributes
         self._thread = None            # the current reader thread
         self._stop_event = None        # set to ask the current reader to exit
         self._wake_writer = None       # write end of this generation's wake pipe
+        # Throttle the untrusted-input parse-error line: a malformed/spoof storm
+        # must not churn the log (DEBUG still hits disk regardless of the view).
+        self._parse_errs = _RateLimit(PARSE_ERROR_LOG_INTERVAL)
 
     @staticmethod
     def unavailable_reason() -> "str | None":
@@ -90,7 +95,7 @@ class BpfCapture:  # pylint: disable=too-many-instance-attributes
         except OSError as e:
             os.close(wake_reader)
             os.close(wake_writer)
-            LOG.error("bpf capture start failed on %s: %s", self.iface, e)
+            LOG.error("bpf open /dev/bpf failed (iface %s): %s", self.iface, e)
             return False
         try:
             self._configure(fd)
@@ -98,7 +103,7 @@ class BpfCapture:  # pylint: disable=too-many-instance-attributes
             os.close(fd)
             os.close(wake_reader)
             os.close(wake_writer)
-            LOG.error("bpf capture start failed on %s: %s", self.iface, e)
+            LOG.error("bpf configure failed on %s: %s", self.iface, e)
             return False
         stop_event = threading.Event()
         # The reader owns fd and wake_reader and closes them when it exits.
@@ -174,8 +179,8 @@ class BpfCapture:  # pylint: disable=too-many-instance-attributes
         if thread is not None and thread.is_alive():
             thread.join(timeout=THREAD_JOIN_TIMEOUT)
             if thread.is_alive():
-                LOG.warning("bpf reader did not exit within 2s -- leaving it to "
-                            "finish; its fd is not reused")
+                LOG.warning("bpf reader did not exit within %ss -- leaving it to "
+                            "finish; its fd is not reused", THREAD_JOIN_TIMEOUT)
 
     def alive(self):
         """True while the descriptor is open and the reader thread runs."""
@@ -198,7 +203,7 @@ class BpfCapture:  # pylint: disable=too-many-instance-attributes
                     data = os.read(fd, self._buflen)
                 except (OSError, ValueError):
                     if not stop_event.is_set():
-                        LOG.warning("bpf read failed -- capture thread exiting")
+                        LOG.warning("bpf read failed on %s -- capture thread exiting", self.iface)
                     return
                 for frame in _bpf_frames(data):
                     self._dispatch(frame)
@@ -223,7 +228,7 @@ class BpfCapture:  # pylint: disable=too-many-instance-attributes
                 elif ethertype == ETHERTYPE_IPV4:
                     decoded, handler = _decode_ipv4_bootp(frame[ETHER_HDR_LEN:]), self._on_bootp
         except Exception as e:
-            LOG.debug("bpf frame parse error: %s", e)
+            self._parse_errs.emit(LOG.debug, "bpf frame parse error: %s", e)
             return
         _deliver(handler, decoded)
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/capture_scapy.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/capture_scapy.py
@@ -10,7 +10,8 @@ from typing import Any
 from .constants import (
     LOGGER_NAME,
     ArpOp, DHCP_CLIENT_PORT, DHCP_SERVER_PORT, ETHER_BROADCAST, ETHER_ZERO,
-    THREAD_JOIN_TIMEOUT)
+    PARSE_ERROR_LOG_INTERVAL, THREAD_JOIN_TIMEOUT)
+from .util import _RateLimit
 from .wire import ArpFrame, BootpFrame, SNIFFER_FILTER, _deliver
 
 LOG = logging.getLogger(LOGGER_NAME)
@@ -53,6 +54,9 @@ class ScapyCapture:
         self._on_bootp = on_bootp
         self._on_arp = on_arp
         self._sniffer = None
+        # Throttle the untrusted-input parse-error line: a malformed/spoof storm
+        # must not churn the log (DEBUG still hits disk regardless of the view).
+        self._parse_errs = _RateLimit(PARSE_ERROR_LOG_INTERVAL)
 
     @staticmethod
     def unavailable_reason() -> "str | None":
@@ -78,7 +82,7 @@ class ScapyCapture:
             self._sniffer.start()
             return True
         except Exception as e:
-            LOG.error("DHCP-reply sniffer start failed: %s", e)
+            LOG.error("DHCP-reply sniffer start failed on %s: %s", self.iface, e)
             return False
 
     def stop(self):
@@ -122,7 +126,7 @@ class ScapyCapture:
                 arp = p[ARP]
                 frame, handler = ArpFrame(arp.op, arp.psrc, arp.pdst), self._on_arp
         except Exception as e:
-            LOG.debug("sniffed packet parse error: %s", e)
+            self._parse_errs.emit(LOG.debug, "sniffed packet parse error: %s", e)
             return
         _deliver(handler, frame)
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/constants.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/constants.py
@@ -129,6 +129,12 @@ SNIFFER_RETRY = 5          # wait before retrying a failed packet-sniffer start
 SNIFFER_WARMUP = 0.5       # let the capture thread attach before the first send
 LOOP_ERROR_BACKOFF = 10    # wait after an unexpected main-loop error before retrying
 
+# Logging rate limits (seconds).
+# Min gap between WAN-untrusted parse-error DEBUG lines, so a malformed/spoof
+# storm cannot churn the log rotation.
+PARSE_ERROR_LOG_INTERVAL = 10
+LEASE_PULSE_INTERVAL = 3600    # emit a throttled "lease healthy" INFO pulse at most this often while bound
+
 # Follow (VIP-rewrite) throttle + apply-retry.
 MIN_FOLLOW_INTERVAL = 60   # min seconds between follow (VIP rewrite) events -- damps flap/spoof storms
 FOLLOW_RETRY_DEADLINE = 120  # re-drive follow_update if we are not restarted within this after firing
@@ -149,6 +155,7 @@ DHCP_SERVER_PORT = 67
 DHCP_CLIENT_PORT = 68
 
 ARP_NUDGE_MIN = 30         # floor for --arp-nudge so a typo cannot flood the segment
+NUDGE_FAIL_LOG_INTERVAL = 300   # min seconds between "ARP nudge failed" warnings on a persistent send failure
 
 
 class Phase(StrEnum):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
@@ -94,12 +94,13 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             chaddr=self.chraw, xid=self.xid, ciaddr=ciaddr, flags=BROADCAST_FLAG,
             options=_dhcp_options(mtype, extra, self._id_opts)))
 
-    def _wait_for_dhcp_reply(self, want, timeout) -> DhcpReply | None:
+    def _wait_for_dhcp_reply(self, want, timeout, phase, for_addr=None) -> DhcpReply | None:
         """Wait up to timeout for a reply of message-type `want`. Returns the
         DhcpReply on a match OR on a DHCPNAK (the caller checks rx.mtype == NAK
         to tell them apart -- a NAK ends the attempt, a match proceeds), or None
         on timeout. Returning the snapshot avoids re-reading self._rx (set by the
-        sniffer thread) after the wait."""
+        sniffer thread) after the wait. phase / for_addr give the NAK log the
+        operator's actual context (which exchange, which address was refused)."""
         end = time.time() + timeout
         while time.time() < end and not self._should_stop():
             self._ev.clear()
@@ -113,7 +114,8 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                 # it is the operator's main clue for a rejected renew.
                 txt = _msg_text(rx.message)
                 reason = f" -- {txt}" if txt else ""
-                LOG.warning("DHCPNAK received (server %s, xid 0x%08x%s)%s",
+                LOG.warning("DHCPNAK in %s for %s (server %s, xid 0x%08x%s)%s",
+                            phase, for_addr or "the requested address",
                             rx.server_id or "unknown", self.xid,
                             f" via relay {rx.giaddr}" if rx.giaddr else "", reason)
                 return rx
@@ -204,17 +206,20 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             try:
                 self._send_dhcp("discover", extra)
             except Exception as e:
-                LOG.error("DHCP DISCOVER send failed: %s", e)
+                LOG.warning("DHCP DISCOVER send failed (attempt %d, xid 0x%08x): %s",
+                            attempt, self.xid, e)
                 time.sleep(SEND_RETRY_DELAY)
                 continue
-            rx = self._wait_for_dhcp_reply(OFFER, REPLY_TIMEOUT)
+            rx = self._wait_for_dhcp_reply(OFFER, REPLY_TIMEOUT, Phase.DORA, request_ip)
             if rx and rx.mtype == NAK:
                 return False
             if rx:
                 self.binding.yiaddr, self.binding.server = rx.yiaddr, rx.server_id
                 return True
-            # xid included so the exchange can be matched against a packet capture.
-            LOG.info("no DHCP OFFER (attempt %d, xid 0x%08x)", attempt, self.xid)
+            # DEBUG (not INFO): a single missed OFFER is routine; the acquire's
+            # overall failure is summarised once by the run loop. xid included so
+            # the exchange can be matched against a packet capture.
+            LOG.debug("no DHCP OFFER (attempt %d, xid 0x%08x)", attempt, self.xid)
             time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
         return False
 
@@ -233,10 +238,11 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                     [(DhcpOptName.SERVER_ID, self.binding.server), (DhcpOptName.REQUESTED_ADDR, self.binding.yiaddr)],
                 )
             except Exception as e:
-                LOG.error("DHCP REQUEST send failed: %s", e)
+                LOG.warning("DHCP REQUEST send failed (attempt %d, xid 0x%08x): %s",
+                            attempt, self.xid, e)
                 time.sleep(SEND_RETRY_DELAY)
                 continue
-            rx = self._wait_for_dhcp_reply(ACK, REPLY_TIMEOUT)
+            rx = self._wait_for_dhcp_reply(ACK, REPLY_TIMEOUT, Phase.DORA, self.binding.yiaddr)
             if rx and rx.mtype == NAK:
                 return False   # NAK -> back to INIT; the run loop re-acquires (DISCOVER)
             if rx:
@@ -245,8 +251,8 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                     return self._on_changed(got, rx, Phase.DORA, True)
                 self.adopt(rx)
                 return True
-            LOG.info("no DHCP ACK from %s for %s (attempt %d, xid 0x%08x)",
-                     self.binding.server, self.binding.yiaddr, attempt, self.xid)
+            LOG.debug("no DHCP ACK from %s for %s (attempt %d, xid 0x%08x)",
+                      self.binding.server, self.binding.yiaddr, attempt, self.xid)
             time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
         return False
 
@@ -278,10 +284,11 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             try:
                 self._send_dhcp("request", extra)
             except Exception as e:
-                LOG.error("DHCP INIT-REBOOT send failed: %s", e)
+                LOG.warning("DHCP INIT-REBOOT send failed (attempt %d, xid 0x%08x): %s",
+                            attempt, self.xid, e)
                 time.sleep(SEND_RETRY_DELAY)
                 continue
-            rx = self._wait_for_dhcp_reply(ACK, REPLY_TIMEOUT)
+            rx = self._wait_for_dhcp_reply(ACK, REPLY_TIMEOUT, Phase.REBOOT, request_ip)
             if rx and rx.mtype == NAK:
                 return False   # server refused our known address -> full DISCOVER
             if rx:
@@ -292,8 +299,8 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                 if not self.binding.yiaddr:
                     self.binding.yiaddr = request_ip   # ACK without yiaddr: we asked for it
                 return True
-            LOG.info("no DHCP ACK to INIT-REBOOT for %s (attempt %d, xid 0x%08x)",
-                     request_ip, attempt, self.xid)
+            LOG.debug("no DHCP ACK to INIT-REBOOT for %s (attempt %d, xid 0x%08x)",
+                      request_ip, attempt, self.xid)
             if attempt < REBOOT_ATTEMPTS:   # no backoff after the last try -- fall to DORA at once
                 time.sleep(min(_jittered(2 ** attempt), ATTEMPT_BACKOFF_CAP))
         return False
@@ -315,8 +322,9 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         yiaddr = self.binding.yiaddr
         if not yiaddr:
             return False   # nothing bound -> nothing to renew
+        phase = Phase.REBIND if rebind else Phase.RENEW
 
-        for _ in range(RENEW_ATTEMPTS):
+        for attempt in range(1, RENEW_ATTEMPTS + 1):
             if self._should_stop():
                 return False
             self._ensure_sniffer()
@@ -325,9 +333,10 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                 # RENEW/REBIND carry no extra options -- ciaddr identifies the lease.
                 self._send_dhcp("request", [], ciaddr=yiaddr)
             except Exception as e:
-                LOG.error("DHCP %s send failed: %s", Phase.REBIND if rebind else Phase.RENEW, e)
+                LOG.warning("DHCP %s send failed (xid 0x%08x, ciaddr %s): %s",
+                            phase, self.xid, yiaddr, e)
                 return False
-            rx = self._wait_for_dhcp_reply(ACK, RENEW_TIMEOUT)
+            rx = self._wait_for_dhcp_reply(ACK, RENEW_TIMEOUT, phase, yiaddr)
             if rx and rx.mtype == NAK:
                 # DHCPNAK: the server revoked the lease. RFC 2131 4.4.5 says go back
                 # to INIT (re-DISCOVER), not keep REBINDing an address it refused, so
@@ -341,10 +350,13 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                     # Some dynamic servers change the address at renewal (ACK with a
                     # new yiaddr) instead of NAKing. Route it through the same
                     # follow / enforce decision (and hardening) as the initial DORA.
-                    phase = Phase.REBIND if rebind else Phase.RENEW
                     return self._on_changed(got, rx, phase, False)
                 self._absorb_reply(rx, self.binding.lease_secs)
                 return True
+            # DEBUG: a single missed renew ACK is routine; the run loop escalates
+            # RENEW -> REBIND -> expiry and logs those outcomes.
+            LOG.debug("no DHCP ACK to %s of %s (attempt %d, xid 0x%08x)",
+                      phase, yiaddr, attempt, self.xid)
         return False
 
     def release(self, yiaddr=None, server=None):
@@ -362,9 +374,10 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                 eth_src=self.eth_src, ip_src=yiaddr, ip_dst=server or IPV4_BROADCAST,
                 chaddr=self.chraw, xid=self.xid, ciaddr=yiaddr, flags=0,
                 options=[(DhcpOptName.MESSAGE_TYPE, "release"), (DhcpOptName.SERVER_ID, server), "end"]))
-            LOG.info("DHCP RELEASE of lease %s sent (server %s)", yiaddr, server or "broadcast")
+            LOG.info("DHCP RELEASE of %s sent (server %s)", yiaddr, server or "broadcast")
         except Exception as e:
-            LOG.error("RELEASE failed: %s", e)
+            LOG.warning("DHCP RELEASE of %s failed (server %s): %s",
+                        yiaddr, server or "broadcast", e)
 
     def timing(self):
         """Effective renew (T1) / rebind (T2) seconds and where they came from.

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
@@ -115,7 +115,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                 txt = _msg_text(rx.message)
                 reason = f" -- {txt}" if txt else ""
                 LOG.warning("DHCPNAK in %s for %s (server %s, xid 0x%08x%s)%s",
-                            phase, for_addr or "the requested address",
+                            phase, for_addr or "an unspecified address",
                             rx.server_id or "unknown", self.xid,
                             f" via relay {rx.giaddr}" if rx.giaddr else "", reason)
                 return rx

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -443,7 +443,13 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             master = self._probe_carp_master()
         if master is None:
             return
-        if master and self._was_master is False:
+        if self._was_master is None:
+            # First definite role after an unknown initial probe (a transient
+            # ifconfig failure at startup): announce it so the log does not stay
+            # stuck at "unknown", but take no failover action -- this is the initial
+            # determination, not a promotion or demotion.
+            LOG.info("CARP role for vhid %s: %s", self._cfg.vhid, "MASTER" if master else "BACKUP")
+        elif master and self._was_master is False:
             LOG.info("became CARP master for vhid %s -- immediate ARP nudge and early lease renew",
                      self._cfg.vhid)
             self._renew_asap = True
@@ -455,15 +461,19 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._was_master = master
 
     def _log_initial_carp_role(self):
-        """Announce the CARP role once at startup and seed _was_master, so the
-        role is in the log immediately instead of only on the next transition (a
-        keeper that starts master and stays master would otherwise never state it)."""
+        """Announce the CARP role once at startup and seed _was_master, so the role
+        is in the log immediately instead of only on the next transition (a keeper
+        that starts master and stays master would otherwise never state it). Seed
+        only a DEFINITE result: an unknown (a transient startup ifconfig failure) is
+        left unseeded so _poll_carp_role announces the first definite role rather
+        than the log staying stuck at 'unknown'."""
         if not self._cfg.vhid:
             return
         master = self._probe_carp_master()
         role = "unknown" if master is None else ("MASTER" if master else "BACKUP")
         LOG.info("initial CARP role for vhid %s: %s", self._cfg.vhid, role)
-        self._was_master = master
+        if master is not None:
+            self._was_master = master
 
     def _reconcile_default_route(self, master=_UNSET):
         """Drive the IPv4 default route toward its CARP-role-owned desired state

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -14,13 +14,13 @@ from . import __version__
 from .capture import CAPTURE_BACKENDS
 from .constants import (
     LOGGER_NAME,
-    ACK, BootpOp, DhcpOptName, HB_REFRESH, LINK_KICK_DEBOUNCE, LINK_POLL_STEP,
-    LOOP_ERROR_BACKOFF, Phase, REBIND_POLL_STEP, REDORA_MAX, REDORA_MIN,
+    ACK, BootpOp, DhcpOptName, HB_REFRESH, LEASE_PULSE_INTERVAL, LINK_KICK_DEBOUNCE,
+    LINK_POLL_STEP, LOOP_ERROR_BACKOFF, Phase, REBIND_POLL_STEP, REDORA_MAX, REDORA_MIN,
     SNIFFER_RETRY, SNIFFER_WARMUP)
 from .dhcpclient import DhcpClient
 from .policy import ArpNudge, FollowPolicy
 from .route import DefaultRouteReconciler
-from .util import _atomic_write, _clock_at, _jittered, _sane_ipv4
+from .util import _RateLimit, _atomic_write, _clock_at, _jittered, _sane_ipv4
 from .wire import _parse_reply
 
 LOG = logging.getLogger(LOGGER_NAME)
@@ -206,6 +206,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
 
         # Main-loop-only state (set by the loop itself, never by a handler):
         self._renew_asap = False       # renew at the next _hold_lease tick instead of waiting for T1
+        self._pulse = _RateLimit(LEASE_PULSE_INTERVAL)   # throttles the "lease healthy" INFO
 
         # DHCP client component: owns the lease state and the protocol sequences;
         # the keeper owns the capture (feeding it xid-matched replies) and the
@@ -254,13 +255,17 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
     # ---- capture (resilient) ----
     def _ensure_sniffer(self):
         if not self._capture.alive():
-            LOG.warning("DHCP-reply capture down -- (re)starting")
+            LOG.warning("DHCP-reply capture down on %s -- (re)starting", self._cfg.iface)
             if not self._capture.start():
                 # The backend already logged why at ERROR; make the persistent
                 # case explicit so the preceding "(re)starting" is not read as
                 # success -- until the capture recovers, every exchange times out.
                 LOG.error("DHCP-reply capture restart failed -- exchanges will "
                           "time out until it recovers")
+            else:
+                # Positive trace so a flap-and-recover is not silent (only failures
+                # were logged before, so a recovery left no evidence).
+                LOG.info("DHCP-reply capture restarted on %s", self._cfg.iface)
             time.sleep(1)
 
     def _on_arp_reply(self, frame):
@@ -449,6 +454,17 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             LOG.info("lost CARP master for vhid %s -- ARP nudges pause on this node", self._cfg.vhid)
         self._was_master = master
 
+    def _log_initial_carp_role(self):
+        """Announce the CARP role once at startup and seed _was_master, so the
+        role is in the log immediately instead of only on the next transition (a
+        keeper that starts master and stays master would otherwise never state it)."""
+        if not self._cfg.vhid:
+            return
+        master = self._probe_carp_master()
+        role = "unknown" if master is None else ("MASTER" if master else "BACKUP")
+        LOG.info("initial CARP role for vhid %s: %s", self._cfg.vhid, role)
+        self._was_master = master
+
     def _reconcile_default_route(self, master=_UNSET):
         """Drive the IPv4 default route toward its CARP-role-owned desired state
         (install 0/0 via the lease gateway only while master AND holding a lease;
@@ -484,14 +500,43 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._reconcile_default_route(master)
         return master
 
-    def _on_lease_extended(self, phase):
-        """A RENEW or REBIND (the Phase) landed a fresh lease: refresh the heartbeat
-        and force an ARP nudge. The default route is reconciled by the loop-head
-        reconcile on the next _maintain_step entry (a renewed lease can carry a new
-        option-3 gateway), so it is not repeated here."""
+    def _lease_facts(self):
+        """The lease facts a renew might change (captured before renewing, for the
+        changed-vs-steady RENEW log): lease length, opt-3 gateway, server T1/T2."""
         b = self._dhcp.binding
-        LOG.info("DHCP %s ok %s (lease=%ss, expires ~%s)", phase, b.yiaddr, b.lease_secs,
-                 _clock_at(b.lease_secs))
+        return (b.lease_secs, b.lease_router, b.t1_server, b.t2_server)
+
+    def _lease_changes(self, prior):
+        """A short 'what changed' summary of the current binding against `prior`,
+        or '' when nothing an operator cares about moved (the routine steady renew)."""
+        old_secs, old_gw, old_t1, old_t2 = prior
+        b = self._dhcp.binding
+        parts = []
+        if b.lease_secs != old_secs:
+            parts.append(f"lease {old_secs}s->{b.lease_secs}s")
+        if b.lease_router != old_gw:
+            parts.append(f"gw {old_gw or 'none'}->{b.lease_router or 'none'}")
+        if (b.t1_server, b.t2_server) != (old_t1, old_t2):
+            parts.append("renew timers changed")
+        return ", ".join(parts)
+
+    def _on_lease_extended(self, phase, prior):
+        """A RENEW or REBIND (the Phase) landed a fresh lease: refresh the heartbeat
+        and force an ARP nudge. A steady RENEW that changed nothing logs at DEBUG so
+        a short lease does not fill the log between events; a RENEW that changed the
+        lease length / gateway / timers -- and every REBIND (recovery from a failed
+        renew is notable) -- logs at INFO stating what changed. The default route is
+        reconciled by the loop-head reconcile on the next _maintain_step entry (a
+        renewed lease can carry a new option-3 gateway), so it is not repeated here."""
+        b = self._dhcp.binding
+        changes = self._lease_changes(prior)
+        if phase == Phase.RENEW and not changes:
+            LOG.debug("DHCP RENEW ok %s (lease=%ss, expires ~%s)", b.yiaddr, b.lease_secs,
+                      _clock_at(b.lease_secs))
+        else:
+            suffix = f" [{changes}]" if changes else ""
+            LOG.info("DHCP %s ok %s (lease=%ss, expires ~%s)%s", phase, b.yiaddr, b.lease_secs,
+                     _clock_at(b.lease_secs), suffix)
         self._hb()
         self._arp_nudge(force=True)
 
@@ -632,12 +677,25 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             remaining -= chunk
 
             self._hb()
+            self._maybe_pulse()       # ~1/h "lease healthy" so a quiet keeper shows life
             self._follow.watchdog()   # re-drive a follow whose apply stalled
             # One CARP-role probe per tick, shared by the role poll, the route
             # reconcile (both via _role_tick) and the nudge below.
             master = self._role_tick()
             self._arp_nudge(master=master)
         return not self._signals.stopping
+
+    def _maybe_pulse(self):
+        """A throttled (~1/h) 'lease healthy' INFO. A keeper holding a steady lease
+        logs nothing at INFO between renews (routine renews are DEBUG), so this
+        periodic line shows it is alive without per-tick spam. Not master-gated: a
+        backup holds the same lease and is just as 'healthy'."""
+        b = self._dhcp.binding
+        if not b.yiaddr:
+            return
+        ok, _ = self._pulse.ready()
+        if ok:
+            LOG.info("lease healthy: %s on %s (lease %ss)", b.yiaddr, self._cfg.iface, b.lease_secs)
 
     def run(self):
         """The daemon main loop: capture up, then maintain the lease until
@@ -656,9 +714,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
 
         # eth-src matters for L2 debugging but only when it differs from the chaddr.
         ethsrc = f", eth-src {self._cfg.eth_src}" if self._cfg.eth_src != self._cfg.chaddr else ""
-        LOG.info("lease-keeper %s up on %s via %s backend: CARP MAC %s%s, requesting %s",
-                 __version__, self._cfg.iface, self._cfg.capture_backend, self._cfg.chaddr,
-                 ethsrc, self._follow.target or "any")
+        LOG.info("lease-keeper %s up on %s (vhid %s, default-route %s) via %s backend: "
+                 "CARP MAC %s%s, requesting %s",
+                 __version__, self._cfg.iface, self._cfg.vhid or "none", self._defroute.mode,
+                 self._cfg.capture_backend, self._cfg.chaddr, ethsrc, self._follow.target or "any")
+        self._log_initial_carp_role()
         time.sleep(SNIFFER_WARMUP)
 
         while not self._signals.stopping:
@@ -734,8 +794,9 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                   b.lease_secs, t1, _clock_at(t1), t2, _clock_at(t2), src)
         if not self._hold_lease(t1):
             return
+        prior = self._lease_facts()   # snapshot to report what a renew changed
         if self._dhcp.renew():
-            self._on_lease_extended(Phase.RENEW)
+            self._on_lease_extended(Phase.RENEW, prior)
             return
         if not b.yiaddr:            # renew() drew a NAK and forgot the binding
             self._on_lease_revoked(Phase.RENEW)
@@ -767,7 +828,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                 self._on_lease_revoked(Phase.REBIND)
                 return
         if ok:
-            self._on_lease_extended(Phase.REBIND)
+            self._on_lease_extended(Phase.REBIND, prior)
             return
 
         LOG.error("DHCP lease expired -- re-acquiring (back to %s)", Phase.DORA)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
@@ -10,8 +10,9 @@ from dataclasses import dataclass, field
 from .constants import (
     LOGGER_NAME,
     ARP_NUDGE_MIN, ArpOp, FOLLOW_RETRY_DEADLINE, MIN_FOLLOW_INTERVAL,
-    Phase)
-from .util import _atomic_write, _fs_safe, _mask_to_bits, _same_ip_class, _sane_ipv4
+    NUDGE_FAIL_LOG_INTERVAL, Phase)
+from .util import (
+    _RateLimit, _atomic_write, _fs_safe, _mask_to_bits, _same_ip_class, _sane_ipv4)
 
 LOG = logging.getLogger(LOGGER_NAME)
 
@@ -47,6 +48,9 @@ class ArpNudge:  # pylint: disable=too-many-instance-attributes
         self.last_reply = 0.0          # epoch of the gateway's last ARP reply (0 = none)
         self._gw = None                # last nudge target we logged (log again on change)
         self._warned = False           # warned once about a missing nudge target
+        # Throttle a failing send so a persistent fault stays periodically visible
+        # (with a suppressed count) instead of spamming or latching fully silent.
+        self._nudge_fail_log = _RateLimit(NUDGE_FAIL_LOG_INTERVAL)
 
     def maybe_nudge(self, yiaddr, gateway, force=False, master=_UNSET):
         """Refresh the gateway's ARP entry for yiaddr by broadcasting an ARP
@@ -96,7 +100,9 @@ class ArpNudge:  # pylint: disable=too-many-instance-attributes
             else:
                 LOG.debug("ARP nudge sent: who-has %s tell %s", gateway, yiaddr)
         except Exception as e:
-            LOG.warning("ARP nudge failed (target %s): %s", gateway, e)
+            # A persistently failing send stays periodically visible (throttled with
+            # a suppressed count), not spammed every interval nor latched silent.
+            self._nudge_fail_log.emit(LOG.warning, "ARP nudge failed (target %s): %s", gateway, e)
 
     def on_arp_reply(self, frame, yiaddr, gateway):
         """Stamp last_reply when the gateway answers our nudge -- a reachability
@@ -170,9 +176,10 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
         except (OSError, ValueError) as e:
             # A present-but-corrupt/unreadable state file returns 0.0, which
             # disarms the MIN_FOLLOW_INTERVAL spoof-storm throttle on the next
-            # changed-address ACK; log it so the corrupt case is not silent.
-            LOG.debug("follow-throttle state %s unreadable (%s) -- treating as never followed",
-                      self._state_file, e)
+            # changed-address ACK -- a security-relevant fail-open, so warn (it is
+            # rare: only a corrupt state file, only on a changed-address ACK).
+            LOG.warning("follow-throttle state %s unreadable (%s) -- treating as never "
+                        "followed (throttle disarmed until the next follow)", self._state_file, e)
             return 0.0
 
     def _record_follow(self):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -59,6 +59,12 @@ class RouteCommand(StrEnum):
 # leak to gate.
 _DEFAULT = "default"
 
+# Sentinel for "no desired state recorded yet". The first reconcile then reads as
+# a change, so the entry state (owning / no default / would-install / ...) is
+# logged once at INFO -- the mode-entry heartbeat -- and every unchanged repeat
+# after it drops to DEBUG, keeping steady state out of the default INFO view.
+_UNSET = object()
+
 # Consecutive unreadable CARP-role probes tolerated while we still hold a
 # default before we withdraw it. An unreadable probe (ifconfig failed) is
 # fail-safe on the INSTALL side (do nothing) but must fail *closed* on the
@@ -105,6 +111,9 @@ class DefaultRouteReconciler:
         self._liveness_probe = liveness_probe
         self._strikes = 0
         self._unreadable_warned = False   # rising-edge gate for the fail-closed warning
+        # Last (want, gateway) we logged, so a steady desired state is confirmed
+        # once at INFO then repeats at DEBUG (see _at / _UNSET).
+        self._last_desired = _UNSET
 
     @property
     def mode(self):
@@ -179,18 +188,31 @@ class DefaultRouteReconciler:
 
         want = (is_master is True) and holds_lease
 
-        if want and self._liveness_blocks():
+        blocked = want and self._liveness_blocks()
+        if blocked:
             # Master with a lease but liveness is explicitly not confirmed
             # (possible split-brain / dead WAN with a stale lease): do not keep a
-            # default we may be unable to honour. Fall through to the withdraw arm.
+            # default we may be unable to honour. Fall through to the withdraw arm,
+            # tagged so the log says why (not a plain CARP role loss).
             want = False
 
         have = self._fib_default_gateway()
+
+        # Confirm the desired state once per change at INFO, then quietly at DEBUG:
+        # a steady master ("owning default via X") or backup ("no default held")
+        # states its ownership at the default log view without per-tick spam, and
+        # observe's would-install/would-withdraw stops repeating every tick.
+        desired = (want, gateway if want else None)
+        changed = desired != self._last_desired
+        self._last_desired = desired
+
         if want:
             if have == gateway:
-                return  # already correct -- silent, no route change, no churn
-            self._install(gateway, replacing=have)
+                self._confirm_owned(changed, gateway)  # already correct -- no route change
+            else:
+                self._install(changed, gateway, replacing=have)
         else:
+            reason = self._no_default_reason(blocked, is_master, holds_lease)
             # A route-get failure (for any reason) also reads as None here, so we
             # skip the withdraw. Treating an unreadable table as "absent" is a
             # deliberate trade-off: an empty table -- the common quiet state on a
@@ -202,8 +224,44 @@ class DefaultRouteReconciler:
             # succeeds the withdraw runs and confirms the FIB. A bounded delay
             # beats a per-tick false alarm.
             if have is None:
-                return  # already absent (or unreadable -- see above)
-            self._withdraw(have)
+                self._confirm_no_default(changed, reason)  # already absent
+            else:
+                self._withdraw(changed, have, reason)
+
+    @staticmethod
+    def _at(changed):
+        """Pick the log level for a desired-state confirmation: INFO the first
+        time a state is entered (changed), DEBUG on every unchanged repeat."""
+        return LOG.info if changed else LOG.debug
+
+    @staticmethod
+    def _no_default_reason(blocked, is_master, holds_lease):
+        """Why the desired state is 'no default' -- the informative half of the
+        backup/no-lease/liveness heartbeat and of a withdraw."""
+        if blocked:
+            return "liveness not confirmed (possible split-brain / dead WAN)"
+        if not holds_lease:
+            return "no usable lease"
+        if is_master is not True:
+            return "CARP backup"
+        return "not owned"
+
+    def _confirm_owned(self, changed, gateway):
+        """Steady-state master heartbeat: the FIB default already matches the lease
+        gateway, so there is nothing to install -- state ownership positively
+        instead of returning silently."""
+        if self._mode == DefaultRouteMode.OBSERVE:
+            self._at(changed)("[observe] default already via %s -- would own", gateway)
+        else:
+            self._at(changed)("owning default via %s", gateway)
+
+    def _confirm_no_default(self, changed, reason):
+        """Steady-state no-default heartbeat: there is correctly no default to
+        hold (backup / no lease / liveness-gated)."""
+        if self._mode == DefaultRouteMode.OBSERVE:
+            self._at(changed)("[observe] no default held (%s) -- as wanted", reason)
+        else:
+            self._at(changed)("no default held (%s)", reason)
 
     # ---- role-unknown handling ----
 
@@ -219,11 +277,12 @@ class DefaultRouteReconciler:
         have = self._fib_default_gateway()
         if have is None:
             return
-        if not self._unreadable_warned:
+        first_time = not self._unreadable_warned
+        if first_time:
             LOG.warning("CARP role unreadable for %d checks -- failing closed on "
                         "the default", self._strikes)
             self._unreadable_warned = True
-        self._withdraw(have)
+        self._withdraw(first_time, have, "CARP role unreadable")
 
     def _liveness_blocks(self):
         """True only when the liveness probe is present and returns an explicit
@@ -238,10 +297,10 @@ class DefaultRouteReconciler:
 
     # ---- FIB operations (idempotent, error-tolerant, main-loop only) ----
 
-    def _install(self, gateway, replacing=None):
+    def _install(self, changed, gateway, replacing=None):
         if self._mode == DefaultRouteMode.OBSERVE:
-            LOG.info("[observe] would install default via %s%s", gateway,
-                     "" if replacing is None else f" (replacing {replacing})")
+            self._at(changed)("[observe] would install default via %s%s", gateway,
+                              "" if replacing is None else f" (replacing {replacing})")
             return
         # Replace atomically with `route change`, not delete-then-add. A bench
         # check on FreeBSD 14.3 confirmed both halves: `route change` to an on-link
@@ -264,9 +323,10 @@ class DefaultRouteReconciler:
             LOG.error("failed to install default via %s (the FIB default is now %s)",
                       gateway, have or "absent")
 
-    def _withdraw(self, current):
+    def _withdraw(self, changed, current, reason):
         if self._mode == DefaultRouteMode.OBSERVE:
-            LOG.info("[observe] would withdraw default (currently via %s)", current)
+            self._at(changed)("[observe] would withdraw default (currently via %s) -- %s",
+                              current, reason)
             return
         self._route(RouteCommand.DELETE, _DEFAULT)
         # Confirm the FIB, not the exit code: a silently failed delete would leave
@@ -274,7 +334,7 @@ class DefaultRouteReconciler:
         # exists to prevent -- so surface it at ERROR. The level-triggered
         # reconcile retries the withdraw next tick.
         if self._fib_default_gateway() is None:
-            LOG.info("withdrew default (was via %s)", current)
+            LOG.info("withdrew default (was via %s) -- %s", current, reason)
         else:
             LOG.error("failed to withdraw default (still via %s) -- this node keeps "
                       "advertising it", current)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/util.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/util.py
@@ -1,5 +1,6 @@
-"""Pure, stateless helpers: MAC/IP/mask conversions, address classification,
-filesystem-safe tokens, jitter, atomic writes and clock formatting.
+"""Pure helpers: MAC/IP/mask conversions, address classification, filesystem-safe
+tokens, jitter, atomic writes and clock formatting -- plus one small stateful
+utility, _RateLimit, for throttling noisy log lines.
 
 No project dependencies (stdlib only), so anything can import from here.
 """
@@ -10,6 +11,44 @@ import re
 import time
 
 MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
+
+
+class _RateLimit:
+    """Monotonic-time throttle for noisy, possibly attacker-driven log lines.
+    ready() returns (ok, suppressed): ok is True at most once per `interval`
+    seconds, and suppressed is how many calls were dropped since the previous ok
+    -- so a malformed-packet or spoof storm collapses to one line per interval
+    that also reports how much it hid, instead of churning the log. Single-thread
+    use only (the call sites are the capture/main threads that already own their
+    logging); it holds no lock."""
+
+    def __init__(self, interval):
+        self._interval = interval
+        self._deadline = 0.0   # monotonic; 0 => the first call is always allowed
+        self._suppressed = 0
+
+    def ready(self):
+        """(ok, suppressed): ok True at most once per interval; suppressed is 0
+        while inside a window and, on the ok call, the count hidden since the
+        previous ok."""
+        now = time.monotonic()
+        if now >= self._deadline:
+            dropped, self._suppressed = self._suppressed, 0
+            self._deadline = now + self._interval
+            return True, dropped
+        self._suppressed += 1
+        return False, 0
+
+    def emit(self, log_fn, fmt, *args):
+        """Log `fmt % args` through log_fn at most once per interval, appending a
+        "(+N more suppressed)" note when calls were dropped since the last emit --
+        so the throttle and the suppressed-count wording live in one place instead
+        of at each call site."""
+        ok, dropped = self.ready()
+        if ok:
+            suffix = f" (+{dropped} more suppressed)" if dropped else ""
+            log_fn(fmt + "%s", *args, suffix)
+
 
 _CGNAT = ipaddress.ip_network("100.64.0.0/10")
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/wire.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/wire.py
@@ -157,5 +157,9 @@ def _deliver(handler, frame):
         return
     try:
         handler(frame)
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        LOG.debug("frame handler error: %s", e)
+    except Exception:  # pylint: disable=broad-exception-caught
+        # A handler bug, not malformed input (parse errors never reach here): make
+        # it visible at the default log view, with a traceback to fix it, rather
+        # than hiding it at DEBUG. We still swallow it so one bad frame cannot kill
+        # the capture thread.
+        LOG.warning("frame handler error -- dropping this frame", exc_info=True)

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1688,6 +1688,24 @@ def test_log_initial_carp_role_skips_without_vhid(lk, caplog):
     assert not any("initial CARP role" in r.getMessage() for r in caplog.records)
 
 
+def test_initial_unknown_carp_role_is_resolved_on_first_poll(lk, caplog):
+    # a transient ifconfig failure at startup gives "unknown"; it must not seed
+    # _was_master, so the first definite poll announces the role instead of the log
+    # staying stuck at "unknown".
+    k = _keeper(lk, vhid=254)
+    k._probe_carp_master = lambda: None
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        k._log_initial_carp_role()
+    assert k._was_master is None
+    assert any("initial CARP role for vhid 254: unknown" in r.getMessage() for r in caplog.records)
+    caplog.clear()
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        k._poll_carp_role(master=True)          # role becomes definite -> announced, no failover action
+    assert k._was_master is True
+    assert any("CARP role for vhid 254: MASTER" in r.getMessage() for r in caplog.records)
+    assert not k._renew_asap                     # initial determination, not a promotion
+
+
 def test_lease_changes_reports_lease_and_timer_deltas(lk):
     k = _keeper(lk)
     b = k._dhcp.binding

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -80,7 +80,7 @@ def test_dhcpreply_giaddr_defaults_none(lk):
 
 def test_reboot_request_shape_and_bind(lk):
     c = _client(lk)
-    c._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
+    c._wait_for_dhcp_reply = lambda want, timeout, *a: lk.DhcpReply(
         lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, None)
     assert c.reboot("100.64.4.7") is True
     assert c.binding.yiaddr == "100.64.4.7" and c.binding.server == "100.64.4.1"
@@ -92,7 +92,7 @@ def test_reboot_request_shape_and_bind(lk):
 
 def test_reboot_nak_falls_through(lk):
     c = _client(lk)
-    c._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
+    c._wait_for_dhcp_reply = lambda want, timeout, *a: lk.DhcpReply(
         lk.NAK, None, None, None, None, None, None)
     assert c.reboot("100.64.4.7") is False
     assert c.binding.yiaddr is None
@@ -351,13 +351,13 @@ def test_on_dhcp_reply_captures_option56_message(lk):
 @pytest.mark.parametrize("message, expect", [
     ("lease not available", "lease not available"),   # option-56 text surfaced
     (b"bad chaddr", "bad chaddr"),   # a bytes reason is decoded
-    (None, "DHCPNAK received"),   # no reason -> the NAK is still logged
+    (None, "DHCPNAK in"),   # no reason -> the NAK is still logged (with phase/address context)
 ])
 def test_dhcpnak_logs_reason(lk, caplog, message, expect):
     keeper = _keeper(lk)
     keeper._dhcp._rx = lk.DhcpReply(lk.NAK, None, "100.64.4.1", None, None, None, None, message)
     with caplog.at_level("WARNING", logger="lease-keeper"):
-        assert keeper._dhcp._wait_for_dhcp_reply(lk.ACK, 0.2).mtype == lk.NAK
+        assert keeper._dhcp._wait_for_dhcp_reply(lk.ACK, 0.2, "DORA").mtype == lk.NAK
     assert any(expect in r.getMessage() for r in caplog.records)
 
 
@@ -1069,7 +1069,7 @@ def test_renew_omits_server_id_and_requested_addr(lk):
     # requested_addr, and ciaddr MUST be the client's address.
     c = _client(lk)
     c.binding.server, c.binding.yiaddr, c.binding.lease_secs = "100.64.4.1", "100.64.4.7", 1800
-    c._wait_for_dhcp_reply = lambda want, timeout: lk.DhcpReply(
+    c._wait_for_dhcp_reply = lambda want, timeout, *a: lk.DhcpReply(
         lk.ACK, c.binding.yiaddr, c.binding.server, 1800, None, None, None)
     assert c.renew() is True   # RENEW (T1)
     assert c.renew(rebind=True) is True  # REBIND (T2)
@@ -1392,7 +1392,7 @@ def test_failed_dora_clears_unconfirmed_offer(lk):
         lk.DhcpReply(lk.OFFER, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1"),  # OFFER
         lk.DhcpReply(lk.NAK, None, "100.64.4.1", None, None, None, None),                     # REQUEST -> NAK
     ])
-    c._wait_for_dhcp_reply = lambda want, timeout: next(replies, None)
+    c._wait_for_dhcp_reply = lambda want, timeout, *a: next(replies, None)
     assert c.dora("100.64.4.7") is False
     assert c.binding.yiaddr is None   # cleared -> re-acquire, never a phantom bound
 
@@ -1406,7 +1406,7 @@ def test_failed_dora_after_offer_timeout_clears_yiaddr(lk, monkeypatch):
     c._ensure_sniffer = lambda: None
     calls = {"n": 0}
 
-    def reply(_want, _timeout):
+    def reply(_want, _timeout, *_a):
         calls["n"] += 1
         # the first wait is the DISCOVER's OFFER; every REQUEST wait after it times out
         if calls["n"] == 1:
@@ -1426,7 +1426,7 @@ def test_renew_keeps_lease_router_when_ack_omits_option3(lk):
     c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1"))
     assert c.binding.lease_router == "100.64.4.1"
     c._ensure_sniffer = lambda: None
-    c._wait_for_dhcp_reply = lambda _want, _timeout: lk.DhcpReply(
+    c._wait_for_dhcp_reply = lambda _want, _timeout, *a: lk.DhcpReply(
         lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, None)   # same lease, no opt 3
     assert c.renew() is True
     assert c.binding.lease_router == "100.64.4.1"
@@ -1466,7 +1466,7 @@ def test_renew_nak_forgets_binding(lk):
     c = _client(lk)
     c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1"))
     c._ensure_sniffer = lambda: None
-    c._wait_for_dhcp_reply = lambda _want, _timeout: lk.DhcpReply(
+    c._wait_for_dhcp_reply = lambda _want, _timeout, *a: lk.DhcpReply(
         lk.NAK, None, "100.64.4.1", None, None, None, None)
     assert c.renew() is False
     assert c.binding.yiaddr is None          # forgotten -> reconcile withdraws, next step re-acquires
@@ -1555,3 +1555,144 @@ def test_renew_changed_gateway_reconciled_by_next_head(lk):
     k._maintain_step()   # head reconciles the OLD gw; renew then changes it to NEW
     k._maintain_step()   # head reconciles the NEW gw
     assert (True, True, "100.64.4.9") in rec.calls
+
+
+# ---- logging: rate limiter, renew gating, nudge liveness, lease pulse ----
+
+def test_rate_limit_throttles_and_reports_suppressed(lk, monkeypatch):
+    now = {"t": 1000.0}
+    monkeypatch.setattr(lk.time, "monotonic", lambda: now["t"])
+    rl = lk._RateLimit(10)
+    assert rl.ready() == (True, 0)     # first call always allowed
+    assert rl.ready() == (False, 0)    # inside the window -> suppressed
+    assert rl.ready() == (False, 0)
+    now["t"] = 1011.0                  # past the interval
+    assert rl.ready() == (True, 2)     # allowed again, reporting the two it hid
+
+
+def test_renew_unchanged_is_debug_changed_is_info_with_delta(lk, caplog):
+    # a steady renew (nothing changed) drops to DEBUG so a short lease does not fill
+    # the log; a renew that moves the gateway logs at INFO stating what changed.
+    k = _keeper(lk)
+    k._hb = lambda: None
+    k._arp_nudge = lambda *_a, **_k: None
+    b = k._dhcp.binding
+    b.yiaddr, b.lease_secs, b.lease_router = "100.64.4.7", 300, "100.64.4.1"
+    b.t1_server = b.t2_server = None
+    prior = k._lease_facts()
+    with caplog.at_level("DEBUG", logger="lease-keeper"):
+        k._on_lease_extended(lk.Phase.RENEW, prior)     # unchanged -> DEBUG
+        b.lease_router = "100.64.4.9"                   # the renewal carries a new gateway
+        k._on_lease_extended(lk.Phase.RENEW, prior)     # changed -> INFO
+    renew_lines = [r for r in caplog.records if "RENEW ok" in r.getMessage()]
+    assert [r.levelname for r in renew_lines] == ["DEBUG", "INFO"]
+    assert any("gw 100.64.4.1->100.64.4.9" in r.getMessage() for r in renew_lines)
+
+
+def test_rebind_always_logs_info(lk, caplog):
+    # a REBIND is recovery from a failed renew -- notable even if nothing changed.
+    k = _keeper(lk)
+    k._hb = lambda: None
+    k._arp_nudge = lambda *_a, **_k: None
+    b = k._dhcp.binding
+    b.yiaddr, b.lease_secs, b.lease_router = "100.64.4.7", 300, "100.64.4.1"
+    prior = k._lease_facts()
+    with caplog.at_level("DEBUG", logger="lease-keeper"):
+        k._on_lease_extended(lk.Phase.REBIND, prior)
+    rebind = [r for r in caplog.records if "REBIND ok" in r.getMessage()]
+    assert [r.levelname for r in rebind] == ["INFO"]
+
+
+def _nudge(lk, send):
+    capture = types.SimpleNamespace(send_arp_request=send)
+    return lk.ArpNudge(capture, CHADDR_STR, lk.ARP_NUDGE_MIN, lambda: True)
+
+
+def test_nudge_send_failure_warns_are_throttled(lk, monkeypatch, caplog):
+    # a persistently failing send warns at most once per NUDGE_FAIL_LOG_INTERVAL
+    # (not per tick, not latched-silent-forever), and re-fires once the window
+    # passes so the fault stays visible.
+    def boom(*_a):
+        raise OSError("send failed")
+    now = {"t": 9000.0}
+    monkeypatch.setattr(lk.time, "monotonic", lambda: now["t"])
+    n = _nudge(lk, boom)
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        n.maybe_nudge("100.64.4.7", "100.64.4.1")         # first failure -> WARNING
+        n.last_nudge = 0.0
+        n.maybe_nudge("100.64.4.7", "100.64.4.1")         # within the window -> throttled
+        assert len([r for r in caplog.records if "ARP nudge failed" in r.getMessage()]) == 1
+        now["t"] += lk.NUDGE_FAIL_LOG_INTERVAL + 1
+        n.last_nudge = 0.0
+        n.maybe_nudge("100.64.4.7", "100.64.4.1")         # window passed -> warns again
+    assert len([r for r in caplog.records if "ARP nudge failed" in r.getMessage()]) == 2
+
+
+def test_lease_healthy_pulse_is_throttled(lk, monkeypatch, caplog):
+    k = _keeper(lk)
+    k._dhcp.binding.yiaddr = "100.64.4.7"
+    k._dhcp.binding.lease_secs = 300
+    now = {"t": 5000.0}
+    monkeypatch.setattr(lk.time, "monotonic", lambda: now["t"])
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        k._maybe_pulse()                              # first -> emits
+        k._maybe_pulse()                              # within the hour -> suppressed
+        now["t"] += lk.LEASE_PULSE_INTERVAL + 1
+        k._maybe_pulse()                              # past the interval -> emits again
+    assert len([r for r in caplog.records if "lease healthy" in r.getMessage()]) == 2
+
+
+def test_lease_healthy_pulse_silent_when_unbound(lk, monkeypatch, caplog):
+    k = _keeper(lk)
+    k._dhcp.binding.yiaddr = None
+    monkeypatch.setattr(lk.time, "monotonic", lambda: 5000.0)
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        k._maybe_pulse()
+    assert not [r for r in caplog.records if "lease healthy" in r.getMessage()]
+
+
+def test_parse_error_storm_collapses_to_one_debug_line(lk, monkeypatch, caplog):
+    # a storm of malformed frames must collapse to one throttled DEBUG line that
+    # reports how many it hid, not one line per frame (log-churn / spoof-storm guard).
+    def boom(*_a):
+        raise ValueError("boom")
+    monkeypatch.setattr("leasekeeper.capture_bpf._decode_arp", boom)
+    now = {"t": 100.0}
+    monkeypatch.setattr(lk.time, "monotonic", lambda: now["t"])
+    cap = lk.BpfCapture("eth0", False, lambda f: None, lambda f: None)
+    frame = b"\x00" * 12 + b"\x08\x06" + b"\x00" * 30   # ARP ethertype, long enough to dispatch
+    with caplog.at_level("DEBUG", logger="lease-keeper"):
+        for _ in range(5):
+            cap._dispatch(frame)
+        assert len([r for r in caplog.records if "bpf frame parse error" in r.getMessage()]) == 1
+        now["t"] += lk.PARSE_ERROR_LOG_INTERVAL + 1
+        cap._dispatch(frame)
+    lines = [r for r in caplog.records if "bpf frame parse error" in r.getMessage()]
+    assert len(lines) == 2
+    assert "more suppressed" in lines[1].getMessage()   # the suffix reports the hidden count
+
+
+def test_log_initial_carp_role_announces_and_seeds(lk, caplog):
+    k = _keeper(lk, vhid=254)
+    k._probe_carp_master = lambda: True
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        k._log_initial_carp_role()
+    assert k._was_master is True    # seeded so the first poll does not log a spurious transition
+    assert any("initial CARP role for vhid 254: MASTER" in r.getMessage() for r in caplog.records)
+
+
+def test_log_initial_carp_role_skips_without_vhid(lk, caplog):
+    k = _keeper(lk)   # no vhid
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        k._log_initial_carp_role()
+    assert not any("initial CARP role" in r.getMessage() for r in caplog.records)
+
+
+def test_lease_changes_reports_lease_and_timer_deltas(lk):
+    k = _keeper(lk)
+    b = k._dhcp.binding
+    b.lease_secs, b.lease_router, b.t1_server, b.t2_server = 300, "100.64.4.1", None, None
+    prior = k._lease_facts()
+    b.lease_secs, b.t1_server = 600, 250    # lease length and a server timer both move
+    changes = k._lease_changes(prior)
+    assert "lease 300s->600s" in changes and "renew timers changed" in changes

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -383,3 +383,79 @@ def test_fresh_install_add_failure_is_logged_absent(lk, monkeypatch, caplog):
     assert fake.gw is None
     assert any(f"failed to install default via {GW}" in r.getMessage()
                and "absent" in r.getMessage() for r in caplog.records)
+
+
+# ---- desired-state confirmation: INFO on entry/change, DEBUG on unchanged repeat ----
+
+def _levels_for(caplog, needle):
+    return [r.levelname for r in caplog.records if needle in r.getMessage()]
+
+
+def test_enforce_owning_heartbeat_info_then_debug(lk, monkeypatch, caplog):
+    # a steady, already-correct master states ownership positively (not silence),
+    # once at INFO then repeating at DEBUG so a stable lease does not spam INFO.
+    rec, _ = _rec(lk, monkeypatch, "enforce", initial=GW)
+    with caplog.at_level("DEBUG", logger="lease-keeper"):
+        rec.reconcile(True, True, GW)   # already correct -> entry
+        rec.reconcile(True, True, GW)   # unchanged repeat
+    assert _levels_for(caplog, f"owning default via {GW}") == ["INFO", "DEBUG"]
+
+
+def test_enforce_no_default_heartbeat_names_reason(lk, monkeypatch, caplog):
+    # a backup that holds the (shared-vMAC) lease but is not master confirms it has
+    # correctly no default, with the reason, at INFO on entry then DEBUG.
+    rec, _ = _rec(lk, monkeypatch, "enforce")
+    with caplog.at_level("DEBUG", logger="lease-keeper"):
+        rec.reconcile(False, True, GW)
+        rec.reconcile(False, True, GW)
+    msgs = [r for r in caplog.records if "no default held (CARP backup)" in r.getMessage()]
+    assert [r.levelname for r in msgs] == ["INFO", "DEBUG"]
+
+
+def test_observe_would_install_info_then_debug(lk, monkeypatch, caplog):
+    # observe never writes the FIB, so the would-install condition persists every
+    # tick; log it once at INFO then DEBUG instead of repeating at INFO forever.
+    rec, _ = _rec(lk, monkeypatch, "observe")
+    with caplog.at_level("DEBUG", logger="lease-keeper"):
+        rec.reconcile(True, True, GW)
+        rec.reconcile(True, True, GW)
+    assert _levels_for(caplog, "would install default") == ["INFO", "DEBUG"]
+
+
+def test_observe_would_withdraw_info_then_debug(lk, monkeypatch, caplog):
+    rec, _ = _rec(lk, monkeypatch, "observe", initial=GW)
+    with caplog.at_level("DEBUG", logger="lease-keeper"):
+        rec.reconcile(False, False, None)
+        rec.reconcile(False, False, None)
+    assert _levels_for(caplog, "would withdraw default") == ["INFO", "DEBUG"]
+
+
+def test_liveness_withdraw_names_the_reason(lk, monkeypatch, caplog):
+    # a withdraw forced by the liveness gate says so, so the operator does not
+    # misread it as a plain CARP role loss.
+    rec, _ = _rec(lk, monkeypatch, "enforce", initial=GW, liveness_probe=lambda: False)
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        rec.reconcile(True, True, GW)
+    assert any("withdrew default" in r.getMessage() and "liveness not confirmed" in r.getMessage()
+               for r in caplog.records)
+
+
+def test_no_default_reason_no_usable_lease(lk, monkeypatch, caplog):
+    # master but holding no lease: the no-default heartbeat names "no usable lease"
+    # (not "CARP backup"), so the operator sees WHY there is no default.
+    rec, _ = _rec(lk, monkeypatch, "enforce")
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        rec.reconcile(True, False, None)
+    assert any("no default held (no usable lease)" in r.getMessage() for r in caplog.records)
+
+
+def test_gateway_change_relogs_ownership_at_info(lk, monkeypatch, caplog):
+    # the desired state is keyed on (want, gateway): a follow to a new gateway is a
+    # change, so ownership is stated again at INFO, not silenced as unchanged.
+    rec, _ = _rec(lk, monkeypatch, "enforce", initial=GW)
+    with caplog.at_level("DEBUG", logger="lease-keeper"):
+        rec.reconcile(True, True, GW)     # own via GW (INFO)
+        rec.reconcile(True, True, GW2)    # gateway changed -> install GW2 (INFO)
+    assert _levels_for(caplog, f"owning default via {GW}") == ["INFO"]
+    assert any(r.levelname == "INFO" and f"installed default via {GW2}" in r.getMessage()
+               for r in caplog.records)


### PR DESCRIPTION
A full pass over every log line in the lease keeper: reserve the default INFO view for state changes and notable events, push routine per-event detail to DEBUG (which the plugin's log page reveals on demand without a daemon restart), and add positive heartbeats so a quiet keeper is legible.

## Why

Two operational papercuts drove this: a short DHCP lease filled the log with identical `DHCP RENEW ok` lines, and enforce mode on a healthy master was completely silent (you had to force a failover to see it act). More broadly the levels had drifted (retried send failures at ERROR, per-attempt misses at INFO).

## Guiding rule

INFO = state changes + notable events + a throttled liveness heartbeat. DEBUG = routine per-event repetition. WARNING = recoverable anomaly. CRITICAL = cannot start. The keeper keeps emitting DEBUG to the file (the log page defaults its severity selector to INFO and reveals DEBUG on demand), so nothing is lost, it is just hidden by default.

## What changed

**Quiet the steady state**
- A steady RENEW that changed nothing drops to DEBUG; a RENEW that moved the lease length / gateway / timers -- and every REBIND -- stays INFO and states what changed.
- The default-route reconciler remembers its last desired `(want, gateway)` and confirms it once at INFO on entry/change, then at DEBUG on unchanged repeats. observe stops repeating would-install/withdraw every tick.

**Positive heartbeats (so quiet is not silence)**
- enforce states ownership positively: `owning default via <gw>` / `no default held (<reason>)` at mode entry, instead of returning silently.
- A throttled (~1/h) `lease healthy` INFO shows a bound keeper is alive between renews.
- The startup line names the vhid and default-route mode; the initial CARP role is announced once; a capture restart logs its recovery.

**Level / context corrections**
- Retried DHCP send failures: ERROR -> WARNING, with attempt + xid. Per-attempt "no OFFER/ACK": INFO -> DEBUG (the run loop already summarises the acquire failure). DHCPNAK names the phase and the refused address. RELEASE failure -> WARNING with address + server.
- A frame-handler exception (a bug, not malformed input) -> WARNING + traceback.
- Pidfile-write failure and invalid MAC -> CRITICAL (they stop the start). Corrupt follow-throttle state -> WARNING (a security-relevant fail-open). A liveness-forced default withdraw names the reason.

**Throttles (churn / spam guards)**
- A shared `_RateLimit` throttles the two WAN-untrusted parse-error DEBUG lines so a malformed/spoof storm cannot churn the log rotation, reporting `(+N more suppressed)` when it does emit.
- A persistently failing ARP nudge send is throttled the same way, so it stays periodically visible rather than spamming every tick or latching silent.

## Review

Built from a per-line review of all 76 log calls, then a five-perspective review of the diff (correctness, simplification, silent-failure, comments, test coverage). Findings folded in: the parse-error blocks were folded into `_RateLimit.emit`; a docstring contract was corrected; the nudge-failure warning became a throttle. One proposed new feature -- warning when a gateway stops answering nudges -- was **withdrawn**: it produced a false "blackholed" warning on master re-promotion (a stale `last_reply` from a previous mastership), exactly the failover false-positive class this project avoids. It is deferred for a failover-safe redesign.

## Not changed

The keeper still defaults to emitting at DEBUG (so the log page can reveal it without a restart); no `--debug` / log-level model field was added.

## Tests

+16 focused tests for the stateful behaviours (throttle + suppressed count, parse-error storm collapse, the reconciler heartbeat across all arms, renew changed-vs-steady gating, the lease pulse, the initial-CARP-role seed, the throttled nudge failure). flake8 / pylint (10.00, exit 0) / pyright / 213 pytest all green.