### PR TITLE
refactor(os-carp-vip-dhcp): shared keeper.conf shell parser + reader conformance test

### DIFF
--- a/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
@@ -11,6 +11,10 @@
 # per keeper, pipe-separated KEY=VALUE fields in no fixed order; we dispatch by
 # key name and use only request= and demote= here.
 
+# request/demote are assigned by the sourced keeperconf.sh parser, which
+# shellcheck cannot follow across its absolute install path; do not flag them as
+# unassigned (file-wide, before any command).
+# shellcheck disable=SC2154
 CONF="/usr/local/etc/carpvipdhcp/keeper.conf"
 RUN_DIR="/var/run"
 # The daemon refreshes the heartbeat every ~30s while holding a lease; the

--- a/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
@@ -11,10 +11,6 @@
 # per keeper, pipe-separated KEY=VALUE fields in no fixed order; we dispatch by
 # key name and use only request= and demote= here.
 
-# request/demote are assigned by the sourced keeperconf.sh parser, whose absolute
-# install path the linter cannot follow; suppress the resulting "unassigned"
-# warnings (file-wide).
-# shellcheck disable=SC2154
 CONF="/usr/local/etc/carpvipdhcp/keeper.conf"
 RUN_DIR="/var/run"
 # The daemon refreshes the heartbeat every ~30s while holding a lease; the
@@ -35,6 +31,10 @@ _id()
 }
 
 now=$(date +%s)
+# request/demote below are assigned by the sourced keeperconf.sh parser; the
+# linter cannot follow its absolute install path, so scope-disable the
+# "unassigned" warning to this loop only.
+# shellcheck disable=SC2154
 while IFS= read -r line || [ -n "${line}" ]; do
     case "${line}" in ''|\#*) continue ;; esac
     carpvipdhcp_parse_line "${line}"

--- a/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
@@ -11,9 +11,9 @@
 # per keeper, pipe-separated KEY=VALUE fields in no fixed order; we dispatch by
 # key name and use only request= and demote= here.
 
-# request/demote are assigned by the sourced keeperconf.sh parser, which
-# shellcheck cannot follow across its absolute install path; do not flag them as
-# unassigned (file-wide, before any command).
+# request/demote are assigned by the sourced keeperconf.sh parser, whose absolute
+# install path the linter cannot follow; suppress the resulting "unassigned"
+# warnings (file-wide).
 # shellcheck disable=SC2154
 CONF="/usr/local/etc/carpvipdhcp/keeper.conf"
 RUN_DIR="/var/run"

--- a/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.carp_service_status.d/carpvipdhcp
@@ -21,6 +21,10 @@ RUN_DIR="/var/run"
 MAX_AGE=3600
 [ -f "${CONF}" ] || exit 0
 
+# Shared keeper.conf line parser, also sourced by the rc.d service, so the two
+# readers cannot drift (and it is unit-tested against keeperconf.py).
+. /usr/local/opnsense/scripts/OPNsense/CarpVipDhcp/keeperconf.sh
+
 _id()
 {
     printf '%s' "$1" | tr -c 'A-Za-z0-9' '_'
@@ -29,16 +33,7 @@ _id()
 now=$(date +%s)
 while IFS= read -r line || [ -n "${line}" ]; do
     case "${line}" in ''|\#*) continue ;; esac
-    request='' demote=''
-    rec="${line}"
-    while [ -n "${rec}" ]; do
-        field="${rec%%|*}"
-        case "${rec}" in *"|"*) rec="${rec#*|}" ;; *) rec='' ;; esac
-        case "${field}" in
-            request=*) request="${field#*=}" ;;
-            demote=*) demote="${field#*=}" ;;
-        esac
-    done
+    carpvipdhcp_parse_line "${line}"
     [ -n "${request}" ] || continue
     [ "${demote}" = "1" ] || continue
     hb="${RUN_DIR}/carpvipdhcp-$(_id "${request}").hb"

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -12,6 +12,10 @@
 # added or removed without shifting a positional column.
 # Starts one supervised daemon per line, keyed by a filesystem-safe request-IP id.
 
+# The keeper-field variables (request, iface, chaddr, ...) are assigned by the
+# sourced keeperconf.sh parser, which shellcheck cannot follow across its absolute
+# install path; do not flag them as unassigned (file-wide, before any command).
+# shellcheck disable=SC2154
 . /etc/rc.subr
 
 name="carpvipdhcp"

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -12,10 +12,6 @@
 # added or removed without shifting a positional column.
 # Starts one supervised daemon per line, keyed by a filesystem-safe request-IP id.
 
