### PR TITLE
os-carp-vip-dhcp: stop steady-state DEBUG from churning the log rotation

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
@@ -18,4 +18,4 @@ wires up and runs the Keeper defined here. Modules, leaf-first:
 # PLUGIN_VERSION from this line (so the package version and the daemon's own
 # reported version can never drift). Keep the assignment on one line as
 # __version__ = "X.Y.Z" so the Makefile's sed can read it.
-__version__ = "1.11.3"
+__version__ = "1.11.4"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/constants.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/constants.py
@@ -134,6 +134,12 @@ LOOP_ERROR_BACKOFF = 10    # wait after an unexpected main-loop error before ret
 # storm cannot churn the log rotation.
 PARSE_ERROR_LOG_INTERVAL = 10
 LEASE_PULSE_INTERVAL = 3600    # emit a throttled "lease healthy" INFO pulse at most this often while bound
+# Steady-state default-route decision (owning / no-default) is DEBUG-logged at most
+# this often while unchanged. Any actual change logs immediately at INFO; this only
+# throttles the per-tick "still the same" heartbeat so it does not dominate the log
+# file (which is written at DEBUG regardless of the GUI view level) and churn the
+# rotation, flushing real events out of the retained backups.
+RECONCILE_HEARTBEAT_INTERVAL = 300
 
 # Follow (VIP-rewrite) throttle + apply-retry.
 MIN_FOLLOW_INTERVAL = 60   # min seconds between follow (VIP rewrite) events -- damps flap/spoof storms

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -511,19 +511,23 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         return master
 
     def _lease_facts(self):
-        """The lease facts a renew might change (captured before renewing, for the
-        changed-vs-steady RENEW log): lease length, opt-3 gateway, server T1/T2."""
+        """The lease facts a renew might meaningfully change (captured before
+        renewing, for the changed-vs-steady RENEW log): the opt-3 gateway and the
+        server T1/T2. The lease length is deliberately excluded -- many servers
+        jitter option 51 by a second or two each renew, which is not an operationally
+        meaningful change and would otherwise force every renew to INFO."""
         b = self._dhcp.binding
-        return (b.lease_secs, b.lease_router, b.t1_server, b.t2_server)
+        return (b.lease_router, b.t1_server, b.t2_server)
 
     def _lease_changes(self, prior):
-        """A short 'what changed' summary of the current binding against `prior`,
-        or '' when nothing an operator cares about moved (the routine steady renew)."""
-        old_secs, old_gw, old_t1, old_t2 = prior
+        """A short 'what changed' summary of the current binding against `prior`, or
+        '' when nothing an operator cares about moved (the routine steady renew).
+        Keyed on the gateway (routing) and the server-provided T1/T2, not the jittery
+        lease length; see _lease_facts. The current lease length is still shown in
+        the renew line itself, just not treated as a change."""
+        old_gw, old_t1, old_t2 = prior
         b = self._dhcp.binding
         parts = []
-        if b.lease_secs != old_secs:
-            parts.append(f"lease {old_secs}s->{b.lease_secs}s")
         if b.lease_router != old_gw:
             parts.append(f"gw {old_gw or 'none'}->{b.lease_router or 'none'}")
         if (b.t1_server, b.t2_server) != (old_t1, old_t2):
@@ -534,8 +538,8 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         """A RENEW or REBIND (the Phase) landed a fresh lease: refresh the heartbeat
         and force an ARP nudge. A steady RENEW that changed nothing logs at DEBUG so
         a short lease does not fill the log between events; a RENEW that changed the
-        lease length / gateway / timers -- and every REBIND (recovery from a failed
-        renew is notable) -- logs at INFO stating what changed. The default route is
+        gateway or renew timers -- and every REBIND (recovery from a failed renew is
+        notable) -- logs at INFO stating what changed. The default route is
         reconciled by the loop-head reconcile on the next _maintain_step entry (a
         renewed lease can carry a new option-3 gateway), so it is not repeated here."""
         b = self._dhcp.binding

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -23,10 +23,16 @@ import logging
 import subprocess
 from enum import StrEnum
 
-from .constants import LOGGER_NAME
-from .util import _sane_ipv4
+from .constants import LOGGER_NAME, RECONCILE_HEARTBEAT_INTERVAL
+from .util import _RateLimit, _sane_ipv4
 
 LOG = logging.getLogger(LOGGER_NAME)
