### PR TITLE
os-carp-vip-dhcp: backup egress for the non-master node (1.12.0)

### DIFF
--- a/net/os-carp-vip-dhcp/README.md
+++ b/net/os-carp-vip-dhcp/README.md
@@ -15,6 +15,7 @@ Quick pointers:
 
 - **Install** (as root): `fetch -o - https://raw.githubusercontent.com/toreamun/opnsense-plugins/main/install.sh | sh` - see the landing page for the verified / manual / build-from-source paths.
 - **Single-IP WAN deep-dive:** [docs/single-ip-wan-carp.md](docs/single-ip-wan-carp.md).
+- **Backup egress (internet for the non-master node):** [docs/backup-egress.md](docs/backup-egress.md).
 - **This directory** holds the plugin sources (`src/`, `tests/`, `docs/`); the repo mirrors the [opnsense/plugins](https://github.com/opnsense/plugins) ports-tree layout.
 
 If this is useful to you, ⭐ [star the repo](https://github.com/toreamun/opnsense-plugins) - I intend to propose it for the official OPNsense community plugins if there's enough interest.

--- a/net/os-carp-vip-dhcp/docs/backup-egress.md
+++ b/net/os-carp-vip-dhcp/docs/backup-egress.md
@@ -153,6 +153,15 @@ active locally, so the recommended VIP gateway is not caught by this guard.
   persists until that acquire returns and the post-acquire reconcile runs, bounded
   by the acquire/backoff wait. Detected-before-the-block promotion is handled up
   front.
+- **no-master state with a non-VIP gateway:** the feature installs the route while
+  this node is CARP backup and removes it while master, but it has no separate
+  "is there actually a master?" liveness gate. In a transient no-master state (both
+  nodes backup during a failover, or a split), a **point-to-point peer or derived
+  `/30`/`/31` gateway** points each node at the other, so both can install a `/1`
+  toward each other and briefly loop. The **recommended CARP-VIP gateway avoids
+  this**: with no master the VIP is answered by no one, so the route black-holes
+  harmlessly instead of looping. Prefer the CARP-VIP gateway; an install-time
+  liveness gate (as on the `0/0` side) is a possible follow-up.
 - **prefixes-list change across a crash:** the master-side cleanup removes the
   `/1`-split plus the **current** configured prefixes, so a `prefixes`-form list
   changed **after an ungraceful exit** that left an old prefix installed can

--- a/net/os-carp-vip-dhcp/docs/backup-egress.md
+++ b/net/os-carp-vip-dhcp/docs/backup-egress.md
@@ -1,0 +1,191 @@
+# Backup egress: internet for the non-master node
+
+Companion to the default-route-by-CARP-role feature (`Own default route by CARP
+role` = observe/enforce). That feature makes the keeper own the WAN default as a
+function of CARP role: the master installs `0.0.0.0/0`, every other state has
+none (fail-stop). A direct consequence is that **the CARP backup node has no
+route to the internet for its own traffic** (pkg/firmware updates, NTP, DNS,
+remote reachability), because the single ISP-assigned WAN address lives on the
+master.
+
+Backup egress is an opt-in feature (default off) that gives the backup node
+egress **via the master**, without reintroducing the leak or black-hole that the
+default-route feature eliminated.
+
+## What it does
+
+The reconcile loop keeps a **backup-egress route set** installed while this node
+is the CARP **backup**, and removes it when the node becomes **master**. Exactly
+one of these exists at a time, keyed on role:
+
+- **Master:** `0.0.0.0/0` via the WAN gateway (the default-route feature).
+- **Backup:** the configured backup-egress route via a gateway that means "the
+  current master".
+
+They are mirror images, so they can never collide: the backup never holds a
+`0/0`, the master never holds the backup-egress route. Removing the route on the
+master is essential, because the default route form (a `/1`-split) is more
+specific than `0/0` and would otherwise beat the master's own default and loop
+its egress back at itself.
+
+## Prerequisites
+
+- `Own default route by CARP role` must be **observe** or **enforce** on this
+  keeper. Backup egress rides the same reconcile loop; in **off** the loop is
+  inert and backup egress does nothing.
+- **observe** logs what it would install/remove without touching the routing
+  table; **enforce** actually installs and removes.
+
+## Route form
+
+What gets installed on the backup. Two options; the `/1`-split is the default.
+
+- **`/1`-split** (`0.0.0.0/1` + `128.0.0.0/1`) - **default, recommended.** Covers
+  the whole internet but is not "the default route":
+  - it wins over any existing `0.0.0.0/0` by longest-prefix match (so it
+    overrides a black-hole WAN default the backup cannot use),
+  - it is never redistributed as a default: if you redistribute kernel routes
+    into a routing protocol with a route-map that permits only exact
+    `0.0.0.0/0`, a `/1` is filtered out,
+  - it never collides with **enforce**, which only ever touches `0/0`.
+
+  This is the safe universal choice, and the only correct one when this node
+  redistributes its default into a routing protocol.
+- **Specific prefixes** - a curated IPv4 CIDR list (for example your pkg mirror
+  and NTP hosts), separated by comma or space. Limited egress, leak-safe by the
+  same longest-prefix argument. A `0.0.0.0/0` entry in this list is dropped under
+  **enforce** with a one-time warning (it would both leak and fight enforce);
+  non-IPv4 entries are ignored (the feature is IPv4-only).
+
+A plain `0.0.0.0/0` route form is deliberately not offered: the feature runs only
+under observe/enforce, enforce owns `0/0` and would withdraw it, and observe
+never writes, so a plain default could never actually install.
+
+## The gateway (= "the current master")
+
+The route's next hop must resolve to whichever node is currently master. There
+are three ways to name that; all share the same reconcile core.
+
+### CARP VIP (recommended)
+
+Point the gateway at an existing internal CARP VIP (for example the LAN VIP). A
+CARP VIP is by definition answered by whoever is master, so "send to the VIP"
+means "send to the current master". The backup ARPs for the VIP (it is in CARP
+backup state locally, so it does not treat the VIP as its own address) and the
+master answers, NATs, and forwards out the WAN.
+
+- One fixed address in config, identical on both nodes, so config sync is
+  trivial.
+- Follows failover automatically: the VIP moves to the new master and the route
+  keeps working with no change.
+- No peer derivation, no `/30` constraint, no new VIP needed.
+
+### Derive the peer from a point-to-point interface (fallback)
+
+Leave the gateway blank and name an **interface** instead. The plugin reads this
+node's own IPv4 on that interface and uses the **other** host of a `/30` or `/31`
+subnet as the gateway. This is config-sync-safe because the synced value is a
+rule ("derive"), not an address, so each node computes its own correct peer. Only
+valid on a two-address (`/30`/`/31`) link; anything else refuses to derive and
+installs no route (warned).
+
+### A separate uplink gateway (most robust, needs hardware)
+
+If the backup has its own second uplink (LTE/DSL), point the gateway at that
+uplink. The backup then egresses independently of the master, so it keeps
+internet even when the master is down (unlike the VIP/peer options, which
+black-hole harmlessly in a common-mode outage where the master has no internet
+either). Larger multi-uplink setups usually use OPNsense native multi-WAN
+instead.
+
+### Why not an explicit peer address
+
+Config syncs identically between the two nodes, so an explicit peer address (for
+example the master's own point-to-point address) is wrong on the node whose own
+address equals it: as backup, it would route via itself. A VIP (stable) or a
+derive rule (per-node) avoids this. The plugin **rejects a gateway equal to this
+node's own address** (resolved via `route get`, which sends a local address to
+`lo0`); the check runs every tick and is never cached, so a transient failure
+cannot permanently disable the guard. A CARP VIP the node is backup for is not
+active locally, so the recommended VIP gateway is not caught by this guard.
+
+## Fail-safe behaviour
+
+- **Ownership, not shape:** the feature installs, changes or removes a route only
+  when its next hop is one it owns (the configured gateway, stable across role and
+  restart, or the gateway it installed this session). A prefix already routed via
+  a different next hop, for example a full-tunnel VPN's `0.0.0.0/1` + `128.0.0.0/1`
+  or a static route matching a configured prefix, is left untouched and the
+  collision is warned once. The feature never overwrites or deletes a route it
+  does not own.
+- **Unreadable routing table:** the install side defers rather than blind-adding;
+  the removal side skips (ownership cannot be verified against an unreadable table,
+  so a blind delete could tear down an unrelated route) and retries on the next
+  readable tick. The unreadable condition is warned once per episode.
+- **Role probe unreadable (`is_master` unknown):** nothing is touched, matching
+  the `0/0` side, to avoid thrashing on a transient failure.
+- **Promotion while unbound:** a backup promoted to master while it holds no lease
+  reconciles backup egress on its real CARP role before the (possibly long)
+  DORA/backoff wait, so it sheds its `/1` before blocking rather than looping the
+  new master's egress for the duration.
+- **Startup and graceful shutdown:** while the feature is enabled, the routes
+  still via our own next hop are cleared at both process boundaries so a stopped
+  keeper leaves no orphan that a later master would loop through.
+- **Form change:** the master-side removal covers the `/1`-split plus the current
+  configured prefixes, so a form change (split to prefixes or back) that orphaned
+  the old set is cleaned up (for entries still via our next hop).
+
+## Known limits (accepted)
+
+- **IPv6:** out of scope, like the default-route logic. IPv4 only.
+- **orphan a fresh master cannot attribute:** on a fresh process, ownership rests
+  on the configured gateway, so a crashed predecessor's `/1` is auto-removed on
+  the master only when it is still routed via that configured gateway. With the
+  derive (blank-gateway) form, or when the feature or the whole default-route mode
+  is disabled before restart, a fresh master has no stable next hop to match on and
+  leaves the `/1` in place. This narrow crash case needs manual cleanup; persisting
+  the managed route set across restarts is a possible follow-up, deferred as
+  disproportionate (the recommended CARP-VIP gateway is auto-cleaned, and the
+  running reconciler removes our `/1` on the master as soon as the node holds the
+  role while the feature stays enabled).
+- **promotion mid-acquire:** if promotion to master lands in the middle of a single
+  blocking acquire (after the pre-acquire reconcile, before it returns), the `/1`
+  persists until that acquire returns and the post-acquire reconcile runs, bounded
+  by the acquire/backoff wait. Detected-before-the-block promotion is handled up
+  front.
+- **prefixes-list change across a crash:** the master-side cleanup removes the
+  `/1`-split plus the **current** configured prefixes, so a `prefixes`-form list
+  changed **after an ungraceful exit** that left an old prefix installed can
+  orphan that one prefix (a black-hole for that destination only, not
+  egress-wide). A graceful restart removes the old set at shutdown; only
+  crash-then-list-change leaves it, and the default `/1`-split form is never
+  affected.
+- **Persistently unreadable table:** while the table cannot be read, the master-side
+  removal is deferred each tick (ownership cannot be verified), so a stuck `/1` on the
+  master is surfaced only by the once-per-episode "cannot read the routing table"
+  warning until the table is readable again, when it is removed. Self-correcting once
+  readable.
+- **Master without a lease + healthy backup:** the backup routes via a master
+  that itself cannot reach the internet, a short black-hole until CARP demotes
+  the lease-less master. Self-correcting.
+
+## Config fields
+
+| Field | Meaning |
+|---|---|
+| Enable backup egress | Off by default. Turn on to give the backup node egress via the master. |
+| Route form | `/1`-split (default, full internet, leak-safe) or specific prefixes. |
+| Gateway | A stable next hop that means "the master": a CARP VIP (recommended) or a separate uplink gateway. Leave blank to derive the peer from an interface. |
+| Interface | Used only to derive the `/30`/`/31` peer when Gateway is blank. Ignored when a Gateway is set (the route uses the gateway's own on-link interface). |
+| Prefixes | For the specific-prefixes form: IPv4 CIDRs separated by comma or space. |
+
+## Leak-safety guardrail
+
+The backup-egress routes are kernel routes, so if you run `redistribute kernel`
+into a routing protocol they are considered for redistribution. The guardrail is
+a route-map that permits only exact `0.0.0.0/0`, which filters out anything that
+is not exactly `0/0` (a `/1` and any specific prefix are dropped). The plugin
+does not read or manage your FRR configuration, so keeping that exact-match
+route-map in place is an operator responsibility, the same guardrail the
+default-route feature relies on. This is also why `0.0.0.0/0` is rejected as a
+specific-prefix entry: it would both leak and fight enforce.

--- a/net/os-carp-vip-dhcp/docs/backup-egress.md
+++ b/net/os-carp-vip-dhcp/docs/backup-egress.md
@@ -51,9 +51,8 @@ What gets installed on the backup. Two options; the `/1`-split is the default.
 
   This is the safe universal choice, and the only correct one when this node
   redistributes its default into a routing protocol.
-- **Specific prefixes** - a curated IPv4 CIDR list (for example your pkg mirror
-  and NTP hosts), separated by comma or space. Limited egress, leak-safe by the
-  same longest-prefix argument. A `0.0.0.0/0` entry in this list is dropped under
+- **Specific prefixes** - a curated IPv4 CIDR list. Limited egress, leak-safe by
+  the same longest-prefix argument. A `0.0.0.0/0` entry in this list is dropped under
   **enforce** with a one-time warning (it would both leak and fight enforce);
   non-IPv4 entries are ignored (the feature is IPv4-only).
 

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -95,7 +95,8 @@ carpvipdhcp_start()
         # Backup egress (keeper.conf columns 14-18): while CARP backup, route this
         # node's own internet traffic to the master. Only acts under observe/enforce
         # (the daemon gates on that); a blank gateway/interface/prefixes field passes
-        # nothing (the form defaults to split, so --backup-egress-form is always sent).
+        # nothing, and --backup-egress-form is only sent for "prefixes" (split relies on
+        # the daemon default).
         if [ "${backupegress}" = "1" ]; then
             set -- "$@" --backup-egress
             # Validate the form here (like default-route-mode above): passing an unknown

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -35,7 +35,7 @@ carpvipdhcp_start()
 {
     [ -f "${conf}" ] || { echo "no config"; return 0; }
     count=0
-    while IFS='|' read -r request iface chaddr demote vhid follow vendorclass clientid hostname arpnudge arplistenpromisc capturebackend defaultroutemode || [ -n "${request}" ]; do
+    while IFS='|' read -r request iface chaddr demote vhid follow vendorclass clientid hostname arpnudge arplistenpromisc capturebackend defaultroutemode backupegress backupegressform backupegressgw backupegressiface backupegressprefixes || [ -n "${request}" ]; do
         [ -n "${request}" ] || continue
         case "${request}" in \#*) continue ;; esac
         if [ -z "${iface}" ] || [ -z "${chaddr}" ]; then
@@ -92,6 +92,24 @@ carpvipdhcp_start()
             observe|enforce) set -- "$@" --default-route-mode "${defaultroutemode}" ;;
             *) echo "carpvipdhcp: ignoring unknown default-route mode '${defaultroutemode}' (use off, observe or enforce)" >&2 ;;
         esac
+        # Backup egress (keeper.conf columns 14-18): while CARP backup, route this
+        # node's own internet traffic to the master. Only acts under observe/enforce
+        # (the daemon gates on that); a blank gateway/interface/prefixes field passes
+        # nothing (the form defaults to split, so --backup-egress-form is always sent).
+        if [ "${backupegress}" = "1" ]; then
+            set -- "$@" --backup-egress
+            # Validate the form here (like default-route-mode above): passing an unknown
+            # legacy value straight to the daemon's argparse choices would exit-loop the
+            # supervised daemon every few seconds instead of falling back to split.
+            case "${backupegressform}" in
+                ''|split) : ;;
+                prefixes) set -- "$@" --backup-egress-form prefixes ;;
+                *) echo "carpvipdhcp: ignoring unknown backup-egress form '${backupegressform}' (use split or prefixes)" >&2 ;;
+            esac
+            [ -n "${backupegressgw}" ] && set -- "$@" --backup-egress-gateway "${backupegressgw}"
+            [ -n "${backupegressiface}" ] && set -- "$@" --backup-egress-interface "${backupegressiface}"
+            [ -n "${backupegressprefixes}" ] && set -- "$@" --backup-egress-prefixes "${backupegressprefixes}"
+        fi
         # -f detach; -r supervise/restart on crash; -R 5 restart delay; -P supervisor pidfile.
         /usr/sbin/daemon -f -r -R 5 -P "${pidfile}" -t "${name}-${id}" "${keeper}" "$@"
         count=$((count + 1))

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
@@ -84,7 +84,7 @@
         <label>ARP listen in promiscuous mode</label>
         <type>checkbox</type>
         <advanced>true</advanced>
