### PR TITLE
Group injected DI hooks into named ports (DhcpHooks, FollowHooks)

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
@@ -7,6 +7,7 @@ import logging
 import threading
 import time
 from dataclasses import dataclass
+from typing import Callable
 
 from .constants import (
     LOGGER_NAME,
@@ -42,20 +43,28 @@ class Lease:  # pylint: disable=too-many-instance-attributes
     lease_router: str | None = None
 
 
+@dataclass(frozen=True)
+class DhcpHooks:
+    """The three policy hooks the caller injects into DhcpClient, grouped so the
+    follow/keeper policy (not the protocol engine) owns them: should_stop aborts
+    a sequence mid-flight, ensure_sniffer guarantees the capture is live before a
+    send, and on_changed_address(got, rx, phase, release_on_enforce) -> bool
+    adjudicates an ACK whose address differs from the expected one."""
+    should_stop: Callable[[], bool]
+    ensure_sniffer: Callable[[], None]
+    on_changed_address: Callable[..., bool]
+
+
 class DhcpClient:  # pylint: disable=too-many-instance-attributes
     """RFC 2131 client for one chaddr: owns the held binding (a Lease)
     and the stateful protocol sequences
     (INIT-REBOOT / DORA / RENEW / REBIND / RELEASE) with their send/await
     machinery. It does NOT own the packet capture: sends travel through the
     injected capture backend, and the capture owner hands xid-matched replies
-    to feed(). Policy stays with the caller through three
-    injected hooks: should_stop (abort mid-sequence), ensure_sniffer (capture
-    must be alive before a send), and on_changed_address(got, rx, phase,
-    release_on_enforce) -> bool for an ACK whose address differs from the
-    expected one (True = the caller validated and adopted it, see adopt())."""
+    to feed(). Policy stays with the caller through the injected DhcpHooks
+    (should_stop / ensure_sniffer / on_changed_address; see that type)."""
 
-    def __init__(self, capture, chaddr, eth_src, id_opts, *,  # pylint: disable=too-many-arguments
-                 should_stop, ensure_sniffer, on_changed_address):
+    def __init__(self, capture, chaddr, eth_src, id_opts, *, hooks):
         self._capture = capture
         self.chaddr = chaddr
         self.chraw = mac2raw(chaddr)
@@ -64,9 +73,9 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         # Optional DHCP request options (empty -> not sent); added to every
         # DISCOVER/REQUEST/RENEW so the server sees a consistent client identity.
         self._id_opts = id_opts
-        self._should_stop = should_stop
-        self._ensure_sniffer = ensure_sniffer
-        self._on_changed = on_changed_address
+        self._should_stop = hooks.should_stop
+        self._ensure_sniffer = hooks.ensure_sniffer
+        self._on_changed = hooks.on_changed_address
 
         self.xid = _new_xid()
         self.binding = Lease()         # the held (or last-held) DHCP binding

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
@@ -52,7 +52,7 @@ class DhcpHooks:
     adjudicates an ACK whose address differs from the expected one."""
     should_stop: Callable[[], bool]
     ensure_sniffer: Callable[[], None]
-    on_changed_address: Callable[..., bool]
+    on_changed_address: Callable[[str | None, DhcpReply, Phase, bool], bool]
 
 
 class DhcpClient:  # pylint: disable=too-many-instance-attributes
@@ -64,7 +64,7 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
     to feed(). Policy stays with the caller through the injected DhcpHooks
     (should_stop / ensure_sniffer / on_changed_address; see that type)."""
 
-    def __init__(self, capture, chaddr, eth_src, id_opts, *, hooks):
+    def __init__(self, capture, chaddr, eth_src, id_opts, *, hooks: DhcpHooks):
         self._capture = capture
         self.chaddr = chaddr
         self.chraw = mac2raw(chaddr)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -18,8 +18,8 @@ from .constants import (
     ACK, BootpOp, DhcpOptName, HB_REFRESH, LEASE_PULSE_INTERVAL, LINK_KICK_DEBOUNCE,
     LINK_POLL_STEP, LOOP_ERROR_BACKOFF, Phase, REBIND_POLL_STEP, REDORA_MAX, REDORA_MIN,
     SNIFFER_RETRY, SNIFFER_WARMUP)
-from .dhcpclient import DhcpClient
-from .policy import ArpNudge, FollowPolicy
+from .dhcpclient import DhcpClient, DhcpHooks
+from .policy import ArpNudge, FollowHooks, FollowPolicy
 from .route import DefaultRouteReconciler
 from .util import _RateLimit, _atomic_write, _clock_at, _jittered, _sane_ipv4
 from .wire import _parse_reply
@@ -166,6 +166,10 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
     operator actions. The lease lives in DhcpClient; the changed-address
     decision and the target address live in FollowPolicy."""
 
+    # Composition root: where the parsed CLI/config surface becomes live
+    # collaborators, so it names every tunable once. Folding the args into a
+    # config object would only relocate that surface (_Config/DhcpHooks/
+    # FollowHooks already group them downstream), so the count is inherent here.
     def __init__(self, iface, chaddr, request_ip=None,  # pylint: disable=too-many-arguments,too-many-locals
                  eth_src=None, *,
                  hbfile=None, release_on_exit=False, vhid=None,
@@ -217,15 +221,17 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._dhcp = DhcpClient(
             self._capture, self._cfg.chaddr, self._cfg.eth_src,
             _identity_options(vendor_class, client_id, hostname),
-            should_stop=lambda: self._signals.stopping,
-            ensure_sniffer=self._ensure_sniffer,
-            on_changed_address=self._on_changed_address)
+            hooks=DhcpHooks(
+                should_stop=lambda: self._signals.stopping,
+                ensure_sniffer=self._ensure_sniffer,
+                on_changed_address=self._on_changed_address))
 
         # Follow/enforce policy component: owns the target address and the
         # follow bookkeeping; drives the client via adopt()/release()/expire().
-        self._follow = FollowPolicy(request_ip, follow, self._cfg.chaddr, self._dhcp,
-                                    self._hb_mismatch,
-                                    dispatch=self._dispatch_follow_update)
+        self._follow = FollowPolicy(
+            request_ip, follow, self._cfg.chaddr, self._dhcp,
+            hooks=FollowHooks(hb_mismatch=self._hb_mismatch,
+                              dispatch=self._dispatch_follow_update))
 
         # Default-route ownership component (opt-in via defaultRouteMode): owns
         # the IPv4 default route as a function of (CARP role, lease-held, lease

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
@@ -133,7 +133,7 @@ class FollowHooks:
     """FollowPolicy's two injected side-effect seams, grouped so the system
     coupling stays out of this decision module: hb_mismatch(got, want) records a
     lease vs heartbeat disagreement, and dispatch(old, new, gw_args) drives the
-    configd CARP-VIP rewrite. Both returns are ignored (fire-and-forget)."""
+    configd CARP-VIP rewrite. Both return values are ignored (fire-and-forget)."""
     hb_mismatch: Callable[[str, str], None]
     dispatch: Callable[[str, str, list], None]
 
@@ -148,7 +148,7 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
     (rewritten on a successful follow), the persisted follow throttle, the
     apply-retry watchdog and the peer-ACK observation handoff."""
 
-    def __init__(self, target, follow, chaddr, dhcp, *, hooks):
+    def __init__(self, target, follow, chaddr, dhcp, *, hooks: FollowHooks):
         self.target = target           # the address this keeper is meant to hold
         self.follow = follow
         self._dhcp = dhcp

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
@@ -6,6 +6,7 @@ rewrite the VIP, or alarm and refuse).
 import logging
 import time
 from dataclasses import dataclass, field