+
+
+def _drop(*_args, **_kwargs):
+    """A log-callable that discards its call: what _at returns for a throttled
+    steady-state repeat, so a suppressed heartbeat is a no-op with the same
+    call shape as LOG.debug/LOG.info."""
 
 # Daemon log-and-continue posture: broad catch-alls are deliberate (see the
 # package docstring / module docstrings).
@@ -114,6 +120,10 @@ class DefaultRouteReconciler:
         # Last (want, gateway) we logged, so a steady desired state is confirmed
         # once at INFO then repeats at DEBUG (see _at / _UNSET).
         self._last_desired = _UNSET
+        # Throttle for the unchanged steady-state DEBUG heartbeat, so a quiet
+        # backup/master does not log its (identical) decision every tick and churn
+        # the log rotation. A change re-arms it (see _at).
+        self._heartbeat = _RateLimit(RECONCILE_HEARTBEAT_INTERVAL)
 
     @property
     def mode(self):
@@ -228,11 +238,19 @@ class DefaultRouteReconciler:
             else:
                 self._withdraw(changed, have, reason)
 
-    @staticmethod
-    def _at(changed):
-        """Pick the log level for a desired-state confirmation: INFO the first
-        time a state is entered (changed), DEBUG on every unchanged repeat."""
-        return LOG.info if changed else LOG.debug
+    def _at(self, changed):
+        """Pick the log callable for a desired-state confirmation. A state change
+        logs at INFO the first time the state is entered, and re-arms the heartbeat
+        so the identical DEBUG repeat does not fire on the very next tick. An
+        unchanged repeat logs at DEBUG at most once per RECONCILE_HEARTBEAT_INTERVAL
+        (proof the reconciler is alive and its decision); the ticks in between are
+        dropped, so a steady node does not fill the log file with a per-tick
+        heartbeat and churn the rotation."""
+        if changed:
+            self._heartbeat.reset()
+            return LOG.info
+        ok, _ = self._heartbeat.ready()
+        return LOG.debug if ok else _drop
 
     @staticmethod
     def _no_default_reason(blocked, is_master, holds_lease):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/util.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/util.py
@@ -49,6 +49,13 @@ class _RateLimit:
             suffix = f" (+{dropped} more suppressed)" if dropped else ""
             log_fn(fmt + "%s", *args, suffix)
 
+    def reset(self):
+        """Start a fresh window: the next ready() waits a full interval again. Used
+        when another line has just conveyed the same state (an immediate INFO on a
+        change), so the throttled periodic repeat should not fire right after it."""
+        self._deadline = time.monotonic() + self._interval
+        self._suppressed = 0
+
 
 _CGNAT = ipaddress.ip_network("100.64.0.0/10")
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1706,11 +1706,37 @@ def test_initial_unknown_carp_role_is_resolved_on_first_poll(lk, caplog):
     assert not k._renew_asap                     # initial determination, not a promotion
 
 
-def test_lease_changes_reports_lease_and_timer_deltas(lk):
+def test_lease_changes_reports_gateway_and_timers_not_lease(lk):
+    # a gateway or server-timer change is reported (and promotes the renew to INFO);
+    # a lease-length change is deliberately not, so server option-51 jitter stays quiet.
     k = _keeper(lk)
     b = k._dhcp.binding
     b.lease_secs, b.lease_router, b.t1_server, b.t2_server = 300, "100.64.4.1", None, None
     prior = k._lease_facts()
-    b.lease_secs, b.t1_server = 600, 250    # lease length and a server timer both move
+    b.lease_secs, b.lease_router, b.t1_server = 600, "100.64.4.9", 250   # all three move
     changes = k._lease_changes(prior)