-        <help><![CDATA[Fallback, default OFF. The keeper listens for the gateway's ARP reply to each nudge and shows on the Status page when the gateway last confirmed reachability. Normally the reply is captured without promiscuous mode (the CARP master already accepts the VIP's MAC). Enable this ONLY if the Status page shows the nudge is never confirmed on a bound master — some NICs drop frames addressed to a non-primary unicast MAC unless the interface is promiscuous. WARNING: promiscuous mode makes this root daemon receive ALL traffic on the segment, not just its own; leave it off unless you need it.]]></help>
+        <help><![CDATA[Fallback, default OFF. Applies only while the ARP nudge is enabled (interval > 0), since it only helps capture the nudge's reply; it is ignored when the nudge is off. The keeper listens for the gateway's ARP reply to each nudge and shows on the Status page when the gateway last confirmed reachability. Normally the reply is captured without promiscuous mode (the CARP master already accepts the VIP's MAC). Enable this ONLY if the Status page shows the nudge is never confirmed on a bound master, since some NICs drop frames addressed to a non-primary unicast MAC unless the interface is promiscuous. WARNING: promiscuous mode makes this root daemon receive ALL traffic on the segment, not just its own; leave it off unless you need it.]]></help>
     </field>
     <field>
         <id>keeper.chaddrOverride</id>

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
@@ -38,6 +38,41 @@
         <help><![CDATA[Default OFF. Make this keeper own the IPv4 default route (0.0.0.0/0) by CARP role: the master node holding this keeper's lease keeps a default via the lease gateway, every other state keeps none, so a node offers a default only while it can actually route one (a failover moves it, a backup withdraws it, instead of black-holing). <b>Off</b>: inert. <b>Observe</b>: log the decision it would make, without touching the routing table (use this first). <b>Enforce</b>: actually install and withdraw the default. Only ONE keeper (the WAN VIP) may enforce. In enforce mode, also tick the WAN gateway's "Mark Gateway as Down" (force_down) so OPNsense does not install a competing default. With os-frr the redistributed kernel default then follows the CARP role automatically; it also works without FRR. See the README.]]></help>
     </field>
     <field>
+        <id>keeper.backupEgress</id>
+        <label>Backup egress (internet while not master)</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help><![CDATA[Default OFF. While this node is the CARP <b>backup</b> (and so holds no WAN default), route its OWN internet traffic (updates, NTP, DNS) to the master, which NATs it out the single WAN. Needs "Own default route by CARP role" set to observe or enforce; the route is removed automatically when this node becomes master. See the backup-egress docs.]]></help>
+    </field>
+    <field>
+        <id>keeper.backupEgressForm</id>
+        <label>Backup egress route form</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help><![CDATA[<b>/1-split</b> (recommended): 0.0.0.0/1 + 128.0.0.0/1, full internet but not the default, so it never redistributes as a default nor collides with enforce. <b>Specific prefixes</b>: only the CIDR destinations listed below (e.g. pkg mirror / NTP hosts).]]></help>
+    </field>
+    <field>
+        <id>keeper.backupEgressGateway</id>
+        <label>Backup egress gateway</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help><![CDATA[The next hop = "the master". Best a stable internal <b>CARP VIP</b> (e.g. the LAN VIP), which always points at the master and follows failover; or a separate fallback-WAN gateway (independent egress). Leave <b>blank</b> to derive the peer automatically from the point-to-point /30 or /31 interface set below. Do not enter a plain peer address that differs per node: it syncs identically and would be wrong on one node.]]></help>
+    </field>
+    <field>
+        <id>keeper.backupEgressInterface</id>
+        <label>Backup egress interface (for auto-derive)</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help><![CDATA[Only used when the gateway above is blank: a point-to-point /30 or /31 interface (typically the SYNC link) whose other host is the master. The peer is derived per node, so it stays correct after a failover. Enter the interface device name.]]></help>
+    </field>
+    <field>
+        <id>keeper.backupEgressPrefixes</id>
+        <label>Backup egress prefixes</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help><![CDATA[Only used with route form "Specific prefixes": a comma- or space-separated list of IPv4 CIDR destinations to route via the gateway (e.g. your pkg mirror / NTP hosts). Do not list 0.0.0.0/0.]]></help>
+    </field>
+    <field>
         <id>keeper.arpNudgeInterval</id>
         <label>ARP nudge interval (s)</label>
         <type>text</type>

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
@@ -61,7 +61,7 @@
     <field>
         <id>keeper.backupEgressInterface</id>
         <label>Backup egress interface (for auto-derive)</label>
-        <type>text</type>
+        <type>dropdown</type>
         <advanced>true</advanced>
         <help><![CDATA[Only used when the gateway above is blank: a point-to-point /30 or /31 interface (typically the SYNC link) whose other host is the master. The peer is derived per node, so it stays correct after a failover. Enter the interface device name.]]></help>
     </field>

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
@@ -49,7 +49,7 @@
         <label>Backup egress route form</label>
         <type>dropdown</type>
         <advanced>true</advanced>
-        <help><![CDATA[<b>/1-split</b> (recommended): 0.0.0.0/1 + 128.0.0.0/1, full internet but not the default, so it never redistributes as a default nor collides with enforce. <b>Specific prefixes</b>: only the CIDR destinations listed below (e.g. pkg mirror / NTP hosts).]]></help>
+        <help><![CDATA[<b>/1-split</b> (recommended): 0.0.0.0/1 + 128.0.0.0/1, full internet but not the default, so it never redistributes as a default nor collides with enforce. <b>Specific prefixes</b>: only the CIDR destinations listed below.]]></help>
     </field>
     <field>
         <id>keeper.backupEgressGateway</id>
@@ -68,9 +68,11 @@
     <field>
         <id>keeper.backupEgressPrefixes</id>
         <label>Backup egress prefixes</label>
-        <type>text</type>
+        <style>tokenize</style>
+        <type>select_multiple</type>
+        <allownew>true</allownew>
         <advanced>true</advanced>
-        <help><![CDATA[Only used with route form "Specific prefixes": a comma- or space-separated list of IPv4 CIDR destinations to route via the gateway (e.g. your pkg mirror / NTP hosts). Do not list 0.0.0.0/0.]]></help>
+        <help><![CDATA[Only used with route form "Specific prefixes": the IPv4 CIDR destinations to route via the gateway, added one per token (CIDR notation like 10.0.0.0/24). Do not list 0.0.0.0/0.]]></help>
     </field>
     <field>
         <id>keeper.arpNudgeInterval</id>

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
@@ -157,10 +157,11 @@
                     </OptionValues>
                 </backupEgressForm>
                 <!--
-                    Gateway and prefixes are NetworkField (proper IPv4 validation, rendered
-                    as address inputs); a valid address cannot contain the pipe or a line
-                    break, so the keeper.conf line stays a single parseable record. The
-                    interface is a device name, so it keeps a text mask that forbids both.
+                    Gateway and prefixes are NetworkField and the interface is an
+                    InterfaceField (proper OPNsense inputs: an address field, a tokenized
+                    IPv4 CIDR list, and an interface dropdown). None can contain the pipe or
+                    a line break, so the rendered keeper.conf line stays a single parseable
+                    record; the template resolves the interface to its device name.
                 -->
                 <backupEgressGateway type="NetworkField">
                     <AddressFamily>ipv4</AddressFamily>
@@ -169,9 +170,7 @@
                     <ValidationMessage>Backup egress gateway: a valid IPv4 address, or blank to derive the peer from the interface.</ValidationMessage>
                     <Required>N</Required>
                 </backupEgressGateway>
-                <backupEgressInterface type="TextField">
-                    <Mask>/^[A-Za-z0-9_.]{0,32}$/u</Mask>
-                    <ValidationMessage>Backup egress interface: a device name (letters, digits, dot, underscore).</ValidationMessage>
+                <backupEgressInterface type="InterfaceField">
                     <Required>N</Required>
                 </backupEgressInterface>
                 <backupEgressPrefixes type="NetworkField">

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
@@ -136,6 +136,47 @@
                     </OptionValues>
                 </defaultRouteMode>
 
+                <!--
+                    Backup egress: while this node is the CARP backup (and so holds
+                    no WAN default), route its OWN internet traffic to the master.
+                    Needs defaultRouteMode observe/enforce. Route form defaults to the
+                    /1-split (leak-safe, never collides with enforce). Gateway is a
+                    stable next hop (a CARP VIP or a fallback-WAN gateway); leave blank
+                    to derive the peer from a point-to-point /30/31 interface. See the
+                    backup-egress docs.
+                -->
+                <backupEgress type="BooleanField">
+                    <Default>0</Default>
+                </backupEgress>
+                <backupEgressForm type="OptionField">
+                    <Required>N</Required>
+                    <Default>split</Default>
+                    <OptionValues>
+                        <split>/1-split (full internet, recommended)</split>
+                        <prefixes>Specific prefixes</prefixes>
+                    </OptionValues>
+                </backupEgressForm>
+                <!--
+                    The masks constrain each value to its own syntax and, like the
+                    DHCP-option fields above, forbid the pipe and any line break so the
+                    rendered keeper.conf line stays a single parseable record.
+                -->
+                <backupEgressGateway type="TextField">
+                    <Mask>/^[0-9.]{0,15}$/u</Mask>
+                    <ValidationMessage>Backup egress gateway: an IPv4 address (digits and dots only).</ValidationMessage>
+                    <Required>N</Required>
+                </backupEgressGateway>
+                <backupEgressInterface type="TextField">
+                    <Mask>/^[A-Za-z0-9_.]{0,32}$/u</Mask>
+                    <ValidationMessage>Backup egress interface: a device name (letters, digits, dot, underscore).</ValidationMessage>
+                    <Required>N</Required>
+                </backupEgressInterface>
+                <backupEgressPrefixes type="TextField">
+                    <Mask>/^[0-9.,\/ ]{0,256}$/u</Mask>
+                    <ValidationMessage>Backup egress prefixes: IPv4 CIDRs separated by comma or space.</ValidationMessage>
+                    <Required>N</Required>
+                </backupEgressPrefixes>
+
                 <description type="DescriptionField"/>
             </keeper>
         </keepers>

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
@@ -157,13 +157,16 @@
                     </OptionValues>
                 </backupEgressForm>
                 <!--
-                    The masks constrain each value to its own syntax and, like the
-                    DHCP-option fields above, forbid the pipe and any line break so the
-                    rendered keeper.conf line stays a single parseable record.
+                    Gateway and prefixes are NetworkField (proper IPv4 validation, rendered
+                    as address inputs); a valid address cannot contain the pipe or a line
+                    break, so the keeper.conf line stays a single parseable record. The
+                    interface is a device name, so it keeps a text mask that forbids both.
                 -->
-                <backupEgressGateway type="TextField">
-                    <Mask>/^[0-9.]{0,15}$/u</Mask>
-                    <ValidationMessage>Backup egress gateway: an IPv4 address (digits and dots only).</ValidationMessage>
+                <backupEgressGateway type="NetworkField">
+                    <AddressFamily>ipv4</AddressFamily>
+                    <NetMaskAllowed>N</NetMaskAllowed>
+                    <WildcardEnabled>N</WildcardEnabled>
+                    <ValidationMessage>Backup egress gateway: a valid IPv4 address, or blank to derive the peer from the interface.</ValidationMessage>
                     <Required>N</Required>
                 </backupEgressGateway>
                 <backupEgressInterface type="TextField">
@@ -171,9 +174,12 @@
                     <ValidationMessage>Backup egress interface: a device name (letters, digits, dot, underscore).</ValidationMessage>
                     <Required>N</Required>
                 </backupEgressInterface>
-                <backupEgressPrefixes type="TextField">
-                    <Mask>/^[0-9.,\/ ]{0,256}$/u</Mask>
-                    <ValidationMessage>Backup egress prefixes: IPv4 CIDRs separated by comma or space.</ValidationMessage>
+                <backupEgressPrefixes type="NetworkField">
+                    <AddressFamily>ipv4</AddressFamily>
+                    <NetMaskAllowed>Y</NetMaskAllowed>
+                    <WildcardEnabled>N</WildcardEnabled>
+                    <AsList>Y</AsList>
+                    <ValidationMessage>Backup egress prefixes: IPv4 CIDR destinations (CIDR notation like 10.0.0.0/24).</ValidationMessage>
                     <Required>N</Required>
                 </backupEgressPrefixes>
 

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/index.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/index.volt
@@ -21,6 +21,35 @@
  #}
 
 <script>
+    // Base dialogs have no declarative "show-if-other-field", so field couplings are
+    // toggled in JS, mirroring the core pattern (the OpenVPN instance dialog does the
+    // same). Hidden rows keep their values (the daemon ignores an inapplicable field);
+    // this only declutters the dialog. Every field toggled here is advanced, so it never
+    // appears unless advanced mode is on, gated on the toggle state exactly as core does.
+    function cvdToggleConditionalFields() {
+        let advancedOn = $("#DialogKeeper [id^='show_advanced_']").hasClass("fa-toggle-on");
+        function advRow(id, show) { $("#keeper\\." + id).closest("tr").toggle(show && advancedOn); }
+
+        // CARP failover on lease loss applies only to a fixed reservation, so it is
+        // mutually exclusive with "Follow dynamic DHCP address" (a follower adopts a new
+        // address instead of losing the lease).
+        advRow("demoteOnLeaseLoss", !$("#keeper\\.followIp").is(":checked"));
+
+        // Backup egress needs "Own default route by CARP role" on observe/enforce; its
+        // sub-fields need the feature enabled, and the prefix list needs the prefixes form.
+        let routeOwned = $("#keeper\\.defaultRouteMode").val() !== "off";
+        let backupOn = routeOwned && $("#keeper\\.backupEgress").is(":checked");
+        advRow("backupEgress", routeOwned);
+        advRow("backupEgressForm", backupOn);
+        advRow("backupEgressGateway", backupOn);
+        advRow("backupEgressInterface", backupOn);
+        advRow("backupEgressPrefixes", backupOn && $("#keeper\\.backupEgressForm").val() === "prefixes");
+
+        // Promiscuous ARP listen only has a reply to catch while the ARP nudge is enabled
+        // (interval 0 disables the nudge).
+        advRow("arpListenPromisc", parseInt($("#keeper\\.arpNudgeInterval").val(), 10) > 0);
+    }
+
     $(document).ready(function () {
         $("#grid-keepers").UIBootgrid({
             search: '/api/carpvipdhcp/settings/searchKeeper',
@@ -32,6 +61,17 @@
         });
         updateServiceControlUI('carpvipdhcp');
         $("#reconfigureAct").SimpleActionButton();
+
+        // Re-evaluate when the dialog opens (values are mapped in without firing change),
+        // when any trigger field changes, and after the advanced-mode toggle (deferred so
+        // it runs once the framework has shown/hidden the advanced rows).
+        let cvdTriggers = "#keeper\\.followIp, #keeper\\.defaultRouteMode, #keeper\\.backupEgress, "
+            + "#keeper\\.backupEgressForm, #keeper\\.arpNudgeInterval";
+        $("#DialogKeeper").on("shown.bs.modal", function () { setTimeout(cvdToggleConditionalFields, 0); });
+        $(cvdTriggers).on("change", cvdToggleConditionalFields);
+        $("#DialogKeeper").on("click", "[id^='show_advanced_']", function () {
+            setTimeout(cvdToggleConditionalFields, 0);
+        });
     });
 </script>
 

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/index.volt
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/views/OPNsense/CarpVipDhcp/index.volt
@@ -32,8 +32,13 @@
 
         // CARP failover on lease loss applies only to a fixed reservation, so it is
         // mutually exclusive with "Follow dynamic DHCP address" (a follower adopts a new
-        // address instead of losing the lease).
-        advRow("demoteOnLeaseLoss", !$("#keeper\\.followIp").is(":checked"));
+        // address instead of losing the lease). Clear it while following so no stale value
+        // lingers to trip the model's mutual-exclusivity check on a now-hidden field.
+        let following = $("#keeper\\.followIp").is(":checked");
+        if (following) {
+            $("#keeper\\.demoteOnLeaseLoss").prop("checked", false);
+        }
+        advRow("demoteOnLeaseLoss", !following);
 
         // Backup egress needs "Own default route by CARP role" on observe/enforce; its
         // sub-fields need the feature enabled, and the prefix list needs the prefixes form.

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -260,7 +260,11 @@ def main():
                    capture_backend=a.capture_backend, default_route_mode=a.default_route_mode,
                    backup_egress=backup_egress)
 
-        if a.arp_listen_promisc:
+        # Warn only when promiscuous capture is ACTUALLY in effect: it is gated on the ARP
+        # nudge (see Keeper.__init__), so a stale flag with the nudge disabled is ignored,
+        # not promiscuous -- warning off the raw flag would contradict that and misstate the
+        # node's security posture.
+        if a.arp_listen_promisc and a.arp_nudge > 0:
             LOG.warning("ARP listen: PROMISCUOUS capture enabled on %s -- the daemon now "
                         "sees all traffic on the segment (opt-in fallback for NICs that "
                         "drop the gateway's unicast ARP reply otherwise)", a.iface)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -64,7 +64,8 @@ from logging.handlers import RotatingFileHandler
 from leasekeeper.capture import CAPTURE_BACKENDS
 from leasekeeper.constants import LOGGER_NAME
 from leasekeeper.keeper import Keeper, carp_master
-from leasekeeper.route import DefaultRouteMode, DefaultRouteReconciler
+from leasekeeper.route import (
+    BackupEgressConfig, BackupEgressForm, DefaultRouteMode, DefaultRouteReconciler)
 from leasekeeper.util import MAC_RE
 
 LOG = logging.getLogger(LOGGER_NAME)
@@ -125,6 +126,13 @@ def acquire_pidfile(path):
             sys.exit(5)
 
 
+def _split_prefixes(raw):
+    """Split a backup-egress prefix list on commas and/or whitespace (both are documented
+    and allowed by the model mask), dropping empty tokens. Returns a tuple, empty for a
+    blank/None field."""
+    return tuple((raw or "").replace(",", " ").split())
+
+
 def _build_arg_parser():
     """The daemon's CLI."""
     ap = argparse.ArgumentParser(description="Robust DHCP lease-keeper (chaddr decoupled from the iface MAC)")
@@ -156,6 +164,19 @@ def _build_arg_parser():
                     help="own the IPv4 default route by CARP role: off (default), observe "
                          "(log what it would do, no FIB write), or enforce (install/withdraw "
                          "0/0 via the lease gateway while CARP master holding a lease)")
+    ap.add_argument("--backup-egress", action="store_true",
+                    help="while CARP backup, route this node's own internet traffic to the "
+                         "master (needs default-route-mode observe/enforce); see backup-egress docs")
+    ap.add_argument("--backup-egress-form", choices=[f.value for f in BackupEgressForm],
+                    default=BackupEgressForm.SPLIT.value,
+                    help="split (0.0.0.0/1+128.0.0.0/1, the default) or prefixes")
+    ap.add_argument("--backup-egress-gateway", default=None,
+                    help="stable next hop for backup egress (a CARP VIP or fallback-WAN gateway); "
+                         "blank derives the point-to-point peer of --backup-egress-interface")
+    ap.add_argument("--backup-egress-interface", default=None,
+                    help="interface to derive the backup-egress peer from when no gateway is set")
+    ap.add_argument("--backup-egress-prefixes", default=None,
+                    help="comma-separated prefixes for --backup-egress-form prefixes")
     ap.add_argument("--once", action="store_true")
     ap.add_argument("--release-on-exit", action="store_true")
     return ap
@@ -196,6 +217,17 @@ def main():
     # test: no guard and no FIB mutation, so it takes neither (pf stays None).
     pf = None if a.once else acquire_pidfile(a.pidfile)
     try:
+        # Built before the startup fail-stop so withdraw_unless_master ->
+        # Built before the fail-stop so the startup reconciler can clean the backup-egress
+        # routes this feature manages when it is enabled (else a node coming up as master
+        # with a stale /1 a crashed predecessor left would loop its egress).
+        backup_egress = BackupEgressConfig(
+            enabled=a.backup_egress,
+            form=BackupEgressForm(a.backup_egress_form),
+            gateway=a.backup_egress_gateway or None,
+            interface=a.backup_egress_interface or None,
+            prefixes=_split_prefixes(a.backup_egress_prefixes))
+
         # Fail-stop: a crashed predecessor (backend now missing, or a bad arg) may
         # have left a default in the FIB, still redistributed by FRR. Drop it here --
         # pure route(8), no capture backend -- BEFORE the backend preflight and the
@@ -203,8 +235,8 @@ def main():
         # (a master keeps its default, a backup withdraws; probe only when the mode
         # acts) lives in withdraw_unless_master. Skipped for --once and no vhid.
         if not a.once and a.vhid:
-            DefaultRouteReconciler(a.default_route_mode).withdraw_unless_master(
-                lambda: carp_master(a.iface, a.vhid))
+            DefaultRouteReconciler(a.default_route_mode, backup_egress=backup_egress) \
+                .withdraw_unless_master(lambda: carp_master(a.iface, a.vhid))
 
         # Fail fast (with a logged reason) if the selected backend cannot run on
         # this host -- checked uniformly through the registry so a future backend
@@ -225,7 +257,8 @@ def main():
                    vhid=a.vhid, follow=a.follow,
                    vendor_class=a.vendor_class, client_id=a.client_id, hostname=a.hostname,
                    arp_nudge=a.arp_nudge, arp_listen_promisc=a.arp_listen_promisc,
-                   capture_backend=a.capture_backend, default_route_mode=a.default_route_mode)
+                   capture_backend=a.capture_backend, default_route_mode=a.default_route_mode,
+                   backup_egress=backup_egress)
 
         if a.arp_listen_promisc:
             LOG.warning("ARP listen: PROMISCUOUS capture enabled on %s -- the daemon now "

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -217,7 +217,6 @@ def main():
     # test: no guard and no FIB mutation, so it takes neither (pf stays None).
     pf = None if a.once else acquire_pidfile(a.pidfile)
     try:
-        # Built before the startup fail-stop so withdraw_unless_master ->
         # Built before the fail-stop so the startup reconciler can clean the backup-egress
         # routes this feature manages when it is enabled (else a node coming up as master
         # with a stale /1 a crashed predecessor left would loop its egress).
@@ -277,15 +276,18 @@ def main():
         signal.signal(signal.SIGINT, _sig)
         signal.signal(signal.SIGTERM, _sig)
 
+        # SIGUSR1/SIGUSR2 are POSIX-only (the daemon runs on FreeBSD); access them
+        # dynamically so a non-POSIX static-analysis host neither errors nor needs a
+        # suppression that is then flagged as useless where the attributes do exist.
         def _sig_arp_nudge(*_):
             # Operator-requested immediate ARP nudge (configd action / kill -USR1).
             k.trigger_nudge()
-        signal.signal(signal.SIGUSR1, _sig_arp_nudge)  # type: ignore[attr-defined]  # pylint: disable=no-member
+        signal.signal(getattr(signal, "SIGUSR1"), _sig_arp_nudge)
 
         def _sig_carp(*_):
             # CARP transition (rc.syshook.d/carp/50-carpvipdhcp sends SIGUSR2).
             k.recheck_carp_role()
-        signal.signal(signal.SIGUSR2, _sig_carp)  # type: ignore[attr-defined]  # pylint: disable=no-member
+        signal.signal(getattr(signal, "SIGUSR2"), _sig_carp)
 
         if a.once:
             return k.claim_once()

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
@@ -18,4 +18,4 @@ wires up and runs the Keeper defined here. Modules, leaf-first:
 # PLUGIN_VERSION from this line (so the package version and the daemon's own
 # reported version can never drift). Keep the assignment on one line as
 # __version__ = "X.Y.Z" so the Makefile's sed can read it.
-__version__ = "1.11.4"
+__version__ = "1.12.0"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -191,8 +191,16 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # back (DHCP replies and ARP replies, routed below). Promiscuous
         # capture is off by default; the rationale lives in the module
         # docstring's security section.
+        # Promiscuous capture serves ONLY the ARP nudge reply (unicast to the CARP vMAC);
+        # DHCP replies are forced broadcast, so they are caught without it. With the nudge
+        # disabled (interval 0) there is nothing for it to catch, so a stale promisc flag is
+        # ignored rather than needlessly receiving all segment traffic.
+        effective_promisc = bool(arp_listen_promisc and arp_nudge > 0)
+        if arp_listen_promisc and not effective_promisc:
+            LOG.info("ARP listen promiscuous is set but the ARP nudge is disabled (interval "
+                     "0) -- ignoring it; promiscuous capture only serves the nudge reply")
         self._capture = CAPTURE_BACKENDS[capture_backend](
-            iface, arp_listen_promisc, self._on_dhcp_reply, self._on_arp_reply)
+            iface, effective_promisc, self._on_dhcp_reply, self._on_arp_reply)
 
         # ARP nudge component: owns the pacing and reachability state; the
         # keeper supplies the lease binding per nudge (_arp_nudge) and the

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -175,7 +175,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
                  hbfile=None, release_on_exit=False, vhid=None,
                  follow=False, vendor_class=None, client_id=None, hostname=None,
                  arp_nudge=0, arp_listen_promisc=False, capture_backend="scapy",
