### PR TITLE
refactor(os-carp-vip-dhcp): pythonic idioms -- SendMsgType enum, comprehension, justified disable

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/codec.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/codec.py
@@ -8,7 +8,7 @@ access is bounds-checked and a malformed frame decodes to None (dropped).
 import ipaddress
 import struct
 
-from .constants import ArpOp, BootpOp, DhcpOpt, DhcpOptName, ETHER_ZERO, MsgType
+from .constants import ArpOp, BootpOp, DhcpOpt, DhcpOptName, ETHER_ZERO, MsgType, SendMsgType
 from .util import mac2raw
 from .wire import ArpFrame, BootpFrame
 
@@ -33,9 +33,9 @@ IP_HDR_LEN = 20             # fixed IPv4 header we build (no options)
 UDP_HDR_LEN = 8             # UDP header (src/dst port, length, checksum)
 
 # The DHCP message types the keeper SENDS, keyed by the option name the outbound
-# option lists carry (the lowercased MsgType name -- "discover" etc.). Derived
-# from MsgType so nothing is hand-duplicated; only these three are ever sent.
-_MTYPE_CODES = {m.name.lower(): m for m in (MsgType.DISCOVER, MsgType.REQUEST, MsgType.RELEASE)}
+# option lists carry (a SendMsgType, which IS the lowercased MsgType name). Keyed
+# by that send type -> its wire code (the MsgType value); only these three are sent.
+_MTYPE_CODES = {t: MsgType[t.name] for t in SendMsgType}
 
 
 def _ip4(ip):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/constants.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/constants.py
@@ -27,6 +27,17 @@ class MsgType(IntEnum):
 OFFER, ACK, NAK = MsgType.OFFER, MsgType.ACK, MsgType.NAK
 
 