-# The keeper-field variables (request, iface, chaddr, ...) are assigned by the
-# sourced keeperconf.sh parser, whose absolute install path the linter cannot
-# follow; suppress the resulting "unassigned" warnings (file-wide).
-# shellcheck disable=SC2154
 . /etc/rc.subr
 
 name="carpvipdhcp"
@@ -41,6 +37,10 @@ _id()
     printf '%s' "$1" | tr -c 'A-Za-z0-9' '_'
 }
 
+# The keeper-field variables used below are assigned by the sourced keeperconf.sh
+# parser (carpvipdhcp_parse_line); the linter cannot follow its absolute install
+# path, so scope-disable the "unassigned" warning to this function only.
+# shellcheck disable=SC2154
 carpvipdhcp_start()
 {
     [ -f "${conf}" ] || { echo "no config"; return 0; }

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -21,6 +21,10 @@ conf="/usr/local/etc/carpvipdhcp/keeper.conf"
 run_dir="/var/run"
 log_dir="/var/log"
 
+# Shared keeper.conf line parser, also sourced by the CARP status hook, so the
+# two readers cannot drift (and it is unit-tested against keeperconf.py).
+. /usr/local/opnsense/scripts/OPNsense/CarpVipDhcp/keeperconf.sh
+
 start_cmd="carpvipdhcp_start"
 stop_cmd="carpvipdhcp_stop"
 status_cmd="carpvipdhcp_status"
@@ -39,37 +43,9 @@ carpvipdhcp_start()
     count=0
     while IFS= read -r line || [ -n "${line}" ]; do
         case "${line}" in ''|\#*) continue ;; esac
-        # Parse the record's KEY=VALUE fields (pipe-separated, any order). Peel one
-        # field off the front at a time with parameter expansion -- no IFS/glob
-        # side effects -- and dispatch by key, so an unknown key is ignored and a
-        # missing key keeps the reset-below default.
-        request='' iface='' chaddr='' vhid='' follow='' vendorclass=''
-        clientid='' hostname='' arpnudge='' arplistenpromisc='' defaultroutemode=''
-        backupegress='' backupegressform='' backupegressgw='' backupegressiface=''
-        backupegressprefixes=''
-        rec="${line}"
-        while [ -n "${rec}" ]; do
-            field="${rec%%|*}"
-            case "${rec}" in *"|"*) rec="${rec#*|}" ;; *) rec='' ;; esac
-            case "${field}" in
-                request=*) request="${field#*=}" ;;
-                iface=*) iface="${field#*=}" ;;
-                chaddr=*) chaddr="${field#*=}" ;;
-                vhid=*) vhid="${field#*=}" ;;
-                follow=*) follow="${field#*=}" ;;
-                vendorclass=*) vendorclass="${field#*=}" ;;
-                clientid=*) clientid="${field#*=}" ;;
-                hostname=*) hostname="${field#*=}" ;;
-                arpnudge=*) arpnudge="${field#*=}" ;;
-                arplistenpromisc=*) arplistenpromisc="${field#*=}" ;;
-                defaultroutemode=*) defaultroutemode="${field#*=}" ;;
-                backupegress=*) backupegress="${field#*=}" ;;
-                backupegressform=*) backupegressform="${field#*=}" ;;
-                backupegressgateway=*) backupegressgw="${field#*=}" ;;
-                backupegressinterface=*) backupegressiface="${field#*=}" ;;
-                backupegressprefixes=*) backupegressprefixes="${field#*=}" ;;
-            esac
-        done
+        # Parse the record's KEY=VALUE fields into request/iface/chaddr/... (see
+        # keeperconf.sh, the shared reader).
+        carpvipdhcp_parse_line "${line}"
         if [ -z "${request}" ] || [ -z "${iface}" ] || [ -z "${chaddr}" ]; then
             # A non-comment line that yields no request/iface/chaddr is unexpected
             # (the template only renders resolvable keepers). Say so rather than

--- a/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
+++ b/net/os-carp-vip-dhcp/src/etc/rc.d/carpvipdhcp
@@ -13,8 +13,8 @@
 # Starts one supervised daemon per line, keyed by a filesystem-safe request-IP id.
 
 # The keeper-field variables (request, iface, chaddr, ...) are assigned by the