-                 default_route_mode="off"):
+                 default_route_mode="off", backup_egress=None):
         # Fixed identity/config, immutable once set (see _Config).
         self._cfg = _Config(
             iface=iface,
@@ -232,7 +232,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # split-brain install-gate is a deliberate follow-up that needs a
         # debounced carrier signal (a single transient ifconfig miss must not
         # flap the default); see docs/single-ip-wan-carp.md.
-        self._defroute = DefaultRouteReconciler(default_route_mode)
+        self._defroute = DefaultRouteReconciler(default_route_mode, backup_egress=backup_egress)
 
         self.redora_wait = REDORA_MIN
         # Link-return fast path (only while UNBOUND): a carrier down->up edge
@@ -475,7 +475,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         if master is not None:
             self._was_master = master
 
-    def _reconcile_default_route(self, master=_UNSET):
+    def _reconcile_default_route(self, master=_UNSET, *, probe_for_backup=False):
         """Drive the IPv4 default route toward its CARP-role-owned desired state
         (install 0/0 via the lease gateway only while master AND holding a lease;
         withdraw it otherwise -- see leasekeeper/route.py). Level-triggered and
@@ -497,6 +497,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             master = self._probe_carp_master()
         b = self._dhcp.binding
         self._defroute.reconcile(master, b.yiaddr is not None, b.lease_router)
+        # Backup egress needs the REAL CARP role: the unbound path drives the 0/0
+        # withdraw with a fictional master=False (role-independent for 0/0), which would
+        # wrongly install a backup route on a master-without-lease. probe_for_backup
+        # re-probes there so that edge is decided on the true role.
+        backup_master = self._probe_carp_master() if probe_for_backup else master
+        self._defroute.reconcile_backup_egress(backup_master)
 
     def _role_tick(self, master=_UNSET):
         """One shared CARP-role probe driving both the role poll and the
@@ -787,9 +793,22 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             # tearing it down and reinstalling. Only when the acquire cannot bind (a
             # lost lease, or a dead WAN: mode-D) do we withdraw, so a node that cannot
             # route stops advertising 0/0. Role-independent, no ifconfig probe.
+            #
+            # Before that (possibly long: DORA + backoff) acquire, settle backup egress on
+            # the REAL CARP role: a routed backup promoted to master while unbound must shed
+            # its /1 before it blocks, or that /1 loops the new master's egress for the whole
+            # acquire; a still-backup keeps its route. The 0/0 deliberately stays after the
+            # acquire (the no-flap restart path above). A promotion that lands mid-acquire is
+            # caught by the post-acquire reconcile on the next iteration.
+            if self._defroute.backup_egress_enabled:
+                self._defroute.reconcile_backup_egress(self._probe_carp_master())
             self._acquire_step()
             if not b.yiaddr:
-                self._reconcile_default_route(master=False)
+                # master=False is the fictional role for the role-independent 0/0
+                # withdraw; backup egress needs the true role (a master-without-lease
+                # must not get a backup route), so probe when the feature is enabled.
+                self._reconcile_default_route(
+                    master=False, probe_for_backup=self._defroute.backup_egress_enabled)
             return
         # Bound: own the default by CARP role, here at the loop head. _maintain_step
         # is re-entered after every transition (a just-acquired lease, a renew that

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -19,8 +19,10 @@ OPNsense does not also manage the default). Every route operation is idempotent
 and error-tolerant, so a redundant add/delete -- or a burst of coalesced signals
 collapsed onto one boolean flag -- converges quietly rather than raising.
 """
+import ipaddress
 import logging
 import subprocess
+from dataclasses import dataclass
 from enum import StrEnum
 
 from .constants import LOGGER_NAME, RECONCILE_HEARTBEAT_INTERVAL
@@ -48,6 +50,41 @@ class DefaultRouteMode(StrEnum):
     OFF = "off"
     OBSERVE = "observe"
     ENFORCE = "enforce"
+
+
+class BackupEgressForm(StrEnum):
+    """The route form the backup installs for its own egress (docs/backup-egress.md).
+    split: 0.0.0.0/1 + 128.0.0.0/1 -- full internet, but not the default, so it never
+    redistributes as a default nor collides with enforce (the recommended default, and
+    the fail-safe fallback for an unrecognised value). prefixes: a curated list of
+    specific destinations. (A plain 0.0.0.0/0 is deliberately not offered: it can only
+    run under observe/enforce, and enforce owns 0/0, so it could never install.)"""
+    SPLIT = "split"
+    PREFIXES = "prefixes"
+
+
+class _BackupState(StrEnum):
+    """The backup-egress desired state for a tick: present (install the set via the
+    gateway), absent (this node is master -- remove any managed route), or unresolved
+    (the gateway could not be worked out -- leave the FIB alone). Recorded per tick so
+    a change re-arms the heartbeat, like the 0/0 decision's _last_desired."""
+    PRESENT = "present"
+    ABSENT = "absent"
+    UNRESOLVED = "unresolved"
+
+
+@dataclass(frozen=True)
+class BackupEgressConfig:
+    """Config for the optional backup-egress feature: while a node is the CARP backup
+    (no WAN default) route its own internet traffic to the master. Flows in from the
+    model via argparse. Disabled by default; the reconciler is a no-op unless enabled.
+    gateway: a stable next hop (a CARP VIP or a fallback-WAN gateway); when blank the
+    peer is derived from `interface` (the other host of a point-to-point /30 or /31)."""
+    enabled: bool = False
+    form: BackupEgressForm = BackupEgressForm.SPLIT
+    gateway: "str | None" = None
+    interface: "str | None" = None
+    prefixes: "tuple[str, ...]" = ()
 
 
 class RouteCommand(StrEnum):