+from typing import Callable
 
 from .constants import (
     LOGGER_NAME,
@@ -127,6 +128,16 @@ class _FollowAttempt:
     gw_args: list = field(default_factory=list)  # [old_gw, new_gw, bits] cross-subnet; else []
 
 
+@dataclass(frozen=True)
+class FollowHooks:
+    """FollowPolicy's two injected side-effect seams, grouped so the system
+    coupling stays out of this decision module: hb_mismatch(got, want) records a
+    lease vs heartbeat disagreement, and dispatch(old, new, gw_args) drives the
+    configd CARP-VIP rewrite. Both returns are ignored (fire-and-forget)."""
+    hb_mismatch: Callable[[str, str], None]
+    dispatch: Callable[[str, str, list], None]
+
+
 class FollowPolicy:  # pylint: disable=too-many-instance-attributes
     """Decides what happens when the server grants a DIFFERENT address than
     the target this keeper exists to hold. In follow mode: validate the new
@@ -137,17 +148,12 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
     (rewritten on a successful follow), the persisted follow throttle, the
     apply-retry watchdog and the peer-ACK observation handoff."""
 
-    def __init__(self, target, follow, chaddr, dhcp, hb_mismatch,  # pylint: disable=too-many-arguments
-                 *, dispatch):
+    def __init__(self, target, follow, chaddr, dhcp, *, hooks):
         self.target = target           # the address this keeper is meant to hold
         self.follow = follow
         self._dhcp = dhcp
-        self._hb_mismatch = hb_mismatch
-        # Injected side-effect seam: the callable that dispatches the CARP-VIP
-        # rewrite (old, new, gw_args). Kept out of this decision module so the
-        # system coupling (configd) lives in the orchestration layer, like the
-        # other hooks.
-        self._dispatch = dispatch
+        self._hb_mismatch = hooks.hb_mismatch
+        self._dispatch = hooks.dispatch    # configd CARP-VIP rewrite; see FollowHooks
 
         self._attempt = _FollowAttempt()   # the in-flight follow (watchdog re-drive state)
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -44,9 +44,10 @@ def _client(lk, id_opts=None, on_changed=None):
     """A bare DhcpClient with stub hooks and a captured send list -- the
     protocol tests need no Keeper and no capture backend."""
     c = lk.DhcpClient(None, CHADDR_STR, CHADDR_STR, id_opts or [],
-                      should_stop=lambda: False,
-                      ensure_sniffer=lambda: None,
-                      on_changed_address=on_changed or (lambda *a: False))
+                      hooks=lk.DhcpHooks(
+                          should_stop=lambda: False,
+                          ensure_sniffer=lambda: None,
+                          on_changed_address=on_changed or (lambda *a: False)))
     c.sent = []
     c._send_dhcp = lambda mtype, extra, ciaddr="0.0.0.0": c.sent.append((mtype, extra, ciaddr))
     return c