-# sourced keeperconf.sh parser, which shellcheck cannot follow across its absolute
-# install path; do not flag them as unassigned (file-wide, before any command).
+# sourced keeperconf.sh parser, whose absolute install path the linter cannot
+# follow; suppress the resulting "unassigned" warnings (file-wide).
 # shellcheck disable=SC2154
 . /etc/rc.subr
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/keeperconf.sh
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/keeperconf.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Shared keeper.conf line parser for the CARP-VIP DHCP lease keepers.
+#
+# Sourced by the rc.d service (etc/rc.d/carpvipdhcp) and the CARP status hook
+# (etc/rc.carp_service_status.d/carpvipdhcp) so both read keeper.conf through ONE
+# implementation and cannot drift from each other. It is the shell counterpart of
+# keeperconf.py (the Python reader); tests/test_reader_conformance.py asserts the
+# two agree. POSIX sh, no rc.subr dependency, so it is also testable in isolation.
+#
+# keeper.conf is one keeper per line: pipe-separated KEY=VALUE fields in no fixed
+# order (rendered by the configd template).
+
+# carpvipdhcp_parse_line <line>: parse one record into the keeper field variables
+# (request, iface, chaddr, demote, vhid, follow, vendorclass, clientid, hostname,
+# arpnudge, arplistenpromisc, defaultroutemode, backupegress, backupegressform,
+# backupegressgw, backupegressiface, backupegressprefixes). All are reset first,
+# then each field is dispatched by key -- an unknown key is ignored and a missing
+# key keeps the empty reset. Peels one field at a time with parameter expansion,
+# so there are no IFS/glob side effects (the caller may be part-way through
+# building an argv with `set --`). Values may contain '=' (split on the first
+# only). The caller reads the variables above after the call.
+carpvipdhcp_parse_line()
+{
+    request='' iface='' chaddr='' demote='' vhid='' follow='' vendorclass=''
+    clientid='' hostname='' arpnudge='' arplistenpromisc='' defaultroutemode=''
+    backupegress='' backupegressform='' backupegressgw='' backupegressiface=''
+    backupegressprefixes=''
+    _rec="$1"
+    while [ -n "${_rec}" ]; do
+        _field="${_rec%%|*}"
+        case "${_rec}" in *"|"*) _rec="${_rec#*|}" ;; *) _rec='' ;; esac
+        case "${_field}" in
+            request=*) request="${_field#*=}" ;;
+            iface=*) iface="${_field#*=}" ;;
+            chaddr=*) chaddr="${_field#*=}" ;;
+            demote=*) demote="${_field#*=}" ;;
+            vhid=*) vhid="${_field#*=}" ;;
+            follow=*) follow="${_field#*=}" ;;
+            vendorclass=*) vendorclass="${_field#*=}" ;;
+            clientid=*) clientid="${_field#*=}" ;;
+            hostname=*) hostname="${_field#*=}" ;;
+            arpnudge=*) arpnudge="${_field#*=}" ;;
+            arplistenpromisc=*) arplistenpromisc="${_field#*=}" ;;
+            defaultroutemode=*) defaultroutemode="${_field#*=}" ;;
+            backupegress=*) backupegress="${_field#*=}" ;;
+            backupegressform=*) backupegressform="${_field#*=}" ;;
+            backupegressgateway=*) backupegressgw="${_field#*=}" ;;
+            backupegressinterface=*) backupegressiface="${_field#*=}" ;;
+            backupegressprefixes=*) backupegressprefixes="${_field#*=}" ;;
+        esac
+    done
+}

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/keeperconf.sh
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/keeperconf.sh
@@ -25,28 +25,31 @@ carpvipdhcp_parse_line()
     clientid='' hostname='' arpnudge='' arplistenpromisc='' defaultroutemode=''
     backupegress='' backupegressform='' backupegressgw='' backupegressiface=''
     backupegressprefixes=''