@@ -80,10 +117,21 @@ _UNSET = object()
 DEFAULT_UNREADABLE_ROLE_STRIKES = 3
 
 _ROUTE = "/sbin/route"
+_NETSTAT = "/usr/bin/netstat"
+_IFCONFIG = "/sbin/ifconfig"
 _NUMERIC = "-n"              # numeric output, no name resolution
 _AF_INET = "-inet"          # IPv4 address family modifier; the v6 twin: -inet6
 _GATEWAY_FIELD = "gateway:"  # the field label parsed from `route get` output
 _SUBPROC_TIMEOUT = 5
+
+# The /1-split: two half-internet routes that together cover 0.0.0.0/0 but are each
+# more specific than it (so they win over any default) and are not the default (so
+# redistribute kernel's exact-0/0 route-map never picks them up, and enforce, which
+# only manages 0/0, ignores them). See docs/backup-egress.md.
+_SPLIT_PREFIXES = ("0.0.0.0/1", "128.0.0.0/1")
+_DEFAULT_NET = ipaddress.ip_network("0.0.0.0/0")
+# Point-to-point prefix lengths a backup-egress peer can be derived from unambiguously.
+_PTP_PREFIXLENS = (30, 31)
 
 
 class DefaultRouteReconciler:
@@ -95,9 +143,13 @@ class DefaultRouteReconciler:
     All methods run on the keeper's main loop thread only; the class holds no
     lock because nothing else in the keeper mutates routes."""
 
+    # The 0/0 decision and the optional backup-egress decision each carry their own
+    # last-state + heartbeat, so the attribute count is intentional.
+    # pylint: disable=too-many-instance-attributes
+
     def __init__(self, mode: "str | DefaultRouteMode" = DefaultRouteMode.OFF, *,
                  unreadable_role_strikes=DEFAULT_UNREADABLE_ROLE_STRIKES,
-                 liveness_probe=None):
+                 liveness_probe=None, backup_egress: "BackupEgressConfig | None" = None):
         # mode flows in from the model verbatim (keeper.conf -> rc.d -> argparse)
         # as a plain string; coerce it, and treat any unrecognised value as inert
         # OFF. Set-once: exposed read-only via the `mode` property.
@@ -124,6 +176,16 @@ class DefaultRouteReconciler:
         # backup/master does not log its (identical) decision every tick and churn
         # the log rotation. A change re-arms it (see _at).
         self._heartbeat = _RateLimit(RECONCILE_HEARTBEAT_INTERVAL)
+        # Optional backup-egress (docs/backup-egress.md), with its own last-state and
+        # heartbeat so its logging does not interfere with the 0/0 decision's.
+        self._backup = backup_egress or BackupEgressConfig()
+        self._last_backup_desired = _UNSET
+        self._backup_heartbeat = _RateLimit(RECONCILE_HEARTBEAT_INTERVAL)
+        self._valid_prefixes = None            # cached validated prefixes (warn-once via the cache)
+        self._backup_unresolved_warned = False  # rising-edge gate for gateway-resolution warnings
+        self._fib_unreadable_warned = False    # rising-edge gate for the netstat-unreadable warning
+        self._backup_installed_gw = None       # the gateway last installed this session (ownership)
+        self._backup_collision_warned = False  # rising-edge gate for foreign-route collision warnings
 
     @property
     def mode(self):
@@ -134,6 +196,13 @@ class DefaultRouteReconciler:
     def enabled(self):
         """True in observe/enforce (off is inert); see DefaultRouteMode."""
         return self._mode in (DefaultRouteMode.OBSERVE, DefaultRouteMode.ENFORCE)
+
+    @property
+    def backup_egress_enabled(self):
+        """True when the backup-egress feature is active (mode observe/enforce AND the
+        feature enabled). Lets the caller decide whether the unbound path must probe the
+        real CARP role for backup egress (the 0/0 withdraw there uses a fictional role)."""
+        return self.enabled and self._backup.enabled
 
     def withdraw_unless_master(self, probe):
         """Drop an owned default UNLESS this node is the CARP master. `probe` is a
@@ -157,10 +226,37 @@ class DefaultRouteReconciler:
         static-correct) and telling it apart from a restart would need a fragile
         stop-vs-restart signal, so it is accepted."""
         if not self.enabled:
-            return
+            return    # off is fully inert: no FIB read/write, no probe.
+        # Clean the backup-egress set at the boundary so a stopped keeper leaves no route a
+        # later master would loop through. Only routes this feature actually manages are
+        # touched (withdraw_backup_egress no-ops when the feature is disabled): the /1-split
+        # is also the classic full-tunnel-VPN pair, so a keeper that never installed it must
+        # not delete a /1 it does not own.
+        self.withdraw_backup_egress()
         if probe() is True:
             return
         self.reconcile(is_master=False, bound=False, gateway=None)
+
+    def withdraw_backup_egress(self):
+        """Remove the backup-egress routes (the /1-split plus any configured prefixes) at a
+        process boundary, so a stopped keeper leaves none that a later master would loop
+        through. A no-op unless the feature is enabled: the /1-split (0.0.0.0/1 +
+        128.0.0.0/1) is also the classic full-tunnel-VPN split, so a keeper that never
+        managed backup egress must not delete a /1 it does not own -- routes are cleaned by
+        ownership, not by matching a shape. observe logs, enforce deletes. Unlike the
+        reconcile loop there is no next tick to retry, so an unconfirmable removal is
+        surfaced loudly here rather than left to a silent re-check.
+
+        Accepted limit: a /1 left by a crashed predecessor whose feature (or mode) is then
+        disabled before restart is not cleaned, because it can no longer be told apart from
+        an unrelated VPN /1. That narrow crash-then-disable case needs manual cleanup (or
+        the deferred persisted-ownership follow-up); see docs/backup-egress.md."""
+        if not self.backup_egress_enabled:
+            return
+        self._backup_remove(self._backup_removal_set(), changed=True, reason="keeper stopping")
+        if self._mode == DefaultRouteMode.ENFORCE and self._fib_routes() is None:
+            LOG.warning("backup egress: could not confirm removal at shutdown (routing table "
+                        "unreadable) -- a leftover /1 would loop egress if this node is master")
 
     def reconcile(self, is_master, bound, gateway):
         """Drive the FIB default toward the desired state for the current
@@ -238,18 +334,20 @@ class DefaultRouteReconciler:
             else:
                 self._withdraw(changed, have, reason)
 