-    assert "lease 300s->600s" in changes and "renew timers changed" in changes
+    assert "gw 100.64.4.1->100.64.4.9" in changes and "renew timers changed" in changes
+    assert "lease" not in changes    # the lease-length change is intentionally not reported
+
+
+def test_renew_lease_length_change_stays_debug(lk, caplog):
+    # the lease length is deliberately not compared (servers jitter option 51 by a
+    # second or two each renew; a live ISP oscillated 295<->296), so a renew that
+    # changes only the lease length stays at DEBUG with no "[lease ...]" delta --
+    # neither the 1s wobble nor even a large change promotes it to INFO.
+    k = _keeper(lk)
+    k._hb = lambda: None
+    k._arp_nudge = lambda *_a, **_k: None
+    b = k._dhcp.binding
+    b.yiaddr, b.lease_router, b.t1_server, b.t2_server = "100.64.4.7", "100.64.4.1", None, None
+    b.lease_secs = 296
+    prior = k._lease_facts()
+    b.lease_secs = 295                                   # a 1-second wobble
+    assert k._lease_changes(prior) == ""
+    b.lease_secs = 600                                   # even a large lease change
+    assert k._lease_changes(prior) == ""                 # is still not a "change"
+    with caplog.at_level("DEBUG", logger="lease-keeper"):
+        k._on_lease_extended(lk.Phase.RENEW, prior)
+    renew = [r for r in caplog.records if "RENEW ok" in r.getMessage()]
+    assert [r.levelname for r in renew] == ["DEBUG"]
+    assert "->" not in renew[0].getMessage()             # no spurious [lease ...] delta

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -385,49 +385,69 @@ def test_fresh_install_add_failure_is_logged_absent(lk, monkeypatch, caplog):
                and "absent" in r.getMessage() for r in caplog.records)
 
 
-# ---- desired-state confirmation: INFO on entry/change, DEBUG on unchanged repeat ----
+# ---- desired-state confirmation: INFO on entry/change, then a throttled DEBUG
+# heartbeat. The per-tick repeat within the heartbeat window is suppressed (see
+# test_reconcile_heartbeat_throttle_cycle) so a quiet node does not churn the log. ----
 
 def _levels_for(caplog, needle):
     return [r.levelname for r in caplog.records if needle in r.getMessage()]
 
 
-def test_enforce_owning_heartbeat_info_then_debug(lk, monkeypatch, caplog):
-    # a steady, already-correct master states ownership positively (not silence),
-    # once at INFO then repeating at DEBUG so a stable lease does not spam INFO.
+def test_enforce_owning_heartbeat_states_at_info(lk, monkeypatch, caplog):
+    # a steady, already-correct master states ownership positively (not silence) at
+    # INFO on entry; the immediate per-tick repeat is throttled away.
     rec, _ = _rec(lk, monkeypatch, "enforce", initial=GW)
     with caplog.at_level("DEBUG", logger="lease-keeper"):
         rec.reconcile(True, True, GW)   # already correct -> entry
-        rec.reconcile(True, True, GW)   # unchanged repeat
-    assert _levels_for(caplog, f"owning default via {GW}") == ["INFO", "DEBUG"]
+        rec.reconcile(True, True, GW)   # unchanged repeat -> throttled
+    assert _levels_for(caplog, f"owning default via {GW}") == ["INFO"]
 
 
 def test_enforce_no_default_heartbeat_names_reason(lk, monkeypatch, caplog):
     # a backup that holds the (shared-vMAC) lease but is not master confirms it has
-    # correctly no default, with the reason, at INFO on entry then DEBUG.
+    # correctly no default, with the reason, at INFO on entry (the repeat throttled).
     rec, _ = _rec(lk, monkeypatch, "enforce")
     with caplog.at_level("DEBUG", logger="lease-keeper"):
         rec.reconcile(False, True, GW)
         rec.reconcile(False, True, GW)
     msgs = [r for r in caplog.records if "no default held (CARP backup)" in r.getMessage()]
-    assert [r.levelname for r in msgs] == ["INFO", "DEBUG"]
+    assert [r.levelname for r in msgs] == ["INFO"]
 
 
-def test_observe_would_install_info_then_debug(lk, monkeypatch, caplog):
+def test_observe_would_install_states_at_info(lk, monkeypatch, caplog):
     # observe never writes the FIB, so the would-install condition persists every
-    # tick; log it once at INFO then DEBUG instead of repeating at INFO forever.
+    # tick; log it once at INFO instead of forever (the repeat throttled).
     rec, _ = _rec(lk, monkeypatch, "observe")
     with caplog.at_level("DEBUG", logger="lease-keeper"):
         rec.reconcile(True, True, GW)
         rec.reconcile(True, True, GW)