+class SendMsgType(StrEnum):
+    """The message types the keeper SENDS, as the lowercased-name strings the
+    option list and codec's send map carry. Derived from MsgType so nothing is
+    hand-duplicated; a member IS its string, so it flows through wire/codec
+    unchanged while making the send-site values typo-proof instead of bare
+    literals."""
+    DISCOVER = MsgType.DISCOVER.name.lower()
+    REQUEST = MsgType.REQUEST.name.lower()
+    RELEASE = MsgType.RELEASE.name.lower()
+
+
 class BootpOp(IntEnum):
     """BOOTP op field (RFC 951): client-to-server messages are REQUEST, the
     server's answers are REPLY. Distinct from the DHCP message type -- every

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
@@ -13,7 +13,7 @@ from .constants import (
     ACK, ATTEMPT_BACKOFF_CAP, BROADCAST_FLAG, DEFAULT_LEASE, DhcpOptName, DORA_ATTEMPTS,
     IPV4_BROADCAST, MIN_LEASE, MIN_T1, NAK, OFFER, Phase, REBIND_MARGIN,
     REBOOT_ATTEMPTS, RENEW_ATTEMPTS,
-    RENEW_TIMEOUT, REPLY_TIMEOUT, SEND_RETRY_DELAY, T1_FACTOR, T2_FACTOR)
+    RENEW_TIMEOUT, REPLY_TIMEOUT, SEND_RETRY_DELAY, SendMsgType, T1_FACTOR, T2_FACTOR)
 from .util import _jittered, _mask_to_bits, _new_xid, mac2raw
 from .wire import DhcpReply, DhcpSend, _dhcp_options, _fmt_reply, _msg_text
 
@@ -200,7 +200,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             self._ensure_sniffer()
             self._rx = None
             try:
-                self._send_dhcp("discover", extra)
+                self._send_dhcp(SendMsgType.DISCOVER, extra)
             except Exception as e:  # pylint: disable=broad-exception-caught
                 LOG.warning("DHCP DISCOVER send failed (attempt %d, xid 0x%08x): %s",
                             attempt, self.xid, e)
@@ -230,7 +230,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             self._rx = None
             try:
                 self._send_dhcp(
-                    "request",
+                    SendMsgType.REQUEST,
                     [(DhcpOptName.SERVER_ID, self.binding.server), (DhcpOptName.REQUESTED_ADDR, self.binding.yiaddr)],
                 )
             except Exception as e:  # pylint: disable=broad-exception-caught
@@ -278,7 +278,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             self._ensure_sniffer()
             self._rx = None
             try:
-                self._send_dhcp("request", extra)
+                self._send_dhcp(SendMsgType.REQUEST, extra)
             except Exception as e:  # pylint: disable=broad-exception-caught
                 LOG.warning("DHCP INIT-REBOOT send failed (attempt %d, xid 0x%08x): %s",
                             attempt, self.xid, e)
@@ -327,7 +327,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             self._rx = None
             try:
                 # RENEW/REBIND carry no extra options -- ciaddr identifies the lease.
-                self._send_dhcp("request", [], ciaddr=yiaddr)
+                self._send_dhcp(SendMsgType.REQUEST, [], ciaddr=yiaddr)
             except Exception as e:  # pylint: disable=broad-exception-caught
                 LOG.warning("DHCP %s send failed (xid 0x%08x, ciaddr %s): %s",
                             phase, self.xid, yiaddr, e)
@@ -369,7 +369,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
             self._capture.send_dhcp(DhcpSend(
                 eth_src=self.eth_src, ip_src=yiaddr, ip_dst=server or IPV4_BROADCAST,
                 chaddr=self.chraw, xid=self.xid, ciaddr=yiaddr, flags=0,
-                options=[(DhcpOptName.MESSAGE_TYPE, "release"), (DhcpOptName.SERVER_ID, server), "end"]))
+                options=[(DhcpOptName.MESSAGE_TYPE, SendMsgType.RELEASE), (DhcpOptName.SERVER_ID, server), "end"]))
             LOG.info("DHCP RELEASE of %s sent (server %s)", yiaddr, server or "broadcast")
         except Exception as e:  # pylint: disable=broad-exception-caught
             LOG.warning("DHCP RELEASE of %s failed (server %s): %s",

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -360,6 +360,8 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         replaces this daemon with one bound to the new address."""
         cmd = ["/usr/local/sbin/configctl", "-d", "carpvipdhcp", "follow_update", old_ip, new_ip]
         cmd += gw_args   # cross-subnet: [old_gw, new_gw, bits]; empty on a same-subnet move
+        # Fire-and-forget: this configctl triggers a service restart that replaces
+        # this very daemon, so we must not wait on the child (`with` would block).
         subprocess.Popen(cmd)  # pylint: disable=consider-using-with
 
     # ---- CARP role (master probe, transitions) ----

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -535,10 +535,8 @@ class DefaultRouteReconciler:
                                   iface, prefixlen)
             return None
         net = ipaddress.ip_network(f"{own}/{prefixlen}", strict=False)
-        for host in net.hosts():
-            if str(host) != own:
-                return str(host)
-        return None
+        # The peer is the other host of the /30 or /31 (the one that is not us).
+        return next((str(host) for host in net.hosts() if str(host) != own), None)
 
     def _iface_ipv4(self, iface):
         """(address, prefixlen) of the first IPv4 on `iface`, or None. Parses


### PR DESCRIPTION
Phase B of the code-quality pass (pythonic consistency, behaviour-preserving).

- **SendMsgType enum**: the send side passed bare `"discover"`/`"request"`/`"release"` literals while the read side used enums. Add a `SendMsgType` StrEnum derived from `MsgType` (no duplicated literal) and use it at the five send sites; the codec keys its send map by it. A member IS its lowercased-name string, so the wire bytes (discover->1, request->3, release->7) and the string-based tests are unchanged.
- **`_derive_peer`**: manual peer-selection loop folded into a `next()` comprehension.
- **`consider-using-with`**: added the fire-and-forget rationale at the follow-update `Popen` (it restarts and replaces this daemon, so it must not be awaited).

274 tests, flake8, pylint 10/10, pyright 0. Reviewed for wire-path behaviour-preservation (verified empirically) before opening.