-    def _at(self, changed):
+    def _at(self, changed, heartbeat=None):
         """Pick the log callable for a desired-state confirmation. A state change
         logs at INFO the first time the state is entered, and re-arms the heartbeat
         so the identical DEBUG repeat does not fire on the very next tick. An
         unchanged repeat logs at DEBUG at most once per RECONCILE_HEARTBEAT_INTERVAL
         (proof the reconciler is alive and its decision); the ticks in between are
         dropped, so a steady node does not fill the log file with a per-tick
-        heartbeat and churn the rotation."""
+        heartbeat and churn the rotation. `heartbeat` defaults to the 0/0 decision's;
+        the backup-egress decision passes its own so the two do not interfere."""
+        hb = heartbeat if heartbeat is not None else self._heartbeat
         if changed:
-            self._heartbeat.reset()
+            hb.reset()
             return LOG.info
-        ok, _ = self._heartbeat.ready()
+        ok, _ = hb.ready()
         return LOG.debug if ok else _drop
 
     @staticmethod
@@ -280,6 +378,318 @@ class DefaultRouteReconciler:
             self._at(changed)("[observe] no default held (%s) -- as wanted", reason)
         else:
             self._at(changed)("no default held (%s)", reason)
+
+    # ---- backup egress (optional; docs/backup-egress.md) ----
+
+    def reconcile_backup_egress(self, is_master):
+        """Keep the backup-egress route set present while this node is the CARP
+        backup and absent while it is master (the inverse of the 0/0 it manages).
+        Call from the same tick as reconcile(), after it. A no-op unless the feature
+        is enabled and the mode is observe/enforce (off is inert). is_master None (an
+        unreadable role) touches nothing, like the 0/0 side."""
+        if not self.enabled or not self._backup.enabled or is_master is None:
+            return
+        if is_master:
+            self._backup_unresolved_warned = False   # re-arm so a returning backup re-warns once
+            desired = (_BackupState.ABSENT, None)
+        else:
+            gateway = self._resolve_backup_gateway()
+            desired = ((_BackupState.PRESENT, gateway) if gateway
+                       else (_BackupState.UNRESOLVED, None))
+        changed = desired != self._last_backup_desired
+        self._last_backup_desired = desired
+        state, gateway = desired
+        if state is _BackupState.PRESENT:
+            self._backup_install(self._backup_route_set(), gateway, changed)
+        elif state is _BackupState.ABSENT:
+            # Remove the UNION of every form's prefixes, not just the current one, so a
+            # form change that orphaned an old set (e.g. split -> prefixes) is cleaned
+            # up here too -- a leftover /1 on the master would loop all egress.
+            self._backup_remove(self._backup_removal_set(), changed)
+        # UNRESOLVED: the gateway could not be worked out (warned, rising-edge); leave
+        # the FIB as-is rather than tearing down a possibly-good route.
+
+    # ---- backup-egress route sets (cached: form/prefixes/mode are set-once) ----
+
+    def _backup_route_set(self):
+        """The prefixes to install for the configured form. SPLIT (and any unrecognised
+        form) is the leak-safe /1-split; PREFIXES is the validated configured list."""
+        if self._backup.form == BackupEgressForm.PREFIXES:
+            return self._backup_prefixes()
+        return _SPLIT_PREFIXES
+
+    def _backup_removal_set(self):
+        """The /1-split plus the CURRENT configured prefixes -- the set removed on the
+        master. This covers a form change (split <-> prefixes; the /1-split is always
+        included) but NOT a prefixes-LIST change across an ungraceful exit: a prefix
+        dropped from the config while a crashed predecessor still had it installed is not
+        known here and would orphan (a black-hole for that one prefix, not egress-wide).
+        A graceful restart removes the old set at shutdown; only crash-then-list-change
+        leaves it. Persisting the managed set is deferred (see docs/backup-egress.md)."""
+        return tuple(dict.fromkeys(_SPLIT_PREFIXES + self._backup_prefixes()))
+
+    def _backup_prefixes(self):
+        """The validated configured prefixes, cached so the drop warnings (invalid
+        prefix, 0.0.0.0/0 under enforce, empty prefixes list) each fire once."""
+        if self._valid_prefixes is None:
+            valid = []
+            for prefix in self._backup.prefixes:
+                try:
+                    net = ipaddress.ip_network(prefix, strict=False)
+                except ValueError:
+                    LOG.warning("backup egress: ignoring invalid prefix %r", prefix)
+                    continue
+                if net.version != 4:   # the FIB ops are IPv4-only (netstat/route -inet)
+                    LOG.warning("backup egress: ignoring non-IPv4 prefix %r (IPv4 only)", prefix)
+                    continue
+                if self._mode == DefaultRouteMode.ENFORCE and net == _DEFAULT_NET:
+                    LOG.warning("backup egress: 0.0.0.0/0 is owned by enforce and cannot be "
+                                "a backup-egress route -- ignoring it (use the /1-split)")
+                    continue
+                valid.append(prefix)
+            if self._backup.form == BackupEgressForm.PREFIXES and not valid:
+                LOG.warning("backup egress: form is 'prefixes' but no valid prefixes are set")
+            self._valid_prefixes = tuple(valid)
+        return self._valid_prefixes
+
+    # ---- gateway resolution ----
+
+    def _resolve_backup_gateway(self):
+        """The next hop for the backup-egress route: the configured stable gateway (a
+        CARP VIP or a fallback-WAN gateway), or, when blank, the derived point-to-point
+        peer of the configured interface. None (warned, rising-edge) when it cannot be
+        worked out; a successful resolve re-arms the warning."""
+        gateway = self._backup_gateway()
+        self._backup_unresolved_warned = gateway is None
+        return gateway
+
+    def _backup_gateway(self):
+        cfg = self._backup
+        if cfg.gateway:
+            own = self._gateway_is_own(cfg.gateway)   # True / False / None (could not check)
+            if own is None:
+                self._warn_unresolved("backup egress: could not verify gateway %s (route get "
+                                      "failed) -- deferring rather than routing via a maybe-own "
+                                      "address", cfg.gateway)
+                return None
+            if own:
+                self._warn_unresolved("backup egress: gateway %s is this node's own address "
+                                      "(config-sync trap) -- not routing via self", cfg.gateway)
+                return None
+            return cfg.gateway
+        if not cfg.interface:
+            self._warn_unresolved("backup egress: no gateway set and no interface to derive "
+                                  "one from")
+            return None
+        return self._derive_peer(cfg.interface)
+
+    def _warn_unresolved(self, fmt, *args):
+        """Log a gateway-resolution failure at most once per unresolved episode: a node
+        can sit as backup for a long time, so the message must not churn the log."""
+        if not self._backup_unresolved_warned:
+            LOG.warning(fmt, *args)
+
+    def _gateway_is_own(self, gateway):
+        """Tri-state: True if `gateway` is this node's own address (FreeBSD routes a local
+        address via lo0), False if it is not, None if the check could not run (route get
+        failed). Catches the config-sync trap of an explicit peer unicast that is correct
+        on the peer but equals this node's own IP. A CARP VIP this node is backup for is
+        not active locally, so it resolves via the real interface, not lo0 -- the
+        recommended VIP gateway is not caught. Never cached: a transient route-get failure
+        must not permanently disable the guard, so the caller defers on None and re-checks."""
+        res = self._run([_ROUTE, _NUMERIC, RouteCommand.GET, _AF_INET, gateway])
+        if res is None or res.returncode != 0:
+            return None   # could not determine -> caller defers rather than routing blind
+        for line in res.stdout.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("interface:"):
+                return stripped.split(":", 1)[1].strip() == "lo0"
+        return False
+
+    def _derive_peer(self, iface):
+        """The other host of a point-to-point (/30 or /31) subnet on `iface` = the
+        peer/master. None (warned) on a non-point-to-point interface or an unreadable
+        address, so we never guess a peer."""
+        info = self._iface_ipv4(iface)
+        if info is None:
+            self._warn_unresolved("backup egress: cannot read an IPv4 address on %s", iface)
+            return None
+        own, prefixlen = info
+        if prefixlen not in _PTP_PREFIXLENS:
+            self._warn_unresolved("backup egress: %s is /%d, not a point-to-point /30 or /31 "
+                                  "-- the peer is not unique, set an explicit gateway",
+                                  iface, prefixlen)
+            return None
+        net = ipaddress.ip_network(f"{own}/{prefixlen}", strict=False)
+        for host in net.hosts():
+            if str(host) != own:
+                return str(host)
+        return None
+
+    def _iface_ipv4(self, iface):
+        """(address, prefixlen) of the first IPv4 on `iface`, or None. Parses
+        `ifconfig <iface> inet` ('inet A netmask 0xMMMMMMMM ...')."""
+        res = self._run([_IFCONFIG, iface, "inet"])
+        if res is None or res.returncode != 0:
+            return None
+        toks = res.stdout.split()
+        addr = mask = None
+        for i, tok in enumerate(toks):
+            if tok == "inet" and addr is None and i + 1 < len(toks):
+                addr = toks[i + 1]
+            elif tok == "netmask" and mask is None and i + 1 < len(toks):
+                mask = toks[i + 1]
+        if addr is None or mask is None:
+            return None
+        try:
+            bits = bin(int(mask, 16)).count("1")
+            ipaddress.ip_address(addr)
+        except ValueError:
+            return None
+        return addr, bits
+
+    # ---- backup-egress FIB operations (idempotent, fail-safe on an unreadable table) ----
+
+    def _backup_owned_gateways(self):
+        """Gateway strings that mark a backup-egress route as managed by THIS feature: the
+        configured explicit gateway (stable across role and restart) and the gateway last
+        installed this session. A FIB entry for one of our prefixes is ours -- safe to
+        change or remove -- only when its next hop is one of these; any other next hop is a
+        foreign route (a full-tunnel VPN's /1, a static or connected route) we must never
+        touch. Empty when neither is known (e.g. a derived peer on a fresh master), which
+        makes cleanup best-effort there rather than risk clobbering an unrelated route."""
+        gateways = set()
+        if self._backup.gateway:
+            gateways.add(self._backup.gateway)
+        if self._backup_installed_gw:
+            gateways.add(self._backup_installed_gw)
+        return gateways
+
+    def _note_backup_collisions(self, prefixes, gateway):
+        """Warn (rising-edge) that a backup-egress prefix already has a foreign next hop, so
+        the operator sees it; re-arm the gate once a pass is collision-free. `gateway` is our
+        intended next hop on install, None on removal."""
+        if not prefixes:
+            self._backup_collision_warned = False
+            return
+        if not self._backup_collision_warned:
+            LOG.warning("backup egress: %s already routed via another next hop (not %s) -- "
+                        "leaving it untouched (not managed by this feature)",
+                        " ".join(prefixes), gateway or "our gateway")
+            self._backup_collision_warned = True
+
+    def _backup_install(self, route_set, gateway, changed):
+        if not route_set:
+            return
+        if self._mode == DefaultRouteMode.OBSERVE:
+            self._at(changed, self._backup_heartbeat)(
+                "[observe] would route backup egress via %s (%s)", gateway, " ".join(route_set))
+            return
+        have = self._fib_routes()
+        if have is None:
+            # netstat unreadable (already warned in _fib_routes); defer rather than
+            # blind-add, which would miss a needed change / stale-gateway correction.
+            return
+        owned = self._backup_owned_gateways() | {gateway}
+        pending, collisions = [], []
+        for prefix in route_set:
+            cur = have.get(self._net(prefix))
+            if cur == gateway:
+                continue                       # already ours and correct
+            if cur is None or cur in owned:
+                pending.append(prefix)         # absent -> ADD; our own stale gateway -> CHANGE
+            else:
+                collisions.append(prefix)      # foreign next hop -> never overwrite
+        self._note_backup_collisions(collisions, gateway)
+        if not pending:
+            if not collisions:
+                self._at(changed, self._backup_heartbeat)(
+                    "backup egress via %s (%s)", gateway, " ".join(route_set))
+            return
+        for prefix in pending:
+            verb = RouteCommand.ADD if have.get(self._net(prefix)) is None else RouteCommand.CHANGE
+            self._route(verb, prefix, gateway)
+        self._backup_installed_gw = gateway
+        now = self._fib_routes()
+        if now is None:
+            return   # adds issued but cannot confirm (already warned); re-check next tick
+        missing = [p for p in pending if now.get(self._net(p)) != gateway]
+        if not missing:
+            LOG.info("backup egress routed via %s (%s)", gateway, " ".join(pending))
+        else:
+            LOG.error("backup egress: failed to route %s via %s", " ".join(missing), gateway)
+
+    def _backup_remove(self, removal_set, changed, reason="now master"):
+        # `reason` distinguishes callers so the log does not assert a role change that
+        # did not happen: the reconcile master path uses the default, the shutdown
+        # boundary passes "keeper stopping".
+        if self._mode == DefaultRouteMode.OBSERVE:
+            self._at(changed, self._backup_heartbeat)(
+                "[observe] would remove backup egress (%s)", " ".join(removal_set))
+            return
+        have = self._fib_routes()
+        if have is None:
+            # Unreadable table: ownership cannot be verified, and the /1-split is also a
+            # full-tunnel-VPN pair, so a blind delete could tear down an unrelated route.
+            # Skip (already warned in _fib_routes); the next readable tick removes ours.
+            return
+        owned = self._backup_owned_gateways()
+        present, collisions = [], []
+        for prefix in removal_set:
+            cur = have.get(self._net(prefix))
+            if cur is None:
+                continue                       # not in the table
+            if cur in owned:
+                present.append(prefix)         # our next hop -> safe to remove
+            else:
+                collisions.append(prefix)      # foreign next hop -> leave it
+        self._note_backup_collisions(collisions, None)
+        if not present:
+            self._at(changed, self._backup_heartbeat)("no backup egress (%s)", reason)
+            return
+        for prefix in present:
+            self._route(RouteCommand.DELETE, prefix)
+        now = self._fib_routes()
+        if now is None:
+            return   # deletes issued but cannot confirm (already warned); re-check next tick
+        still = [p for p in present if now.get(self._net(p)) in owned]
+        if not still:
+            LOG.info("removed backup egress -- %s", reason)
+        else:
+            LOG.error("backup egress: failed to remove %s -- this node would loop its egress",
+                      " ".join(still))
+
+    def _fib_routes(self):
+        """{network: gateway} for the IPv4 FIB from one `netstat -rn` pass, or None when
+        the table cannot be read -- callers must not mistake an unreadable table for 'no
+        routes' and skip the master-side removal. A bare host address parses as /32;
+        header and default rows that are not a network are skipped."""
+        res = self._run([_NETSTAT, "-rn", "-f", "inet"])
+        if res is None or res.returncode != 0:
+            if not self._fib_unreadable_warned:   # once per unreadable episode (re-armed below)
+                # Neutral wording: on install this defers the write, but on the master
+                # removal path the deletes ARE issued and only the confirm is deferred.
+                LOG.warning("backup egress: cannot read the routing table (netstat) -- route "
+                            "state cannot be confirmed until it is readable")
+                self._fib_unreadable_warned = True
+            return None
+        self._fib_unreadable_warned = False
+        routes = {}
+        for line in res.stdout.splitlines():
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            try:
+                net = ipaddress.ip_network(parts[0], strict=False)
+            except ValueError:
+                continue
+            routes.setdefault(net, parts[1])
+        return routes
+
+    @staticmethod
+    def _net(prefix):
+        """Parse a (pre-validated) prefix string to a network, for FIB comparison."""
+        return ipaddress.ip_network(prefix, strict=False)
 
     # ---- role-unknown handling ----
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -184,7 +184,7 @@ class DefaultRouteReconciler:
         self._valid_prefixes = None            # cached validated prefixes (warn-once via the cache)
         self._backup_unresolved_warned = False  # rising-edge gate for gateway-resolution warnings
         self._fib_unreadable_warned = False    # rising-edge gate for the netstat-unreadable warning
-        self._backup_installed_gw = None       # the gateway last installed this session (ownership)
+        self._backup_installed_gws = set()     # gateways our prefixes are confirmed at (ownership)
         self._backup_collision_warned = False  # rising-edge gate for foreign-route collision warnings
 
     @property
@@ -552,17 +552,16 @@ class DefaultRouteReconciler:
 
     def _backup_owned_gateways(self):
         """Gateway strings that mark a backup-egress route as managed by THIS feature: the
-        configured explicit gateway (stable across role and restart) and the gateway last
-        installed this session. A FIB entry for one of our prefixes is ours -- safe to
-        change or remove -- only when its next hop is one of these; any other next hop is a
-        foreign route (a full-tunnel VPN's /1, a static or connected route) we must never
-        touch. Empty when neither is known (e.g. a derived peer on a fresh master), which
-        makes cleanup best-effort there rather than risk clobbering an unrelated route."""
-        gateways = set()
+        configured explicit gateway (stable across role and restart) plus every gateway our
+        prefixes are currently confirmed present at this session. A FIB entry for one of our
+        prefixes is ours -- safe to change or remove -- only when its next hop is one of
+        these; any other next hop is a foreign route (a full-tunnel VPN's /1, a static or
+        connected route) we must never touch. Empty when nothing is known (e.g. a derived
+        peer on a fresh master), which makes cleanup best-effort there rather than risk
+        clobbering an unrelated route."""
+        gateways = set(self._backup_installed_gws)
         if self._backup.gateway:
             gateways.add(self._backup.gateway)
-        if self._backup_installed_gw:
-            gateways.add(self._backup_installed_gw)
         return gateways
 
     def _note_backup_collisions(self, prefixes, gateway):
@@ -586,6 +585,34 @@ class DefaultRouteReconciler:
                             " ".join(prefixes), gateway)
             self._backup_collision_warned = True
 
+    def _classify_backup_prefixes(self, route_set, gateway, have):
+        """Split the desired prefixes against the current FIB `have` into (pending,
+        collisions): pending are absent or present via a gateway we already own (ADD/CHANGE
+        toward `gateway`); collisions are present via a foreign next hop we must never
+        overwrite. A prefix already correct via `gateway` needs neither."""
+        owned = self._backup_owned_gateways() | {gateway}
+        pending, collisions = [], []
+        for prefix in route_set:
+            cur = have.get(self._net(prefix))
+            if cur == gateway:
+                continue                       # already ours and correct
+            if cur is None or cur in owned:
+                pending.append(prefix)         # absent -> ADD; our own stale gateway -> CHANGE
+            else:
+                collisions.append(prefix)      # foreign next hop -> never overwrite
+        return pending, collisions
+
+    def _record_backup_ownership(self, gateway, state, route_set):
+        """Own the gateways at which our prefixes are CONFIRMED present in `state` (a FIB
+        snapshot): fold in the just-resolved `gateway`, then keep only owned gateways still
+        hosting one of our prefixes. Never speculative -- a failed change keeps the still-
+        present old next hop owned (so promotion still removes it), while a succeeded change
+        retires it."""
+        self._backup_installed_gws = {
+            gw for gw in (self._backup_installed_gws | {gateway})
+            if any(state.get(self._net(p)) == gw for p in route_set)
+        }
+
     def _backup_install(self, route_set, gateway, changed):
         if not route_set:
             return
@@ -598,37 +625,23 @@ class DefaultRouteReconciler:
             # netstat unreadable (already warned in _fib_routes); defer rather than
             # blind-add, which would miss a needed change / stale-gateway correction.
             return
-        owned = self._backup_owned_gateways() | {gateway}
-        pending, collisions, mine = [], [], False
-        for prefix in route_set:
-            cur = have.get(self._net(prefix))
-            if cur == gateway:
-                mine = True                    # already ours and correct
-                continue
-            if cur is None or cur in owned:
-                pending.append(prefix)         # absent -> ADD; our own stale gateway -> CHANGE
-            else:
-                collisions.append(prefix)      # foreign next hop -> never overwrite
-        if pending or mine:
-            # Ownership is "the next hop we have resolved as ours", recorded whether we install
-            # or merely confirm the set already present -- so a restarted backup that inherited
-            # its own /1 still owns it and removes it on promotion. Without this, a derived-peer
-            # master (no configured gateway to fall back on) would see an empty ownership set,
-            # treat its own leftover /1 as foreign, and loop its egress.
-            self._backup_installed_gw = gateway
+        pending, collisions = self._classify_backup_prefixes(route_set, gateway, have)
         self._note_backup_collisions(collisions, gateway)
+        state = have
+        if pending:
+            for prefix in pending:
+                verb = RouteCommand.ADD if have.get(self._net(prefix)) is None else RouteCommand.CHANGE
+                self._route(verb, prefix, gateway)
+            state = self._fib_routes()
+            if state is None:
+                return   # writes issued but cannot confirm (already warned); re-check next tick
+        self._record_backup_ownership(gateway, state, route_set)
         if not pending:
             if not collisions:
                 self._at(changed, self._backup_heartbeat)(
                     "backup egress via %s (%s)", gateway, " ".join(route_set))
             return
-        for prefix in pending:
-            verb = RouteCommand.ADD if have.get(self._net(prefix)) is None else RouteCommand.CHANGE
-            self._route(verb, prefix, gateway)
-        now = self._fib_routes()
-        if now is None:
-            return   # adds issued but cannot confirm (already warned); re-check next tick
-        missing = [p for p in pending if now.get(self._net(p)) != gateway]
+        missing = [p for p in pending if state.get(self._net(p)) != gateway]
         if not missing:
             LOG.info("backup egress routed via %s (%s)", gateway, " ".join(pending))
         else:

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -602,16 +602,21 @@ class DefaultRouteReconciler:
                 collisions.append(prefix)      # foreign next hop -> never overwrite
         return pending, collisions
 
-    def _record_backup_ownership(self, gateway, state, route_set):
-        """Own the gateways at which our prefixes are CONFIRMED present in `state` (a FIB
-        snapshot): fold in the just-resolved `gateway`, then keep only owned gateways still
-        hosting one of our prefixes. Never speculative -- a failed change keeps the still-
-        present old next hop owned (so promotion still removes it), while a succeeded change
-        retires it."""
+    def _prune_backup_ownership(self, state, route_set):
+        """Keep only owned gateways still hosting one of our prefixes in `state`, so a route
+        that was removed or migrated does not leave its old next hop retained as owned --
+        which would let a later CHANGE overwrite an unrelated route that reappears via it."""
         self._backup_installed_gws = {
-            gw for gw in (self._backup_installed_gws | {gateway})
+            gw for gw in self._backup_installed_gws
             if any(state.get(self._net(p)) == gw for p in route_set)
         }
+
+    def _record_backup_ownership(self, gateway, state, route_set):
+        """Fold in the just-resolved `gateway`, then prune to gateways still hosting one of
+        our prefixes. Never speculative -- a failed change keeps the still-present old next
+        hop owned (so promotion still removes it), while a succeeded change retires it."""
+        self._backup_installed_gws.add(gateway)
+        self._prune_backup_ownership(state, route_set)
 
     def _backup_install(self, route_set, gateway, changed):
         if not route_set:
@@ -673,6 +678,7 @@ class DefaultRouteReconciler:
                 collisions.append(prefix)      # foreign next hop -> leave it
         self._note_backup_collisions(collisions, None)
         if not present:
+            self._prune_backup_ownership(have, removal_set)   # nothing of ours here -> drop stale gws
             self._at(changed, self._backup_heartbeat)("no backup egress (%s)", reason)
             return
         for prefix in present:
@@ -680,6 +686,7 @@ class DefaultRouteReconciler:
         now = self._fib_routes()
         if now is None:
             return   # deletes issued but cannot confirm (already warned); re-check next tick
+        self._prune_backup_ownership(now, removal_set)        # removed routes -> retire their gws
         still = [p for p in present if now.get(self._net(p)) in owned]
         if not still:
             LOG.info("removed backup egress -- %s", reason)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -255,7 +255,7 @@ class DefaultRouteReconciler:
             return
         self._backup_remove(self._backup_removal_set(), changed=True, reason="keeper stopping")
         if self._mode == DefaultRouteMode.ENFORCE and self._fib_routes() is None:
-            LOG.warning("backup egress: could not confirm removal at shutdown (routing table "
+            LOG.warning("backup egress: could not clean up at shutdown (routing table "
                         "unreadable) -- a leftover /1 would loop egress if this node is master")
 
     def reconcile(self, is_master, bound, gateway):
@@ -387,7 +387,7 @@ class DefaultRouteReconciler:
         Call from the same tick as reconcile(), after it. A no-op unless the feature
         is enabled and the mode is observe/enforce (off is inert). is_master None (an
         unreadable role) touches nothing, like the 0/0 side."""
-        if not self.enabled or not self._backup.enabled or is_master is None:
+        if not self.backup_egress_enabled or is_master is None:
             return
         if is_master:
             self._backup_unresolved_warned = False   # re-arm so a returning backup re-warns once
@@ -568,14 +568,22 @@ class DefaultRouteReconciler:
     def _note_backup_collisions(self, prefixes, gateway):
         """Warn (rising-edge) that a backup-egress prefix already has a foreign next hop, so
         the operator sees it; re-arm the gate once a pass is collision-free. `gateway` is our
-        intended next hop on install, None on removal."""
+        intended next hop on install; None on the master-side removal, where an unattributable
+        /1 might actually be our own stale leftover looping this node's egress."""
         if not prefixes:
             self._backup_collision_warned = False
             return
         if not self._backup_collision_warned:
-            LOG.warning("backup egress: %s already routed via another next hop (not %s) -- "
-                        "leaving it untouched (not managed by this feature)",
-                        " ".join(prefixes), gateway or "our gateway")
+            if gateway is None:
+                LOG.warning("backup egress: %s present via a next hop this node does not own "
+                            "-- leaving it untouched; if it is a stale backup-egress route this "
+                            "node is now looping its own egress (clean it up, or set an explicit "
+                            "backup-egress gateway so ownership survives a restart)",
+                            " ".join(prefixes))
+            else:
+                LOG.warning("backup egress: %s already routed via another next hop (not %s) -- "
+                            "leaving it untouched (not managed by this feature)",
+                            " ".join(prefixes), gateway)
             self._backup_collision_warned = True
 
     def _backup_install(self, route_set, gateway, changed):
@@ -591,15 +599,23 @@ class DefaultRouteReconciler:
             # blind-add, which would miss a needed change / stale-gateway correction.
             return
         owned = self._backup_owned_gateways() | {gateway}
-        pending, collisions = [], []
+        pending, collisions, mine = [], [], False
         for prefix in route_set:
             cur = have.get(self._net(prefix))
             if cur == gateway:
-                continue                       # already ours and correct
+                mine = True                    # already ours and correct
+                continue
             if cur is None or cur in owned:
                 pending.append(prefix)         # absent -> ADD; our own stale gateway -> CHANGE
             else:
                 collisions.append(prefix)      # foreign next hop -> never overwrite
+        if pending or mine:
+            # Ownership is "the next hop we have resolved as ours", recorded whether we install
+            # or merely confirm the set already present -- so a restarted backup that inherited
+            # its own /1 still owns it and removes it on promotion. Without this, a derived-peer
+            # master (no configured gateway to fall back on) would see an empty ownership set,
+            # treat its own leftover /1 as foreign, and loop its egress.
+            self._backup_installed_gw = gateway
         self._note_backup_collisions(collisions, gateway)
         if not pending:
             if not collisions:
@@ -609,7 +625,6 @@ class DefaultRouteReconciler:
         for prefix in pending:
             verb = RouteCommand.ADD if have.get(self._net(prefix)) is None else RouteCommand.CHANGE
             self._route(verb, prefix, gateway)
-        self._backup_installed_gw = gateway
         now = self._fib_routes()
         if now is None:
             return   # adds issued but cannot confirm (already warned); re-check next tick

--- a/net/os-carp-vip-dhcp/src/opnsense/service/templates/OPNsense/CarpVipDhcp/keeper.conf
+++ b/net/os-carp-vip-dhcp/src/opnsense/service/templates/OPNsense/CarpVipDhcp/keeper.conf
@@ -26,7 +26,11 @@
 {%       set chaddr = '' %}
 {%     endif %}
 {%     if vip.iface and chaddr %}
-{{ k.carpVip }}|{{ vip.iface }}|{{ chaddr }}|{{ k.demoteOnLeaseLoss|default('0') }}|{{ vip.vhid }}|{{ k.followIp|default('0') }}|{{ k.vendorClass|default('') }}|{{ k.clientId|default('') }}|{{ k.hostname|default('') }}|{{ k.arpNudgeInterval|default('0') }}|{{ k.arpListenPromisc|default('0') }}|{{ k.captureBackend|default('') }}|{{ k.defaultRouteMode|default('off') }}|{{ k.backupEgress|default('0') }}|{{ k.backupEgressForm|default('split') }}|{{ k.backupEgressGateway|default('') }}|{{ k.backupEgressInterface|default('') }}|{{ k.backupEgressPrefixes|default('') }}
+{%       set beiface = '' %}
+{%       if k.backupEgressInterface|default('') %}
+{%         set beiface = helpers.physical_interface(k.backupEgressInterface) %}
+{%       endif %}
+{{ k.carpVip }}|{{ vip.iface }}|{{ chaddr }}|{{ k.demoteOnLeaseLoss|default('0') }}|{{ vip.vhid }}|{{ k.followIp|default('0') }}|{{ k.vendorClass|default('') }}|{{ k.clientId|default('') }}|{{ k.hostname|default('') }}|{{ k.arpNudgeInterval|default('0') }}|{{ k.arpListenPromisc|default('0') }}|{{ k.captureBackend|default('') }}|{{ k.defaultRouteMode|default('off') }}|{{ k.backupEgress|default('0') }}|{{ k.backupEgressForm|default('split') }}|{{ k.backupEgressGateway|default('') }}|{{ beiface }}|{{ k.backupEgressPrefixes|default('') }}
 {%     endif %}
 {%   endif %}
 {% endfor %}

--- a/net/os-carp-vip-dhcp/src/opnsense/service/templates/OPNsense/CarpVipDhcp/keeper.conf
+++ b/net/os-carp-vip-dhcp/src/opnsense/service/templates/OPNsense/CarpVipDhcp/keeper.conf
@@ -1,7 +1,7 @@
 {#
     Rendered keeper table for lease_keeper.py (one line per enabled keeper).
 
-    Format per line:  REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE|ARP_LISTEN_PROMISC|CAPTURE_BACKEND|DEFAULT_ROUTE_MODE
+    Format per line:  REQUEST_IP|IFACE|CHADDR|DEMOTE_ON_LEASE_LOSS|VHID|FOLLOW_IP|VENDOR_CLASS|CLIENT_ID|HOSTNAME|ARP_NUDGE|ARP_LISTEN_PROMISC|CAPTURE_BACKEND|DEFAULT_ROUTE_MODE|BACKUP_EGRESS|BACKUP_EGRESS_FORM|BACKUP_EGRESS_GW|BACKUP_EGRESS_IFACE|BACKUP_EGRESS_PREFIXES
     Everything is derived from each keeper's referenced CARP VirtualIP: we look
     the VIP up in the legacy virtualip list to get its interface (-> physical
     device) and VHID (-> chaddr 00:00:5e:00:01:VHID). chaddrOverride wins when set.
@@ -26,7 +26,7 @@
 {%       set chaddr = '' %}
 {%     endif %}
 {%     if vip.iface and chaddr %}
-{{ k.carpVip }}|{{ vip.iface }}|{{ chaddr }}|{{ k.demoteOnLeaseLoss|default('0') }}|{{ vip.vhid }}|{{ k.followIp|default('0') }}|{{ k.vendorClass|default('') }}|{{ k.clientId|default('') }}|{{ k.hostname|default('') }}|{{ k.arpNudgeInterval|default('0') }}|{{ k.arpListenPromisc|default('0') }}|{{ k.captureBackend|default('') }}|{{ k.defaultRouteMode|default('off') }}
+{{ k.carpVip }}|{{ vip.iface }}|{{ chaddr }}|{{ k.demoteOnLeaseLoss|default('0') }}|{{ vip.vhid }}|{{ k.followIp|default('0') }}|{{ k.vendorClass|default('') }}|{{ k.clientId|default('') }}|{{ k.hostname|default('') }}|{{ k.arpNudgeInterval|default('0') }}|{{ k.arpListenPromisc|default('0') }}|{{ k.captureBackend|default('') }}|{{ k.defaultRouteMode|default('off') }}|{{ k.backupEgress|default('0') }}|{{ k.backupEgressForm|default('split') }}|{{ k.backupEgressGateway|default('') }}|{{ k.backupEgressInterface|default('') }}|{{ k.backupEgressPrefixes|default('') }}
 {%     endif %}
 {%   endif %}
 {% endfor %}

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1095,15 +1095,20 @@ def test_backoff_jitter(lk):
 
 # ---- default-route ownership wiring (keeper <-> DefaultRouteReconciler) ----
 
-class _RecordingReconciler:  # pylint: disable=too-few-public-methods
+class _RecordingReconciler:
     """Stand-in for DefaultRouteReconciler that records reconcile() args, so the
     keeper-side wiring can be asserted without a real route(8) probe."""
     def __init__(self, enabled=True):
         self.enabled = enabled
+        self.backup_egress_enabled = enabled
         self.calls = []
+        self.backup_egress_calls = []
 
     def reconcile(self, is_master, bound, gateway):
         self.calls.append((is_master, bound, gateway))
+
+    def reconcile_backup_egress(self, is_master):
+        self.backup_egress_calls.append(is_master)
 
 
 def test_default_route_mode_off_is_inert(lk):
@@ -1125,6 +1130,37 @@ def test_default_route_forwards_role_bound_gateway(lk):
     k._dhcp.binding.lease_router = "100.64.4.1"
     k._reconcile_default_route(master=True)
     assert rec.calls == [(True, True, "100.64.4.1")]
+    # the same tick also drives the backup-egress reconcile with the CARP role.
+    assert rec.backup_egress_calls == [True]
+
+
+def test_backup_egress_uses_real_role_on_unbound_path(lk, monkeypatch):
+    # the unbound path drives the 0/0 withdraw with a fictional master=False; backup
+    # egress must get the REAL role so a CARP master-without-lease is not handed a
+    # backup route (which would black-hole/loop the master's own egress).
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    monkeypatch.setattr(k, "_probe_carp_master", lambda: True)     # actually CARP master
+    k._reconcile_default_route(master=False, probe_for_backup=True)
+    assert rec.calls[0][0] is False                                # 0/0 got the fiction
+    assert rec.backup_egress_calls == [True]                       # backup egress got the true role
+
+
+def test_backup_egress_reconciled_before_blocking_acquire_when_unbound(lk, monkeypatch):
+    # A routed backup promoted to master while unbound must shed its /1 BEFORE the (possibly
+    # long) acquire blocks, or the /1 loops the new master's egress for the whole acquire.
+    # So the unbound path reconciles backup egress with the real CARP role ahead of acquire.
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    k._defroute = rec
+    monkeypatch.setattr(k, "_probe_carp_master", lambda: True)     # promoted to master
+    order = []
+    monkeypatch.setattr(rec, "reconcile_backup_egress", lambda m: order.append(("backup", m)))
+    monkeypatch.setattr(k, "_acquire_step", lambda: order.append(("acquire", None)))
+    k._dhcp.binding.yiaddr = None                                 # unbound
+    k._maintain_step()
+    assert order[:2] == [("backup", True), ("acquire", None)]     # real role, before the block
 
 
 def test_default_route_bound_keyed_on_yiaddr_not_router(lk):
@@ -1306,6 +1342,17 @@ def test_withdraw_unless_master_off_is_inert_without_probing(lk, monkeypatch):
     probed = []
     lk.DefaultRouteReconciler("off").withdraw_unless_master(lambda: probed.append(1))
     assert fake.gw == RGW and not fake.calls and not probed
+
+
+def test_split_prefixes_accepts_commas_and_whitespace():
+    # the model mask and docs allow both separators; a space-separated list must not
+    # collapse into one invalid token (which would install neither route).
+    import lease_keeper  # noqa: E402  # pylint: disable=import-outside-toplevel
+    both = ("192.0.2.0/24", "198.51.100.0/24")
+    assert lease_keeper._split_prefixes("192.0.2.0/24 198.51.100.0/24") == both   # spaces
+    assert lease_keeper._split_prefixes("192.0.2.0/24,198.51.100.0/24") == both   # commas
+    assert lease_keeper._split_prefixes("192.0.2.0/24, 198.51.100.0/24") == both  # mixed
+    assert not lease_keeper._split_prefixes("") and not lease_keeper._split_prefixes(None)
 
 
 def test_carp_master_decision_from_ifconfig_text(lk):

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -873,11 +873,21 @@ def test_sniffer_filter_captures_arp_and_honours_promisc(lk, monkeypatch):
 
     # ScapyCapture looks AsyncSniffer up in its own module, so patch it there.
     monkeypatch.setattr("leasekeeper.capture_scapy.AsyncSniffer", _Cap)
-    keeper = _keeper(lk, arp_listen_promisc=True)
+    keeper = _keeper(lk, arp_listen_promisc=True, arp_nudge=240)   # promisc serves the nudge
     assert keeper._capture.start() is True
     assert "arp" in captured["filter"]        # ARP replies now reach the parser
     assert "port 67" in captured["filter"]     # ...alongside DHCP, unchanged
     assert captured["promisc"] is True         # opt-in flag reaches the socket
+
+
+def test_promisc_ignored_when_nudge_disabled(lk, caplog):
+    # Promiscuous capture only serves the ARP nudge reply; with the nudge disabled it is
+    # ignored rather than needlessly receiving all segment traffic, so a stale promisc flag
+    # (hidden in the GUI when the nudge is 0) has no runtime effect.
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        keeper = _keeper(lk, arp_listen_promisc=True, arp_nudge=0)
+    assert keeper._capture.promisc is False
+    assert any("ARP nudge is disabled" in r.getMessage() for r in caplog.records)
 
 
 def test_ensure_sniffer_logs_when_restart_fails(lk, monkeypatch, caplog):

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1173,6 +1173,25 @@ def test_backup_egress_reconciled_before_blocking_acquire_when_unbound(lk, monke
     assert order[:2] == [("backup", True), ("acquire", None)]     # real role, before the block
 
 
+def test_backup_egress_no_pre_acquire_probe_when_disabled(lk, monkeypatch):
+    # The unbound pre-acquire backup-egress settle runs only when the feature is enabled;
+    # with it off, the hot unbound loop adds no extra CARP probe or reconcile before acquire.
+    k = _keeper(lk, vhid=254, default_route_mode="enforce")
+    rec = _RecordingReconciler()
+    rec.backup_egress_enabled = False              # feature off
+    k._defroute = rec
+    order = []
+    monkeypatch.setattr(k, "_probe_carp_master", lambda: (order.append("probe"), True)[1])
+    monkeypatch.setattr(rec, "reconcile_backup_egress", lambda m: order.append(("backup", m)))
+    monkeypatch.setattr(k, "_acquire_step", lambda: order.append("acquire"))
+    k._dhcp.binding.yiaddr = None                  # unbound
+    k._maintain_step()
+    assert "acquire" in order
+    before = order[:order.index("acquire")]
+    assert "probe" not in before                   # no extra probe before the block
+    assert not any(isinstance(x, tuple) for x in before)   # no pre-acquire backup reconcile
+
+
 def test_default_route_bound_keyed_on_yiaddr_not_router(lk):
     # lease_router lingers after a lease loss (expire() clears only yiaddr); bound
     # must be keyed on yiaddr, so a lost lease (yiaddr None, gateway still set)

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -650,6 +650,25 @@ def test_backup_egress_derive_peer_change_uses_change(lk, monkeypatch):
     assert RouteCommand.CHANGE in fake.verbs
 
 
+def test_backup_egress_failed_change_keeps_old_ownership(lk, monkeypatch):
+    # Derive form: if the peer changes A->B but `route change` FAILS, the /1 stays at A and
+    # ownership of A must be preserved (not overwritten by the unconfirmed B) -- else
+    # promotion would treat the still-present /1 at A as foreign and loop egress. (Ownership
+    # is recorded only for gateways CONFIRMED to host our prefixes.)
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(interface="sync0"),
+                     ifaces={"sync0": ("10.168.9.2", 30)})
+    rec.reconcile_backup_egress(False)             # install via peer .1
+    assert fake.routes.get("0.0.0.0/1") == "10.168.9.1"
+    fake.ifaces["sync0"] = ("10.168.9.5", 30)      # peer becomes .6
+    fake.broken.add(RouteCommand.CHANGE)           # the change to .6 fails
+    rec.reconcile_backup_egress(False)
+    assert fake.routes.get("0.0.0.0/1") == "10.168.9.1"   # still at .1 (change did not take)
+    fake.broken.discard(RouteCommand.CHANGE)
+    rec.reconcile_backup_egress(True)              # promote -> must remove the /1 still at .1
+    assert "0.0.0.0/1" not in fake.routes and "128.0.0.0/1" not in fake.routes
+
+
 def test_backup_egress_collision_warns_once_and_rearms(lk, monkeypatch, caplog):
     # A persistent foreign /1 warns once (not per tick); once it clears and re-collides a
     # second warning fires -- rising-edge parity with the unresolved-gateway gate.

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -620,6 +620,55 @@ def test_backup_egress_derive_non_ptp_inactive(lk, monkeypatch, caplog):
     assert any("not a point-to-point" in r.getMessage() for r in caplog.records)
 
 
+def test_backup_egress_derive_form_master_removes_own_route(lk, monkeypatch):
+    # Derive form (no configured gateway): ownership rests only on the gateway confirmed
+    # this session. A backup that inherits (or installs) its own /1 via the derived peer
+    # must still remove it on promotion -- else an empty ownership set on the derived-peer
+    # master would treat its own leftover as foreign and loop egress. Regression for the
+    # ownership-lost-on-restart bug: ownership is recorded on the confirmed-present path.
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(interface="sync0"),
+                     ifaces={"sync0": ("10.168.9.2", 30)})
+    fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = "10.168.9.1"   # inherited via the peer
+    rec.reconcile_backup_egress(False)             # backup tick confirms the set is ours
+    rec.reconcile_backup_egress(True)              # promote -> must remove our own /1
+    assert "0.0.0.0/1" not in fake.routes and "128.0.0.0/1" not in fake.routes
+
+
+def test_backup_egress_derive_peer_change_uses_change(lk, monkeypatch):
+    # Derive form: when the interface is re-addressed so the derived peer changes, the /1
+    # is updated IN PLACE (CHANGE) to the new peer -- the only path that issues CHANGE
+    # (its ownership of the old next hop comes from the session-installed gateway).
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(interface="sync0"),
+                     ifaces={"sync0": ("10.168.9.2", 30)})
+    rec.reconcile_backup_egress(False)             # install via peer .1
+    assert fake.routes.get("0.0.0.0/1") == "10.168.9.1"
+    fake.ifaces["sync0"] = ("10.168.9.5", 30)      # re-addressed -> peer becomes .6
+    rec.reconcile_backup_egress(False)
+    assert fake.routes.get("0.0.0.0/1") == "10.168.9.6"
+    assert RouteCommand.CHANGE in fake.verbs
+
+
+def test_backup_egress_collision_warns_once_and_rearms(lk, monkeypatch, caplog):
+    # A persistent foreign /1 warns once (not per tick); once it clears and re-collides a
+    # second warning fires -- rising-edge parity with the unresolved-gateway gate.
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = "10.9.9.9"   # both foreign
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        for _ in range(3):
+            rec.reconcile_backup_egress(False)
+    assert len([r for r in caplog.records if "another next hop" in r.getMessage()]) == 1
+    caplog.clear()
+    fake.routes.pop("0.0.0.0/1")
+    fake.routes.pop("128.0.0.0/1")                                  # foreign routes gone
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)                          # collision-free -> re-arm
+        fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = "10.9.9.9"
+        rec.reconcile_backup_egress(False)                          # re-collide
+    assert any("another next hop" in r.getMessage() for r in caplog.records)
+
+
 def test_backup_egress_observe_dry_run(lk, monkeypatch, caplog):
     rec, fake = _rec(lk, monkeypatch, "observe", backup_egress=_becfg(gateway=BE_GW))
     with caplog.at_level("INFO", logger="lease-keeper"):