-    _rec="$1"
-    while [ -n "${_rec}" ]; do
-        _field="${_rec%%|*}"
-        case "${_rec}" in *"|"*) _rec="${_rec#*|}" ;; *) _rec='' ;; esac
-        case "${_field}" in
-            request=*) request="${_field#*=}" ;;
-            iface=*) iface="${_field#*=}" ;;
-            chaddr=*) chaddr="${_field#*=}" ;;
-            demote=*) demote="${_field#*=}" ;;
-            vhid=*) vhid="${_field#*=}" ;;
-            follow=*) follow="${_field#*=}" ;;
-            vendorclass=*) vendorclass="${_field#*=}" ;;
-            clientid=*) clientid="${_field#*=}" ;;
-            hostname=*) hostname="${_field#*=}" ;;
-            arpnudge=*) arpnudge="${_field#*=}" ;;
-            arplistenpromisc=*) arplistenpromisc="${_field#*=}" ;;
-            defaultroutemode=*) defaultroutemode="${_field#*=}" ;;
-            backupegress=*) backupegress="${_field#*=}" ;;
-            backupegressform=*) backupegressform="${_field#*=}" ;;
-            backupegressgateway=*) backupegressgw="${_field#*=}" ;;
-            backupegressinterface=*) backupegressiface="${_field#*=}" ;;
-            backupegressprefixes=*) backupegressprefixes="${_field#*=}" ;;
+    # Namespaced scratch temporaries (POSIX sh has no `local`), unset at the end so
+    # sourcing this parser does not leak them into the caller's environment.
+    _kc_rec="$1"
+    while [ -n "${_kc_rec}" ]; do
+        _kc_field="${_kc_rec%%|*}"
+        case "${_kc_rec}" in *"|"*) _kc_rec="${_kc_rec#*|}" ;; *) _kc_rec='' ;; esac
+        case "${_kc_field}" in
+            request=*) request="${_kc_field#*=}" ;;
+            iface=*) iface="${_kc_field#*=}" ;;
+            chaddr=*) chaddr="${_kc_field#*=}" ;;
+            demote=*) demote="${_kc_field#*=}" ;;
+            vhid=*) vhid="${_kc_field#*=}" ;;
+            follow=*) follow="${_kc_field#*=}" ;;
+            vendorclass=*) vendorclass="${_kc_field#*=}" ;;
+            clientid=*) clientid="${_kc_field#*=}" ;;
+            hostname=*) hostname="${_kc_field#*=}" ;;
+            arpnudge=*) arpnudge="${_kc_field#*=}" ;;
+            arplistenpromisc=*) arplistenpromisc="${_kc_field#*=}" ;;
+            defaultroutemode=*) defaultroutemode="${_kc_field#*=}" ;;
+            backupegress=*) backupegress="${_kc_field#*=}" ;;
+            backupegressform=*) backupegressform="${_kc_field#*=}" ;;
+            backupegressgateway=*) backupegressgw="${_kc_field#*=}" ;;
+            backupegressinterface=*) backupegressiface="${_kc_field#*=}" ;;
+            backupegressprefixes=*) backupegressprefixes="${_kc_field#*=}" ;;
         esac
     done
+    unset _kc_rec _kc_field
 }

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
@@ -18,4 +18,4 @@ wires up and runs the Keeper defined here. Modules, leaf-first:
 # PLUGIN_VERSION from this line (so the package version and the daemon's own
 # reported version can never drift). Keep the assignment on one line as
 # __version__ = "X.Y.Z" so the Makefile's sed can read it.
-__version__ = "1.13.0"
+__version__ = "1.13.1"

