### PR TITLE
refactor(os-carp-vip-dhcp): per-line broad-except disables, narrow the safe ones

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -50,9 +50,6 @@ Usage:
   lease_keeper.py ... --once            # one-shot claim+verify+release (test)
 """
 
-# The daemon must never die on unexpected input: the components log-and-continue
-# on a catch-all (see the docstring); main() and one-shot mode do the same.
-# pylint: disable=broad-exception-caught
 import argparse
 import logging
 import os
@@ -197,7 +194,7 @@ def _setup_logging(logfile):
     if logfile:
         try:
             handlers.append(RotatingFileHandler(logfile, maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUPS))
-        except Exception as e:
+        except OSError as e:
             # No log sink is configured yet, so stash the reason and emit it
             # once logging is up -- otherwise a bad --logfile (unwritable dir,
             # bad path) leaves an empty log with no explanation.
@@ -317,7 +314,7 @@ def main():
         if pf and os.path.exists(pf):
             try:
                 os.unlink(pf)
-            except Exception:
+            except OSError:
                 pass
 
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/capture_bpf.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/capture_bpf.py
@@ -26,10 +26,6 @@ from .wire import _deliver
 
 LOG = logging.getLogger(LOGGER_NAME)
 
-# Daemon log-and-continue posture: broad catch-alls are deliberate (see the
-# package docstring / module docstrings).
-# pylint: disable=broad-exception-caught
-
 
 # The raw /dev/bpf backend drives its ioctls through fcntl, which does not
 # exist on non-POSIX development hosts. Import it defensively so the module still
@@ -97,7 +93,7 @@ class BpfCapture:  # pylint: disable=too-many-instance-attributes
             return False
         try:
             self._configure(fd)
-        except Exception as e:
+        except OSError as e:
             os.close(fd)
             os.close(wake_reader)
             os.close(wake_writer)
@@ -225,7 +221,8 @@ class BpfCapture:  # pylint: disable=too-many-instance-attributes
                     decoded, handler = _decode_arp(frame[ETHER_HDR_LEN:]), self._on_arp
                 elif ethertype == ETHERTYPE_IPV4:
                     decoded, handler = _decode_ipv4_bootp(frame[ETHER_HDR_LEN:]), self._on_bootp
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            # Untrusted wire bytes: any decode failure is malformed input, not a bug.
             self._parse_errs.emit(LOG.debug, "bpf frame parse error: %s", e)
             return
         _deliver(handler, decoded)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
@@ -19,10 +19,6 @@ from .wire import DhcpReply, DhcpSend, _dhcp_options, _fmt_reply, _msg_text
 
 LOG = logging.getLogger(LOGGER_NAME)
 
-# Daemon log-and-continue posture: broad catch-alls are deliberate (see the
-# package docstring / module docstrings).
-# pylint: disable=broad-exception-caught
-
 
 @dataclass
 class Lease:  # pylint: disable=too-many-instance-attributes
@@ -205,7 +201,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             self._rx = None
             try:
                 self._send_dhcp("discover", extra)
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-exception-caught
                 LOG.warning("DHCP DISCOVER send failed (attempt %d, xid 0x%08x): %s",
                             attempt, self.xid, e)
                 time.sleep(SEND_RETRY_DELAY)
@@ -237,7 +233,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                     "request",
                     [(DhcpOptName.SERVER_ID, self.binding.server), (DhcpOptName.REQUESTED_ADDR, self.binding.yiaddr)],
                 )
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-exception-caught
                 LOG.warning("DHCP REQUEST send failed (attempt %d, xid 0x%08x): %s",
                             attempt, self.xid, e)
                 time.sleep(SEND_RETRY_DELAY)
@@ -283,7 +279,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             self._rx = None
             try:
                 self._send_dhcp("request", extra)
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-exception-caught
                 LOG.warning("DHCP INIT-REBOOT send failed (attempt %d, xid 0x%08x): %s",
                             attempt, self.xid, e)
                 time.sleep(SEND_RETRY_DELAY)
@@ -332,7 +328,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             try:
                 # RENEW/REBIND carry no extra options -- ciaddr identifies the lease.
                 self._send_dhcp("request", [], ciaddr=yiaddr)
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-exception-caught
                 LOG.warning("DHCP %s send failed (xid 0x%08x, ciaddr %s): %s",
                             phase, self.xid, yiaddr, e)
                 return False
@@ -375,7 +371,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
                 chaddr=self.chraw, xid=self.xid, ciaddr=yiaddr, flags=0,
                 options=[(DhcpOptName.MESSAGE_TYPE, "release"), (DhcpOptName.SERVER_ID, server), "end"]))
             LOG.info("DHCP RELEASE of %s sent (server %s)", yiaddr, server or "broadcast")
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             LOG.warning("DHCP RELEASE of %s failed (server %s): %s",
                         yiaddr, server or "broadcast", e)
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -26,10 +26,6 @@ from .wire import _parse_reply
 
 LOG = logging.getLogger(LOGGER_NAME)
 
-# Daemon log-and-continue posture: broad catch-alls are deliberate (see the
-# package docstring / module docstrings).
-# pylint: disable=broad-exception-caught
-
 # The keeper's dependency on ifconfig(8) output text, named in one place. The
 # trailing space in the CARP format is load-bearing: it stops vhid 1 matching
 # "vhid 11".
@@ -328,7 +324,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             return
         try:
             _atomic_write(self._cfg.hbfile, content)
-        except Exception as e:
+        except OSError as e:
             # The heartbeat drives CARP gating, so a write failure is worth surfacing.
             LOG.warning("heartbeat write failed (%s): %s", self._cfg.hbfile, e)
 
@@ -754,11 +750,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             # and retry after a short backoff.
             try:
                 self._maintain_step()
-            except Exception:
+            except Exception:  # pylint: disable=broad-exception-caught
                 LOG.exception("unexpected error in main loop -- recovering")
                 try:
                     self._hb()
-                except Exception:
+                except Exception:  # pylint: disable=broad-exception-caught
                     pass
                 self._sleep(LOOP_ERROR_BACKOFF)
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
@@ -16,10 +16,6 @@ from .util import (
 
 LOG = logging.getLogger(LOGGER_NAME)
 
-# Daemon log-and-continue posture: broad catch-alls are deliberate (see the
-# package docstring / module docstrings).
-# pylint: disable=broad-exception-caught
-
 # "CARP-master value not supplied by the caller" sentinel: the maintain loop
 # passes the role it already probed this tick, but None is itself a valid probe
 # result (probe failed), so a distinct sentinel means "probe it yourself".
@@ -99,7 +95,7 @@ class ArpNudge:  # pylint: disable=too-many-instance-attributes
                 self._gw = gateway
             else:
                 LOG.debug("ARP nudge sent: who-has %s tell %s", gateway, yiaddr)
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             # A persistently failing send stays periodically visible (throttled with
             # a suppressed count), not spammed every interval nor latched silent.
             self._nudge_fail_log.emit(LOG.warning, "ARP nudge failed (target %s): %s", gateway, e)
@@ -271,7 +267,7 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
             # spawn failure is retried next cycle instead of getting stuck.
             self._attempt.followed_ip = new_ip
             LOG.info("requested CARP VIP update %s -> %s", self.target, new_ip)
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             LOG.error("follow_update request failed: %s", e)
 
     def _fire_follow_update(self, old_ip, new_ip):
@@ -298,7 +294,7 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
                     att.follow_from, att.followed_ip, FOLLOW_RETRY_DEADLINE)
         try:
             self._fire_follow_update(att.follow_from, att.followed_ip)
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             LOG.error("follow_update retry failed: %s", e)
 
     def observe(self, rx):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -36,10 +36,6 @@ def _drop(*_args, **_kwargs):
     steady-state repeat, so a suppressed heartbeat is a no-op with the same
     call shape as LOG.debug/LOG.info."""
 