@@ -708,7 +757,7 @@ def test_backup_egress_remove_leaves_foreign_route(lk, monkeypatch, caplog):
         rec.reconcile_backup_egress(True)              # master -> remove ours only
     assert fake.routes.get("0.0.0.0/1") == "10.9.9.9"  # foreign left
     assert "128.0.0.0/1" not in fake.routes            # ours removed
-    assert any("already routed via another next hop" in r.getMessage() for r in caplog.records)
+    assert any("does not own" in r.getMessage() for r in caplog.records)
 
 
 def test_backup_egress_install_defers_on_unreadable_fib(lk, monkeypatch, caplog):
@@ -901,4 +950,4 @@ def test_backup_egress_shutdown_unconfirmed_removal_warns(lk, monkeypatch, caplo
     fake.routes["0.0.0.0/1"] = BE_GW
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.withdraw_unless_master(lambda: False)
-    assert any("could not confirm removal at shutdown" in r.getMessage() for r in caplog.records)
+    assert any("could not clean up at shutdown" in r.getMessage() for r in caplog.records)

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -669,6 +669,22 @@ def test_backup_egress_failed_change_keeps_old_ownership(lk, monkeypatch):
     assert "0.0.0.0/1" not in fake.routes and "128.0.0.0/1" not in fake.routes
 
 
+def test_backup_egress_ownership_pruned_after_removal(lk, monkeypatch):
+    # After removing our /1 on promotion, the old peer must NOT stay owned: if the peer then
+    # changes and a route reappears via the OLD peer (e.g. a VPN takes that address), it must
+    # be treated as foreign, not CHANGEd/overwritten (ownership is pruned on removal too).
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(interface="sync0"),
+                     ifaces={"sync0": ("10.168.9.2", 30)})
+    rec.reconcile_backup_egress(False)             # backup: install via peer .1 (own .1)
+    rec.reconcile_backup_egress(True)              # master: remove -> ownership of .1 pruned
+    fake.ifaces["sync0"] = ("10.168.9.5", 30)      # peer changes to .6
+    fake.routes["0.0.0.0/1"] = "10.168.9.1"        # a foreign route reappears at the OLD peer .1
+    rec.reconcile_backup_egress(False)             # back to backup, peer now .6
+    assert fake.routes.get("0.0.0.0/1") == "10.168.9.1"   # old-peer route left untouched (foreign)
+    assert RouteCommand.CHANGE not in fake.verbs          # never overwrote it
+
+
 def test_backup_egress_collision_warns_once_and_rearms(lk, monkeypatch, caplog):
     # A persistent foreign /1 warns once (not per tick); once it clears and re-collides a
     # second warning fires -- rising-edge parity with the unresolved-gateway gate.

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -10,7 +10,7 @@ import types
 
 import pytest
 