-    assert _levels_for(caplog, "would install default") == ["INFO", "DEBUG"]
+    assert _levels_for(caplog, "would install default") == ["INFO"]
 
 
-def test_observe_would_withdraw_info_then_debug(lk, monkeypatch, caplog):
+def test_observe_would_withdraw_states_at_info(lk, monkeypatch, caplog):
     rec, _ = _rec(lk, monkeypatch, "observe", initial=GW)
     with caplog.at_level("DEBUG", logger="lease-keeper"):
         rec.reconcile(False, False, None)
         rec.reconcile(False, False, None)
-    assert _levels_for(caplog, "would withdraw default") == ["INFO", "DEBUG"]
+    assert _levels_for(caplog, "would withdraw default") == ["INFO"]
+
+
+def test_reconcile_heartbeat_throttle_cycle(lk, monkeypatch, caplog):
+    # the steady-state decision logs INFO once on entry, suppresses the per-tick
+    # repeat within the heartbeat window, emits a single DEBUG once the window
+    # elapses, and returns to INFO (re-arming the throttle) the moment the decision
+    # actually changes -- so a quiet node cannot fill the log with a per-tick line.
+    rec, _ = _rec(lk, monkeypatch, "observe")
+    with caplog.at_level("DEBUG", logger="lease-keeper"):
+        rec.reconcile(True, True, GW)        # would-install entry -> INFO
+        rec.reconcile(True, True, GW)        # within the window -> suppressed
+        assert _levels_for(caplog, "would install default") == ["INFO"]
+        rec._heartbeat._deadline = 0         # the heartbeat window has elapsed
+        rec.reconcile(True, True, GW)        # -> a single DEBUG heartbeat
+        assert _levels_for(caplog, "would install default") == ["INFO", "DEBUG"]
+        rec.reconcile(False, False, None)    # the decision changes -> INFO, re-arm
+        rec.reconcile(False, False, None)    # immediate repeat -> suppressed again
+    assert _levels_for(caplog, "no default held") == ["INFO"]
 
 
 def test_liveness_withdraw_names_the_reason(lk, monkeypatch, caplog):


### PR DESCRIPTION
Found while reviewing the live secondary's log: the keeper's log file rotated fast enough (Python `RotatingFileHandler`, 512 KiB x 3) to flush startup and failover events out of the retained backups within days. Two steady-state lines drove it. The file is written at DEBUG regardless of the GUI view level, so the GUI filter does not save the file from the churn.

## 1. Throttle the reconciler's steady-state heartbeat (the main churn)
On a quiet node the unchanged default-route decision (`owning default via X` / `no default held (...)`) was DEBUG-logged **every tick** (~every 20-30 s), making it ~two thirds of all log lines.

It now logs at DEBUG at most once per `RECONCILE_HEARTBEAT_INTERVAL` (300 s). A real change still logs immediately at INFO and re-arms the throttle, so no event visibility is lost, only the identical per-tick repeat is dropped. Adds `_RateLimit.reset()` for the re-arm.

## 2. Do not treat a lease-length change as a renew change (the jitter false-positive)
Many DHCP servers jitter option 51 by a second or two each renew. A live ISP was seen oscillating between 295 s and 296 s, so **every** renew logged at INFO with a spurious `[lease 295s->296s]` delta, defeating the routine-renew-is-DEBUG behaviour from the previous logging pass.

The renew change-detection now keys on the gateway (routing) and the server-provided T1/T2 only, not the jittery lease length. The current lease length is still shown in the renew line itself, it is just no longer treated as a change. Chosen over a magic "ignore < N seconds" tolerance because the lease length is the wrong field to compare at all; a gateway change is what warrants promoting a renew to INFO.

## Effect
On a steady node the default INFO view drops to startup, initial CARP role, and the hourly `lease healthy` pulse. The dominant per-tick line falls ~14x; overall file volume ~2.5-3x, so the retained history stretches from a few days into the ~two-week range. `backupCount`/`maxBytes` are left unchanged (the throttle addresses the root; bumping retention stays available as a cheap lever).

Not verified: the reduced churn has not yet been observed live (unit-tested only); the 300 s interval is a chosen default, not tuned against preference.

Tests: 216 pass. flake8 / pylint (10.00, `--enable=useless-suppression`) / pyright clean.