--- a/net/os-carp-vip-dhcp/tests/test_keeperconf.py
+++ b/net/os-carp-vip-dhcp/tests/test_keeperconf.py
@@ -83,18 +83,20 @@ def _read_plugin_file(rel):
 
 def test_keeper_conf_key_names_agree_across_readers():
     """The keeper.conf key names are hand-duplicated across the template (producer)
-    and every reader (the two sh scripts and the Python readers), which have no
-    shared source. A rename in one but not the others degrades SILENTLY -- worst
-    case rc.d skips every line and lease-keeping stops ("Started 0 keeper(s)").
-    Pin the contract: every key a reader consumes must be one the template emits.
-    Catches the rename-divergence class without a Volt/sh runtime."""
+    and every reader (the shared shell parser and the Python/PHP readers), which
+    have no common source. A rename in one but not the others degrades SILENTLY --
+    worst case the shell parser matches nothing, rc.d skips every line and
+    lease-keeping stops ("Started 0 keeper(s)"). Pin the contract: every key a
+    reader consumes must be one the template emits. Catches the rename-divergence
+    class without a Volt/sh runtime (test_reader_conformance runs the shell parser
+    for real)."""
     template = _read_plugin_file(
         "src/opnsense/service/templates/OPNsense/CarpVipDhcp/keeper.conf")
     emitted = set(re.findall(r"(\w+)=\{\{", template))
     # Guard the regex itself: the template really does emit the core keys.
     assert {"request", "iface", "chaddr", "defaultroutemode"} <= emitted
 
-    def sh_keys(rel):                       # rc.d/hook `case` arms: `key=*)`
+    def sh_keys(rel):                       # keeperconf.sh `case` arms: `key=*)`
         return set(re.findall(r"^\s*(\w+)=\*\)", _read_plugin_file(rel), re.MULTILINE))
 
     def py_get_keys(rel):                   # Python readers: `rec.get("key"...)`
@@ -106,8 +108,9 @@ def test_keeper_conf_key_names_agree_across_readers():
         return set(re.findall(r'\$field\b[^;\n]*?["\'](\w+)=', _read_plugin_file(rel)))
 
     readers = {
-        "rc.d": sh_keys("src/etc/rc.d/carpvipdhcp"),
-        "carp-hook": sh_keys("src/etc/rc.carp_service_status.d/carpvipdhcp"),
+        # The rc.d service and the CARP status hook both source this one parser.
+        "keeperconf.sh": sh_keys(
+            "src/opnsense/scripts/OPNsense/CarpVipDhcp/keeperconf.sh"),
         "status.py": py_get_keys(
             "src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py"),
         "logparse.py": py_get_keys(

--- a/net/os-carp-vip-dhcp/tests/test_reader_conformance.py
+++ b/net/os-carp-vip-dhcp/tests/test_reader_conformance.py
@@ -3,8 +3,15 @@
 keeperconf.sh (sourced by the rc.d service and the CARP status hook) is the shell
 counterpart of keeperconf.keeper_records. A shared parser already means the two
 shell consumers cannot drift from each other; this pins that the shell parser
-also extracts exactly what the Python reader does, field for field, so a future
-edit to one format that misses the other is caught.
+extracts the same field split the Python reader does, field for field, so a
+future edit to one that misses the other is caught.
+
+Scope: this compares the field splitter only. keeper_records additionally strips
+the line, skips blank/comment lines and requires a request; those behaviours live
+in the shell CALLERS (rc.d, the CARP hook), not in carpvipdhcp_parse_line, so they
+are out of scope here (the fixtures are clean single records). Runs only where a
+POSIX sh is on PATH -- always on the CI Linux runner; it is skipped (not failed)
+on a dev box without one, so shell parser changes must be validated under CI.
 """
 # pylint: disable=missing-function-docstring
 import os
@@ -42,6 +49,11 @@ _FIXTURES = [
     "request=1.2.3.4|iface=em0|chaddr=aa|clientid=id=with=eq|hostname=",
     # Leading-dash values (the DHCP-option masks allow them; must survive as the value).
     "request=1.2.3.4|iface=em0|chaddr=aa|vendorclass=-foo|defaultroutemode=-bad",
+    # A glob/special character in a value (guards the "no glob side effects"
+    # contract against a future missing quote in the parser).
+    "request=1.2.3.4|iface=em0|chaddr=aa|vendorclass=a[b]*c|hostname=",
+    # A stray field with no '=' (must be ignored, not mis-dispatched).
+    "request=1.2.3.4|garbage|iface=em0|chaddr=aa",
 ]
 
 
@@ -52,7 +64,10 @@ def _sh_parse(line):
     script = f'. "$1"\ncarpvipdhcp_parse_line "$2"\n{dump}\n'
     out = subprocess.run(
         ["sh", "-c", script, "sh", _KEEPERCONF_SH, line],
-        capture_output=True, text=True, check=True).stdout.split("\n")
+        capture_output=True, text=True, check=True).stdout.splitlines()
+    # One line per key and nothing else -- catches stray output that would
+    # otherwise misalign or be silently dropped by zip().
+    assert len(out) == len(_KEYS), f"expected {len(_KEYS)} lines, got {out!r}"
     return dict(zip(_KEYS, out))
 
 