-from leasekeeper.route import RouteCommand
+from leasekeeper.route import BackupEgressConfig, BackupEgressForm, RouteCommand
 
 GW = "185.41.66.1"
 GW2 = "185.41.66.9"
@@ -18,51 +18,105 @@ CGNAT_GW = "100.64.4.1"   # the production case: a 100.64/10 single-IP CGNAT WAN
 
 
 class FakeRoute:
-    """In-memory stand-in for `/sbin/route`: one default nexthop, verb log."""
+    """In-memory stand-in for /sbin/route + /usr/bin/netstat + /sbin/ifconfig: a
+    dest->nexthop table (dest 'default' or a CIDR), a verb log, and per-interface
+    (addr, prefixlen) for backup-egress peer derivation. `gw` is the default's
+    nexthop, kept as a property so the default-route tests read it unchanged."""
 
-    def __init__(self, initial=None, broken=(), lying=()):
-        self.gw = initial
+    def __init__(self, initial=None, *, broken=(), lying=(),  # pylint: disable=too-many-arguments
+                 ifaces=None, netstat_fails=False, local_ips=()):
+        self.routes = {}
+        if initial is not None:
+            self.routes["default"] = initial
         self.calls = []
         self.broken = set(broken)  # verbs that fail with a genuine (non-benign) error
         self.lying = set(lying)    # verbs that exit 0 but do NOT mutate the FIB
+        self.ifaces = dict(ifaces or {})   # iface -> (addr, prefixlen)
+        self.netstat_fails = netstat_fails  # netstat -rn exits non-zero (unreadable table)
+        self.local_ips = set(local_ips)     # addresses a `route get` resolves to lo0 (own IPs)
+
+    @property
+    def gw(self):
+        return self.routes.get("default")
+
+    @gw.setter
+    def gw(self, value):
+        if value is None:
+            self.routes.pop("default", None)
+        else:
+            self.routes["default"] = value
 
     def run(self, cmd, **_kwargs):  # capture_output / errors / timeout -- ignored
-        # One return (accumulate rc/out/err) to keep the verb branches readable
-        # without tripping too-many-return-statements.
         self.calls.append(list(cmd))
-        verb = cmd[2]  # ["/sbin/route","-n",verb,"-inet","default"[,gw]]
+        prog = cmd[0]
+        if prog.endswith("netstat"):
+            if self.netstat_fails:
+                return self._reply(1, "", "netstat: routing table unavailable")
+            return self._reply(0, self._netstat_body())
+        if prog.endswith("ifconfig"):
+            return self._ifconfig(cmd[1])
+        return self._route(cmd)
+
+    def _route(self, cmd):
+        # ["/sbin/route","-n",verb,"-inet",dest[,gw]]; single return to keep the verb
+        # branches readable without tripping too-many-return-statements.
+        verb, dest = cmd[2], cmd[4]
         rc, out, err = 0, "", ""
         if verb in self.broken:  # a real failure: stuck route / bad socket, not a no-op
             rc, err = 1, "route: writing to routing socket: permission denied"
         elif verb == RouteCommand.GET:
-            has = self.gw is not None  # empty table exits non-zero
-            rc = 0 if has else 1
-            out = f"   gateway: {self.gw}\n   flags: <UP,GATEWAY>\n" if has else ""
-            err = "" if has else "route: not in table"
+            if dest in self.routes:                 # a known route dest (e.g. "default")
+                out = f"   gateway: {self.routes[dest]}\n   interface: vlan0\n"
+            elif dest == "default":                 # no default installed
+                rc, err = 1, "route: not in table"
+            else:                                   # host lookup (used by _gateway_is_own):
+                iface = "lo0" if dest in self.local_ips else "vlan0"  # own IP resolves to lo0
+                out = f"   gateway: {dest}\n   interface: {iface}\n"
         elif verb == RouteCommand.ADD:
-            if self.gw is not None:  # FreeBSD: add fails when a default already exists
+            if self.routes.get(dest) is not None:  # FreeBSD: add fails when it exists
                 rc, err = 1, "route: writing to routing socket: File exists"
             elif verb not in self.lying:  # a lying add exits 0 but leaves the FIB unchanged
-                self.gw = cmd[-1]
+                self.routes[dest] = cmd[-1]
         elif verb == RouteCommand.CHANGE:
-            if self.gw is None:  # FreeBSD: change fails when no route exists to change
-                rc, err = 1, "route: change net default: not in table"
+            if self.routes.get(dest) is None:  # change fails when no route exists
+                rc, err = 1, "route: change: not in table"
             else:
-                self.gw = cmd[-1]  # on-link swaps in place; off-link is broken={RouteCommand.CHANGE}
+                self.routes[dest] = cmd[-1]  # on-link swaps in place; off-link is broken={CHANGE}
         elif verb == RouteCommand.DELETE:
-            existed = self.gw is not None
-            self.gw = None
+            existed = self.routes.pop(dest, None) is not None
             rc, err = (0, "") if existed else (1, "not in table")
+        return self._reply(rc, out, err)
+
+    def _netstat_body(self):
+        lines = ["Routing tables", "", "Internet:",
+                 "Destination        Gateway            Flags     Netif"]
+        for dest, gw in self.routes.items():
+            shown = dest[:-3] if dest.endswith("/32") else dest  # FreeBSD prints host routes bare
+            lines.append(f"{shown}        {gw}        UGS       vlan0")
+        return "\n".join(lines) + "\n"
+
+    def _ifconfig(self, iface):
+        info = self.ifaces.get(iface)
+        if info is None:
+            return self._reply(1, "", f"ifconfig: interface {iface} does not exist")
+        addr, prefixlen = info
+        mask = (0xffffffff << (32 - prefixlen)) & 0xffffffff if prefixlen else 0
+        body = f"{iface}: flags=8843<UP>\n\tinet {addr} netmask 0x{mask:08x} broadcast 0.0.0.0\n"
+        return self._reply(0, body)
+
+    @staticmethod
+    def _reply(rc, out, err=""):
         return types.SimpleNamespace(returncode=rc, stdout=out, stderr=err)
 
     @property
     def verbs(self):
-        return [c[2] for c in self.calls]
+        return [c[2] for c in self.calls if c[0].endswith("route")]
 
 
 def _rec(lk, monkeypatch, mode, initial=None, *,  # pylint: disable=too-many-arguments
-         broken=(), lying=(), **kw):
-    fake = FakeRoute(initial, broken=broken, lying=lying)
+         broken=(), lying=(), ifaces=None, netstat_fails=False, local_ips=(), **kw):
+    fake = FakeRoute(initial, broken=broken, lying=lying, ifaces=ifaces,
+                     netstat_fails=netstat_fails, local_ips=local_ips)
     monkeypatch.setattr(lk.subprocess, "run", fake.run)
     return lk.DefaultRouteReconciler(mode=mode, **kw), fake
 
@@ -479,3 +533,372 @@ def test_gateway_change_relogs_ownership_at_info(lk, monkeypatch, caplog):
     assert _levels_for(caplog, f"owning default via {GW}") == ["INFO"]
     assert any(r.levelname == "INFO" and f"installed default via {GW2}" in r.getMessage()
                for r in caplog.records)