-# Daemon log-and-continue posture: broad catch-alls are deliberate (see the
-# package docstring / module docstrings).
-# pylint: disable=broad-exception-caught
-
 
 class DefaultRouteMode(StrEnum):
     """Per-keeper default-route mode (the values the model's defaultRouteMode
@@ -772,7 +768,7 @@ class DefaultRouteReconciler:
             return False
         try:
             return self._liveness_probe() is False
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             # A broken liveness probe must not block routing.
             return False
 


### PR DESCRIPTION
First PR of the code-quality pass. Replaces the six module-level `broad-exception-caught` blanket disables (which blind pylint to any future lazy catch-all) with per-line disables on the sites where a broad catch is deliberate (main-loop and heartbeat keep-alive, untrusted-wire decode, injected liveness probe, DHCP send/dispatch), and narrows four sites whose only real failure is I/O to `OSError` (heartbeat write, log-file handler, pidfile unlink, bpf configure) -- after which lease_keeper.py has no broad catch.

Behaviour-preserving: the daemon's log-and-continue posture is unchanged; the four narrowings only stop swallowing a would-be bug on paths that raise nothing but OSError. Narrowing the send/dispatch sites is deferred to the test-informed pass (it needs raising-injection tests). pylint 10.00/10 (up from 9.85), 274 tests, flake8/pyright/pycodestyle clean. Reviewed for silent-failure regressions before opening.