### PR DESCRIPTION
Part of the code-quality pass: reduce self-imposed pylint pragmas that flag refactoring opportunities.

## What

The keeper injects a handful of callables into `DhcpClient` and `FollowPolicy`. Passing them as a flat kwarg list pushed both constructors over the argument-count threshold, each carrying a `# pylint: disable=too-many-arguments`. This groups the injected callables into two small frozen dataclass ports:

- `DhcpHooks`: `should_stop`, `ensure_sniffer`, `on_changed_address`
- `FollowHooks`: `hb_mismatch`, `dispatch`

Both pragmas are removed as a result. `FollowPolicy` keeps its `dhcp` collaborator as a visible positional argument (it is a driven dependency, not a fire-and-forget seam, so it does not belong in a "hooks" bag).

`Keeper.__init__` keeps its own `too-many-arguments,too-many-locals` pragma, now with a comment: it is the composition root, so naming the full parsed config surface once is inherent, and folding it into a config object would only relocate that surface.

## Behaviour

Behaviour-preserving. The constructors unpack the ports into the same private attributes, so every method body is unchanged. Only the constructor signatures and the two construction sites in the keeper change; the one direct `DhcpClient` construction in the tests is adapted to the ports form.

## Verification

- unit tests: all pass
- flake8 (max-line-length 120): clean
- pylint 10.00/10 with useless-suppression enabled
- pyright: 0 errors