+
+
+# ---- backup egress (optional feature; docs/backup-egress.md) ----
+
+BE_GW = "10.168.9.1"
+
+
+def _becfg(**kw):
+    kw.setdefault("enabled", True)
+    return BackupEgressConfig(**kw)
+
+
+def test_backup_egress_disabled_is_inert(lk, monkeypatch):
+    # no backup_egress config -> the reconcile is a no-op, issues nothing.
+    rec, fake = _rec(lk, monkeypatch, "enforce")
+    rec.reconcile_backup_egress(False)
+    assert not fake.calls
+
+
+def test_backup_egress_off_mode_inert(lk, monkeypatch):
+    # off mode: even with the feature enabled, nothing runs.
+    rec, fake = _rec(lk, monkeypatch, "off", backup_egress=_becfg(gateway=BE_GW))
+    rec.reconcile_backup_egress(False)
+    assert not fake.calls
+
+
+def test_backup_egress_installs_split_on_backup(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    rec.reconcile_backup_egress(False)
+    assert fake.routes.get("0.0.0.0/1") == BE_GW
+    assert fake.routes.get("128.0.0.0/1") == BE_GW
+
+
+def test_backup_egress_removed_on_master(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = BE_GW
+    rec.reconcile_backup_egress(True)
+    assert "0.0.0.0/1" not in fake.routes and "128.0.0.0/1" not in fake.routes
+
+
+def test_backup_egress_role_swap(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    rec.reconcile_backup_egress(False)                 # backup -> installed
+    assert fake.routes.get("0.0.0.0/1") == BE_GW
+    rec.reconcile_backup_egress(True)                  # master -> removed
+    assert "0.0.0.0/1" not in fake.routes
+    rec.reconcile_backup_egress(False)                 # backup again -> reinstalled
+    assert fake.routes.get("0.0.0.0/1") == BE_GW
+
+
+def test_backup_egress_idempotent_no_churn(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    rec.reconcile_backup_egress(False)
+    n = len(fake.calls)
+    rec.reconcile_backup_egress(False)                 # already correct
+    # the second pass reads (own-check route get + netstat) but issues no route mutation.
+    mutations = [c for c in fake.calls[n:] if c[0].endswith("route")
+                 and c[2] in (RouteCommand.ADD, RouteCommand.CHANGE, RouteCommand.DELETE)]
+    assert fake.calls[n:] and not mutations
+
+
+def test_backup_egress_unknown_role_touches_nothing(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    rec.reconcile_backup_egress(None)
+    assert not fake.calls
+
+
+def test_backup_egress_derive_peer_on_ptp(lk, monkeypatch):
+    # gateway blank + a /30 interface -> derive the other host as the peer/master.
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(interface="sync0"),
+                     ifaces={"sync0": ("10.168.9.2", 30)})
+    rec.reconcile_backup_egress(False)
+    assert fake.routes.get("0.0.0.0/1") == "10.168.9.1"
+
+
+def test_backup_egress_derive_non_ptp_inactive(lk, monkeypatch, caplog):
+    # a /24 interface has no unique peer -> warn and install nothing.
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(interface="lan0"),
+                     ifaces={"lan0": ("10.168.1.3", 24)})
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)
+    assert "0.0.0.0/1" not in fake.routes
+    assert any("not a point-to-point" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_observe_dry_run(lk, monkeypatch, caplog):
+    rec, fake = _rec(lk, monkeypatch, "observe", backup_egress=_becfg(gateway=BE_GW))
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)
+    assert "0.0.0.0/1" not in fake.routes              # observe never writes
+    assert any("would route backup egress" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_zero_prefix_dropped_under_enforce(lk, monkeypatch, caplog):
+    # a 0.0.0.0/0 inside a specific-prefix list is dropped under enforce (enforce owns
+    # the default); the other prefixes still install.
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                          prefixes=("0.0.0.0/0", "192.0.2.0/24")))
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)
+    assert "0.0.0.0/0" not in fake.routes and fake.routes.get("192.0.2.0/24") == BE_GW
+    assert any("0.0.0.0/0 is owned by enforce" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_specific_prefixes(lk, monkeypatch):
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                          prefixes=("192.0.2.0/24",)))
+    rec.reconcile_backup_egress(False)
+    assert fake.routes.get("192.0.2.0/24") == BE_GW
+    assert "0.0.0.0/1" not in fake.routes
+
+
+def test_backup_egress_host_prefix_round_trips(lk, monkeypatch):
+    # a /32 host prefix prints without a CIDR suffix in netstat; it must still round-
+    # trip so we do not re-add + false-ERROR every tick.
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                          prefixes=("192.0.2.5/32",)))
+    rec.reconcile_backup_egress(False)
+    assert fake.routes.get("192.0.2.5/32") == BE_GW
+    n = len(fake.calls)
+    rec.reconcile_backup_egress(False)                 # already correct -> no re-add
+    assert not any(c[2] in (RouteCommand.ADD, RouteCommand.CHANGE) for c in fake.calls[n:]
+                   if c[0].endswith("route"))
+
+
+def test_backup_egress_partial_install_adds_missing_only(lk, monkeypatch):
+    # one /1 already ours, the other absent -> only the absent one is added (ADD); the
+    # correct one is left untouched (no CHANGE).
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    fake.routes["0.0.0.0/1"] = BE_GW                   # already ours
+    rec.reconcile_backup_egress(False)
+    assert fake.routes["0.0.0.0/1"] == BE_GW and fake.routes["128.0.0.0/1"] == BE_GW
+    assert RouteCommand.ADD in fake.verbs and RouteCommand.CHANGE not in fake.verbs
+
+
+def test_backup_egress_install_leaves_foreign_route(lk, monkeypatch, caplog):
+    # 0.0.0.0/1 is also the full-tunnel-VPN pair: a /1 already via a FOREIGN next hop is
+    # not overwritten (managed by ownership, not by prefix), and the collision is warned.
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    fake.routes["0.0.0.0/1"] = "10.9.9.9"              # foreign next hop
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)
+    assert fake.routes["0.0.0.0/1"] == "10.9.9.9"      # left untouched
+    assert fake.routes.get("128.0.0.0/1") == BE_GW     # the absent one is still ours to add
+    assert RouteCommand.CHANGE not in fake.verbs
+    assert any("already routed via another next hop" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_remove_on_unreadable_fib_skips(lk, monkeypatch, caplog):
+    # unreadable table -> ownership cannot be verified, and the /1-split is also a VPN
+    # full-tunnel pair, so skip rather than blind-delete an unrelated route (retry next tick).
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
+                     netstat_fails=True)
+    fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = BE_GW
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(True)              # master, table unreadable
+    assert fake.routes.get("0.0.0.0/1") == BE_GW       # NOT deleted (cannot verify ownership)
+    assert any("cannot read the routing table" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_remove_leaves_foreign_route(lk, monkeypatch, caplog):
+    # on the master, a /1 present via a FOREIGN next hop (a VPN's) is left untouched; only
+    # our own next hop is removed.
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    fake.routes["0.0.0.0/1"] = "10.9.9.9"              # foreign
+    fake.routes["128.0.0.0/1"] = BE_GW                 # ours
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(True)              # master -> remove ours only
+    assert fake.routes.get("0.0.0.0/1") == "10.9.9.9"  # foreign left
+    assert "128.0.0.0/1" not in fake.routes            # ours removed
+    assert any("already routed via another next hop" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_install_defers_on_unreadable_fib(lk, monkeypatch, caplog):
+    # unreadable table on the backup: do not blind-add (would miss a needed CHANGE);
+    # defer to the next tick.
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
+                     netstat_fails=True)
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)
+    assert "0.0.0.0/1" not in fake.routes
+    assert any("cannot read the routing table" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_readback_failure_is_error(lk, monkeypatch, caplog):
+    # a lying add (exits 0, FIB unchanged) must be caught by the read-back and reported
+    # as failed, not success -- the mirror of the 0/0 lying-add test.
+    rec, _ = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
+                  lying=(RouteCommand.ADD,))
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)
+    assert any(r.levelname == "ERROR" and "failed to route" in r.getMessage()
+               for r in caplog.records)
+    assert not any("backup egress routed via" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_broken_removal_is_error(lk, monkeypatch, caplog):
+    # a delete that does not take leaves a looping /1 on the master -> must surface ERROR.
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
+                     broken=(RouteCommand.DELETE,))
+    fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = BE_GW
+    with caplog.at_level("ERROR", logger="lease-keeper"):
+        rec.reconcile_backup_egress(True)
+    assert any("would loop its egress" in r.getMessage() for r in caplog.records)
+    assert "0.0.0.0/1" in fake.routes                  # the failed delete left the route (the hazard)
+
+
+def test_backup_egress_orphan_from_form_change_cleaned_on_master(lk, monkeypatch):
+    # a prefixes-form daemon still removes an orphaned /1-split (left by a prior split
+    # form) when it becomes master, via the union removal set.
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                          prefixes=("192.0.2.0/24",)))
+    fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = BE_GW   # orphan from the old form
+    rec.reconcile_backup_egress(True)                  # master -> clean the union
+    assert "0.0.0.0/1" not in fake.routes and "128.0.0.0/1" not in fake.routes
+
+
+def test_backup_egress_rejects_own_ip_gateway(lk, monkeypatch, caplog):
+    # the config-sync trap: an explicit gateway equal to this node's own IP would route
+    # via self -> reject (route get resolves it to lo0) and install nothing.
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(gateway="10.168.9.2"), local_ips=("10.168.9.2",))
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)
+    assert "0.0.0.0/1" not in fake.routes
+    assert any("own address" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_derive_peer_on_31(lk, monkeypatch):
+    # RFC 3021 /31: both addresses are usable; the peer is the other one.
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(interface="sync0"),
+                     ifaces={"sync0": ("10.168.9.2", 31)})
+    rec.reconcile_backup_egress(False)
+    assert fake.routes.get("0.0.0.0/1") == "10.168.9.3"
+
+
+def test_backup_egress_resolve_warns_once_not_per_tick(lk, monkeypatch, caplog):
+    # an unresolvable gateway (no gateway, no interface) must warn once, not every tick.
+    rec, _ = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg())
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        for _ in range(3):
+            rec.reconcile_backup_egress(False)
+    warns = [r for r in caplog.records if "no gateway set and no interface" in r.getMessage()]
+    assert len(warns) == 1
+
+
+def test_backup_egress_observe_would_remove(lk, monkeypatch, caplog):
+    rec, fake = _rec(lk, monkeypatch, "observe", backup_egress=_becfg(gateway=BE_GW))
+    fake.routes["0.0.0.0/1"] = BE_GW
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        rec.reconcile_backup_egress(True)
+    assert fake.routes.get("0.0.0.0/1") == BE_GW        # observe never writes
+    assert any("would remove backup egress" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_independent_of_default_reconcile(lk, monkeypatch):
+    # the backup /1-split does not touch the 0/0 decision and vice versa.
+    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW,
+                     backup_egress=_becfg(gateway=BE_GW))
+    rec.reconcile(True, True, GW)                       # master: keeps 0/0 via WAN
+    rec.reconcile_backup_egress(True)                  # master: no /1-split
+    assert fake.routes.get("default") == GW and "0.0.0.0/1" not in fake.routes
+
+
+def test_backup_egress_derive_unreadable_interface_inactive(lk, monkeypatch, caplog):
+    # an interface with no readable IPv4 -> no peer, no install (warned).
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(interface="sync0"), ifaces={})
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)
+    assert "0.0.0.0/1" not in fake.routes
+    assert any("cannot read an IPv4 address" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_resolve_rearms_warning(lk, monkeypatch, caplog):
+    # unresolved -> warn; a successful resolve re-arms; unresolved again -> a 2nd warning.
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(interface="sync0"), ifaces={})
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)                 # warn #1 (no inet)
+        fake.ifaces["sync0"] = ("10.168.9.2", 30)          # now resolvable
+        rec.reconcile_backup_egress(False)                 # resolves -> re-arms
+        del fake.ifaces["sync0"]                           # unresolvable again
+        rec.reconcile_backup_egress(False)                 # warn #2
+    warns = [r for r in caplog.records if "cannot read an IPv4 address" in r.getMessage()]
+    assert len(warns) == 2
+
+
+def test_backup_egress_invalid_prefix_dropped(lk, monkeypatch, caplog):
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                          prefixes=("not-an-ip", "192.0.2.0/24")))
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)
+    assert fake.routes.get("192.0.2.0/24") == BE_GW
+    assert any("ignoring invalid prefix" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_ipv6_prefix_dropped(lk, monkeypatch, caplog):
+    # ip_network() accepts IPv6, but the FIB ops are IPv4-only (netstat/route -inet); a v6
+    # prefix must be dropped at validation rather than retried and failing every tick.
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                          prefixes=("2001:db8::/32", "192.0.2.0/24")))
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)
+    assert fake.routes.get("192.0.2.0/24") == BE_GW
+    assert "2001:db8::/32" not in fake.routes
+    assert any("non-IPv4 prefix" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_boundary_leaves_unowned_split_when_disabled(lk, monkeypatch):
+    # 0.0.0.0/1 + 128.0.0.0/1 is also the classic full-tunnel-VPN split; a keeper that
+    # never managed backup egress must NOT delete a pre-existing /1 it does not own.
+    rec, fake = _rec(lk, monkeypatch, "enforce")            # mode enabled, feature OFF
+    fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = BE_GW
+    rec.withdraw_unless_master(lambda: False)
+    assert fake.routes.get("0.0.0.0/1") == BE_GW and fake.routes.get("128.0.0.0/1") == BE_GW
+
+
+def test_backup_egress_empty_prefixes_warns_and_installs_nothing(lk, monkeypatch, caplog):
+    rec, fake = _rec(lk, monkeypatch, "enforce",
+                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                          prefixes=()))
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)
+    assert not fake.routes                               # nothing routed
+    assert any("no valid prefixes" in r.getMessage() for r in caplog.records)
+
+
+def test_backup_egress_own_check_transient_defers_then_recovers(lk, monkeypatch, caplog):
+    # a transient own-check (route get) failure must defer (not route via a maybe-own
+    # gateway) AND not cache the indeterminate result -- it recovers once route get works.
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
+                     broken=(RouteCommand.GET,))
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.reconcile_backup_egress(False)               # own-check fails -> defer
+    assert "0.0.0.0/1" not in fake.routes
+    assert any("could not verify gateway" in r.getMessage() for r in caplog.records)
+    fake.broken.discard(RouteCommand.GET)                # own-check now works
+    rec.reconcile_backup_egress(False)
+    assert fake.routes.get("0.0.0.0/1") == BE_GW         # not permanently disabled
+
+
+def test_backup_egress_removed_at_shutdown(lk, monkeypatch):
+    # the shutdown boundary (withdraw_unless_master) cleans the backup-egress set so no
+    # orphan /1 loops if this node later becomes master with no reconciler running.
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = BE_GW
+    rec.withdraw_unless_master(lambda: False)            # shutdown as backup
+    assert "0.0.0.0/1" not in fake.routes and "128.0.0.0/1" not in fake.routes
+
+
+def test_backup_egress_shutdown_unconfirmed_removal_warns(lk, monkeypatch, caplog):
+    # at shutdown there is no next tick to retry; an unconfirmable removal (unreadable
+    # table) must warn loudly rather than silently leave a possible orphan /1 that loops.
+    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
+                     netstat_fails=True)
+    fake.routes["0.0.0.0/1"] = BE_GW
+    with caplog.at_level("WARNING", logger="lease-keeper"):
+        rec.withdraw_unless_master(lambda: False)
+    assert any("could not confirm removal at shutdown" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
Opt-in feature (default off): while a node is the CARP **backup** and so holds no WAN default (under `defaultRouteMode` observe/enforce), route its OWN internet traffic (updates, NTP, DNS) to the master, which NATs it out the single WAN. The route is removed automatically when the node becomes master. On a single-IP-CARP WAN the non-master node otherwise has no egress of its own.

## Design
- The reconciler keeps a **backup-egress route set** present on the backup and absent on the master (the inverse of the 0/0 it manages).
- **Route form**: a `/1`-split (`0.0.0.0/1` + `128.0.0.0/1`) by default, full internet but not the default route, so it is never redistributed as a default (leak-safe with os-frr `redistribute kernel`) and never collides with the enforce 0/0 logic. A specific-prefix IPv4 list is the alternative.
- **Gateway** = a stable next hop: best an internal **CARP VIP** (follows failover for free), or the point-to-point `/30`/`/31` peer derived from an interface, or a fallback-WAN gateway.

## Fail-safe behaviour
- **Ownership, not shape**: the feature only changes or removes a route whose next hop it owns (the configured gateway, or a gateway its prefixes are confirmed present at this session). A prefix already routed via a foreign next hop (a full-tunnel VPN's `/1`, or a static route on a configured prefix) is left untouched and the collision is warned; the feature never overwrites or deletes a route it does not own.
- **Unreadable routing table**: the install defers rather than blind-adding; the removal skips (ownership cannot be verified) and retries on the next readable tick.
- The config-sync trap (gateway == this node's own IP) is refused via `route get` (a CARP VIP the node is backup for is not caught).
- The unbound path drives backup egress with the **real** CARP role, and a backup promoted while unbound sheds its `/1` before the blocking acquire, so a master-without-lease is never handed a backup route and a promoted node never loops.
- The route set is cleaned up at startup and graceful shutdown; warnings are throttled (once per episode / rising-edge).

## Testing
CI green: flake8, pylint 10.00 (`--enable=useless-suppression`), pyright, and the pytest suite, exercising the failure paths (unreadable routing table, lying/broken route ops, ownership collisions, derived-peer change, role swap, config-sync trap, shutdown cleanup). Additionally bench-validated on a two-node CARP pair with the feature enabled: the backup installs the `/1`-split via the configured gateway, a foreign `/1` on the master is left untouched, and the promoted node removes its own `/1`.

Draft pending review.