--- a/net/os-carp-vip-dhcp/tests/test_reader_conformance.py
+++ b/net/os-carp-vip-dhcp/tests/test_reader_conformance.py
@@ -1,0 +1,71 @@
+"""Conformance between the shell and Python keeper.conf readers.
+
+keeperconf.sh (sourced by the rc.d service and the CARP status hook) is the shell
+counterpart of keeperconf.keeper_records. A shared parser already means the two
+shell consumers cannot drift from each other; this pins that the shell parser
+also extracts exactly what the Python reader does, field for field, so a future
+edit to one format that misses the other is caught.
+"""
+# pylint: disable=missing-function-docstring
+import os
+import shutil
+import subprocess
+
+import pytest
+
+_SCRIPT_DIR = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..",
+    "src", "opnsense", "scripts", "OPNsense", "CarpVipDhcp"))
+_KEEPERCONF_SH = os.path.join(_SCRIPT_DIR, "keeperconf.sh")
+
+# keeper.conf key -> the shell variable carpvipdhcp_parse_line sets for it. All
+# match the key name except the two backup-egress fields (shorter var names).
+_KEYS = [
+    "request", "iface", "chaddr", "demote", "vhid", "follow", "vendorclass",
+    "clientid", "hostname", "arpnudge", "arplistenpromisc", "defaultroutemode",
+    "backupegress", "backupegressform", "backupegressgateway",
+    "backupegressinterface", "backupegressprefixes",
+]
+_VAR = {k: k for k in _KEYS}
+_VAR["backupegressgateway"] = "backupegressgw"
+_VAR["backupegressinterface"] = "backupegressiface"
+
+_FIXTURES = [
+    # A full record.
+    "request=185.41.66.101|iface=lagg1|chaddr=00:00:5e:00:01:c7|demote=0|vhid=199|"
+    "follow=1|vendorclass=|clientid=|hostname=|arpnudge=240|arplistenpromisc=0|"
+    "defaultroutemode=enforce|backupegress=1|backupegressform=split|"
+    "backupegressgateway=10.0.0.1|backupegressinterface=em0|backupegressprefixes=",
+    # Reordered, an unknown key, and several keys missing.
+    "vhid=42|newkey=x|request=1.2.3.4|iface=em0|chaddr=aa",
+    # Empty values, and a value that itself contains '='.
+    "request=1.2.3.4|iface=em0|chaddr=aa|clientid=id=with=eq|hostname=",
+    # Leading-dash values (the DHCP-option masks allow them; must survive as the value).
+    "request=1.2.3.4|iface=em0|chaddr=aa|vendorclass=-foo|defaultroutemode=-bad",
+]
+
+
+def _sh_parse(line):
+    """{key: value} as keeperconf.sh's carpvipdhcp_parse_line extracts it (one
+    `printf` per key, in _KEYS order, so the split lines up)."""
+    dump = "\n".join(f'printf "%s\\n" "${{{_VAR[k]}}}"' for k in _KEYS)
+    script = f'. "$1"\ncarpvipdhcp_parse_line "$2"\n{dump}\n'
+    out = subprocess.run(
+        ["sh", "-c", script, "sh", _KEEPERCONF_SH, line],
+        capture_output=True, text=True, check=True).stdout.split("\n")
+    return dict(zip(_KEYS, out))
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="no POSIX sh available")
+@pytest.mark.parametrize("line", _FIXTURES)
+def test_sh_reader_matches_python(tmp_path, line):
+    from keeperconf import keeper_records  # pylint: disable=import-outside-toplevel
+    conf = tmp_path / "keeper.conf"
+    conf.write_text(line + "\n")
+    records = list(keeper_records(str(conf)))
+    assert len(records) == 1
+    py = records[0]
+    sh = _sh_parse(line)
+    for key in _KEYS:
+        assert sh[key] == py.get(key, ""), \
+            f"key {key}: shell={sh[key]!r} python={py.get(key, '')!r}"


### PR DESCRIPTION
## What

Follow-up to #74 (name-keyed keeper.conf): a behavioural conformance harness for the keeper.conf readers, plus the small refactor that makes it possible.

### Shared shell parser
The rc.d service and the CARP status hook each carried their own copy of the keeper.conf peel-loop. This extracts it into `keeperconf.sh`, sourced by both, so the two shell readers now parse through one implementation and cannot drift from each other. The parse logic is unchanged.

### Conformance test
`test_reader_conformance.py` runs the shared shell parser under `sh` over edge-case records (reordered keys, empty values, a value containing `=`, leading-dash values) and asserts it extracts exactly what the Python reader (`keeper_records`) does, field for field. This catches a future edit to one reader's format handling that the text-based key-name agreement test (added in #74) would not, because it exercises the real shell code, not just the key names. The key-name agreement test now points at `keeperconf.sh`, the single shell reader.

The two PHP readers only consume `request`, still covered by the key-name agreement test.

## Testing
272 unit tests, flake8, pylint 10/10, pyright 0, and `sh -n` on all three shell files, all green. shellcheck runs in CI.

## Version
Bumped to 1.13.1 (internal refactor plus test, no behaviour change).
