### PR TITLE
Split DefaultRouteReconciler into two peer reconcilers

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -61,7 +61,8 @@ from leasekeeper.capture_bpf import BpfCapture
 from leasekeeper.constants import LOGGER_NAME
 from leasekeeper.keeper import Keeper, carp_master
 from leasekeeper.route import (
-    BackupEgressConfig, BackupEgressForm, DefaultRouteMode, DefaultRouteReconciler)
+    BackupEgressConfig, BackupEgressForm, BackupEgressReconciler, DefaultRouteMode,
+    DefaultRouteReconciler, withdraw_unless_master)
 from leasekeeper.util import MAC_RE
 
 LOG = logging.getLogger(LOGGER_NAME)
@@ -242,8 +243,13 @@ def main():
         # (a master keeps its default, a backup withdraws; probe only when the mode
         # acts) lives in withdraw_unless_master. Skipped for --once and no vhid.
         if not a.once and a.vhid:
-            DefaultRouteReconciler(a.default_route_mode, backup_egress=backup_egress) \
-                .withdraw_unless_master(lambda: carp_master(a.iface, a.vhid))
+            # a.default_route_mode is already coerced (above), so both reconcilers take
+            # it verbatim; the backup set is cleaned before the 0/0 withdraw inside
+            # withdraw_unless_master, the one sequence that spans the two reconcilers.
+            withdraw_unless_master(
+                DefaultRouteReconciler(a.default_route_mode),
+                BackupEgressReconciler(a.default_route_mode, backup_egress=backup_egress),
+                lambda: carp_master(a.iface, a.vhid))
 
         # Fail fast (with a logged reason) if the raw /dev/bpf backend cannot run
         # on this host (e.g. fcntl missing off FreeBSD).

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -20,7 +20,8 @@ from .constants import (
     SNIFFER_RETRY, SNIFFER_WARMUP)
 from .dhcpclient import DhcpClient, DhcpHooks
 from .policy import ArpNudge, FollowHooks, FollowPolicy
-from .route import DefaultRouteReconciler
+from .route import (BackupEgressReconciler, DefaultRouteMode, DefaultRouteReconciler,
+                    withdraw_unless_master)
 from .util import _RateLimit, _atomic_write, _clock_at, _jittered, _sane_ipv4
 from .wire import _parse_reply
 
@@ -241,7 +242,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # split-brain install-gate is a deliberate follow-up that needs a
         # debounced carrier signal (a single transient ifconfig miss must not
         # flap the default); see docs/single-ip-wan-carp.md.
-        self._defroute = DefaultRouteReconciler(default_route_mode, backup_egress=backup_egress)
+        # Coerce the mode once and hand the same value to both reconcilers so an
+        # unrecognised mode string warns once, not twice.
+        mode = DefaultRouteMode.coerce(default_route_mode)
+        self._defroute = DefaultRouteReconciler(mode)
+        self._backup = BackupEgressReconciler(mode, backup_egress=backup_egress)
 
         self.redora_wait = REDORA_MIN
         # Link-return fast path (only while UNBOUND): a carrier down->up edge
@@ -513,7 +518,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # wrongly install a backup route on a master-without-lease. probe_for_backup
         # re-probes there so that edge is decided on the true role.
         backup_master = self._probe_carp_master() if probe_for_backup else master
-        self._defroute.reconcile_backup_egress(backup_master)
+        self._backup.reconcile_backup_egress(backup_master)
 
     def _role_tick(self, master=_UNSET):
         """One shared CARP-role probe driving both the role poll and the
@@ -769,7 +774,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # shutdown: relinquish an owned default unless we are the CARP master, so a
         # keeper restart on a master does not flap 0/0 (the rationale and the accepted
         # trade-off live in withdraw_unless_master).
-        self._defroute.withdraw_unless_master(self._probe_carp_master)
+        withdraw_unless_master(self._defroute, self._backup, self._probe_carp_master)
         if self._cfg.release_on_exit:
             self._dhcp.release()
         self._capture.stop()
@@ -811,15 +816,15 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             # acquire; a still-backup keeps its route. The 0/0 deliberately stays after the
             # acquire (the no-flap restart path above). A promotion that lands mid-acquire is
             # caught by the post-acquire reconcile on the next iteration.
-            if self._defroute.backup_egress_enabled:
-                self._defroute.reconcile_backup_egress(self._probe_carp_master())
+            if self._backup.enabled:
+                self._backup.reconcile_backup_egress(self._probe_carp_master())
             self._acquire_step()
             if not b.yiaddr:
                 # master=False is the fictional role for the role-independent 0/0
                 # withdraw; backup egress needs the true role (a master-without-lease
                 # must not get a backup route), so probe when the feature is enabled.
                 self._reconcile_default_route(
-                    master=False, probe_for_backup=self._defroute.backup_egress_enabled)
+                    master=False, probe_for_backup=self._backup.enabled)
             return
         # Bound: own the default by CARP role, here at the loop head. _maintain_step
         # is re-entered after every transition (a just-acquired lease, a renew that

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -7,6 +7,12 @@ node with no default advertises none (via os-frr redistribute kernel), so the
 failure mode is a withdrawn default, never a black-holed one. See
 docs/single-ip-wan-carp.md.
 
+Two independent reconcilers live here: DefaultRouteReconciler owns the 0/0
+decision, and the optional BackupEgressReconciler owns the backup-egress route
+set (docs/backup-egress.md). They share nothing but the /sbin/route exec helpers
+below; the one cross-cutting sequence -- clean the backup set BEFORE withdrawing
+0/0 at a process boundary -- lives in the module-level withdraw_unless_master().
+
 Concurrency: reconcile() must be called only from the keeper's main loop thread;
 the caller is Keeper._reconcile_default_route -- the per-tick poll, the acquire
 arm (unbound and just after a successful acquire) and the SIGUSR2 CARP edge, plus
@@ -105,6 +111,16 @@ class BackupEgressConfig:
     prefixes: "tuple[str, ...]" = ()
 
 
+@dataclass
+class _WarnGates:
+    """The backup reconciler's rising-edge one-shot warn flags, each re-armed when
+    its condition clears so a node that sits as backup for a long time does not
+    churn the log with a repeated warning."""
+    unresolved: bool = False       # the backup gateway could not be resolved
+    fib_unreadable: bool = False   # netstat could not read the routing table
+    collision: bool = False        # a backup prefix is present via a foreign next hop
+
+
 class RouteCommand(StrEnum):
     """The `/sbin/route` commands we issue (route(8) calls add/delete/get
     'commands'). StrEnum so a member drops straight into the argv list and logs
@@ -152,6 +168,86 @@ _DEFAULT_NET = ipaddress.ip_network("0.0.0.0/0")
 _PTP_PREFIXLENS = (30, 31)
 
 
+# ---- /sbin/route exec helpers (stateless; shared by both reconcilers) ----
+
+def _run(cmd):
+    """Run a `/sbin/route` argv, capturing output and bounded by a timeout;
+    return the CompletedProcess, or None if it could not be executed at all
+    (logged)."""
+    try:
+        return subprocess.run(cmd, capture_output=True, errors="replace",
+                              timeout=_SUBPROC_TIMEOUT, check=False)
+    except (OSError, subprocess.SubprocessError) as e:
+        LOG.warning("route command failed to run (%s): %s", " ".join(cmd), e)
+        return None
+
+
+def _route(command, dest, gateway=None):
+    """Issue a `/sbin/route` command (best effort). The caller confirms the
+    resulting FIB state, so a non-zero exit -- an idempotent no-op or a real
+    failure alike -- is only debug-logged and left for that confirm to judge,
+    rather than guessed from route(8)'s wording here."""
+    cmd = [_ROUTE, _NUMERIC, command, _AF_INET, dest]
+    if gateway is not None:
+        cmd.append(gateway)
+    res = _run(cmd)
+    if res is not None and res.returncode != 0:
+        LOG.debug("route %s %s exit %d: %s", command, dest, res.returncode,
+                  (res.stderr or "").strip())
+
+
+def _at(changed, heartbeat):
+    """Pick the log callable for a desired-state confirmation. A state change
+    logs at INFO the first time the state is entered, and re-arms the heartbeat
+    so the identical DEBUG repeat does not fire on the very next tick. An
+    unchanged repeat logs at DEBUG at most once per RECONCILE_HEARTBEAT_INTERVAL
+    (proof the reconciler is alive and its decision); the ticks in between are
+    dropped, so a steady node does not fill the log file with a per-tick
+    heartbeat and churn the rotation. `heartbeat` is the deciding reconciler's own
+    throttle -- the 0/0 and backup-egress decisions pass separate ones so the two
+    do not interfere."""
+    if changed:
+        heartbeat.reset()
+        return LOG.info
+    ok, _ = heartbeat.ready()
+    return LOG.debug if ok else _drop
+
+
+def withdraw_unless_master(default_route, backup_egress, probe):
+    """Drop an owned default UNLESS this node is the CARP master, cleaning the
+    backup-egress set first. `probe` is a callable() -> bool|None returning the
+    CARP-master role; it runs only once the mode would act, so off never spawns it.
+    A confirmed master KEEPS its default (a keeper restart -- a config change or an
+    upgrade -- must not tear it down and flap 0/0; the maintain loop re-adopts it).
+    A backup or an unreadable role (False / None) withdraws, fail-closed, so a stale
+    default is never left for FRR to keep advertising with nothing managing it.
+
+    Run at the two process boundaries: main()'s startup fail-stop (on throwaway
+    reconcilers, before the Keeper / capture backend exist and ahead of any
+    arg/backend early-exit that would skip Keeper.run()) and Keeper.run()'s
+    graceful shutdown. off is a no-op; observe logs a would-withdraw without
+    touching the FIB; enforce actually withdraws. The caller gates on a CARP vhid.
+
+    Ordering: the backup-egress set is cleaned BEFORE the 0/0 withdraw so a stopped
+    keeper leaves no route a later master would loop through (withdraw_backup_egress
+    no-ops when the feature is disabled and cleans only what it owns; see it for why).
+    This is the one sequence that spans the two reconcilers, so it lives here rather
+    than in either object.
+
+    Trade-off: a GENUINE permanent stop (an operator disabling the plugin) on a
+    node that is still CARP master keeps the default in the FIB with nothing
+    managing it after -- the state this withdraw otherwise prevents. That window
+    is narrow (the node is still master, so the default is at least
+    static-correct) and telling it apart from a restart would need a fragile
+    stop-vs-restart signal, so it is accepted."""
+    if not default_route.enabled:
+        return    # off is fully inert: no FIB read/write, no probe.
+    backup_egress.withdraw_backup_egress()
+    if probe() is True:
+        return
+    default_route.reconcile(is_master=False, bound=False, gateway=None)
+
+
 class DefaultRouteReconciler:
     """Reconciles the IPv4 default route against (CARP role, lease-held,
     gateway). Level-triggered and idempotent: reconcile() may be called as often
@@ -161,13 +257,9 @@ class DefaultRouteReconciler:
     All methods run on the keeper's main loop thread only; the class holds no
     lock because nothing else in the keeper mutates routes."""
 
-    # The 0/0 decision and the optional backup-egress decision each carry their own
-    # last-state + heartbeat, so the attribute count is intentional.
-    # pylint: disable=too-many-instance-attributes
-
     def __init__(self, mode: "str | DefaultRouteMode" = DefaultRouteMode.OFF, *,
                  unreadable_role_strikes=DEFAULT_UNREADABLE_ROLE_STRIKES,
-                 liveness_probe=None, backup_egress: "BackupEgressConfig | None" = None):
+                 liveness_probe=None):
         # mode flows in from the model verbatim (keeper.conf -> rc.d -> argparse)
         # as a plain string; coerce it, treating any unrecognised value as inert
         # OFF (never guess an active mode). Set-once: exposed read-only via `mode`.
@@ -190,16 +282,6 @@ class DefaultRouteReconciler:
         # backup/master does not log its (identical) decision every tick and churn
         # the log rotation. A change re-arms it (see _at).
         self._heartbeat = _RateLimit(RECONCILE_HEARTBEAT_INTERVAL)
-        # Optional backup-egress (docs/backup-egress.md), with its own last-state and
-        # heartbeat so its logging does not interfere with the 0/0 decision's.
-        self._backup = backup_egress or BackupEgressConfig()
-        self._last_backup_desired = _UNSET
-        self._backup_heartbeat = _RateLimit(RECONCILE_HEARTBEAT_INTERVAL)
-        self._valid_prefixes = None            # cached validated prefixes (warn-once via the cache)
-        self._backup_unresolved_warned = False  # rising-edge gate for gateway-resolution warnings
-        self._fib_unreadable_warned = False    # rising-edge gate for the netstat-unreadable warning
-        self._backup_installed_gws = set()     # gateways our prefixes are confirmed at (ownership)
-        self._backup_collision_warned = False  # rising-edge gate for foreign-route collision warnings
 
     @property
     def mode(self):
@@ -210,67 +292,6 @@ class DefaultRouteReconciler:
     def enabled(self):
         """True in observe/enforce (off is inert); see DefaultRouteMode."""
         return self._mode in (DefaultRouteMode.OBSERVE, DefaultRouteMode.ENFORCE)
-
-    @property
-    def backup_egress_enabled(self):
-        """True when the backup-egress feature is active (mode observe/enforce AND the
-        feature enabled). Lets the caller decide whether the unbound path must probe the
-        real CARP role for backup egress (the 0/0 withdraw there uses a fictional role)."""
-        return self.enabled and self._backup.enabled
-
-    def withdraw_unless_master(self, probe):
-        """Drop an owned default UNLESS this node is the CARP master. `probe` is a
-        callable() -> bool|None returning the CARP-master role; it runs only once the
-        mode would act, so off never spawns it. A confirmed master KEEPS its default
-        (a keeper restart -- a config change or an upgrade -- must not tear it down
-        and flap 0/0; the maintain loop re-adopts it). A backup or an unreadable role
-        (False / None) withdraws, fail-closed, so a stale default is never left for
-        FRR to keep advertising with nothing managing it.
-
-        Run at the two process boundaries: main()'s startup fail-stop (on a throwaway
-        reconciler, before the Keeper / capture backend exist and ahead of any
-        arg/backend early-exit that would skip Keeper.run()) and Keeper.run()'s
-        graceful shutdown. off is a no-op; observe logs a would-withdraw without
-        touching the FIB; enforce actually withdraws. The caller gates on a CARP vhid.
-
-        Trade-off: a GENUINE permanent stop (an operator disabling the plugin) on a
-        node that is still CARP master keeps the default in the FIB with nothing
-        managing it after -- the state this withdraw otherwise prevents. That window
-        is narrow (the node is still master, so the default is at least
-        static-correct) and telling it apart from a restart would need a fragile
-        stop-vs-restart signal, so it is accepted."""
-        if not self.enabled:
-            return    # off is fully inert: no FIB read/write, no probe.
-        # Clean the backup-egress set at the boundary so a stopped keeper leaves no route a
-        # later master would loop through. Only routes this feature actually manages are
-        # touched (withdraw_backup_egress no-ops when the feature is disabled): the /1-split
-        # is also the classic full-tunnel-VPN pair, so a keeper that never installed it must
-        # not delete a /1 it does not own.
-        self.withdraw_backup_egress()
-        if probe() is True:
-            return
-        self.reconcile(is_master=False, bound=False, gateway=None)
-
-    def withdraw_backup_egress(self):
-        """Remove the backup-egress routes (the /1-split plus any configured prefixes) at a
-        process boundary, so a stopped keeper leaves none that a later master would loop
-        through. A no-op unless the feature is enabled: the /1-split (0.0.0.0/1 +
-        128.0.0.0/1) is also the classic full-tunnel-VPN split, so a keeper that never
-        managed backup egress must not delete a /1 it does not own -- routes are cleaned by
-        ownership, not by matching a shape. observe logs, enforce deletes. Unlike the
-        reconcile loop there is no next tick to retry, so an unconfirmable removal is
-        surfaced loudly here rather than left to a silent re-check.
-
-        Accepted limit: a /1 left by a crashed predecessor whose feature (or mode) is then
-        disabled before restart is not cleaned, because it can no longer be told apart from
-        an unrelated VPN /1. That narrow crash-then-disable case needs manual cleanup (or
-        the deferred persisted-ownership follow-up); see docs/backup-egress.md."""
-        if not self.backup_egress_enabled:
-            return
-        self._backup_remove(self._backup_removal_set(), changed=True, reason="keeper stopping")
-        if self._mode == DefaultRouteMode.ENFORCE and self._fib_routes() is None:
-            LOG.warning("backup egress: could not clean up at shutdown (routing table "
-                        "unreadable) -- a leftover /1 would loop egress if this node is master")
 
     def reconcile(self, is_master, bound, gateway):
         """Drive the FIB default toward the desired state for the current
@@ -348,22 +369,6 @@ class DefaultRouteReconciler:
             else:
                 self._withdraw(changed, have, reason)
 
-    def _at(self, changed, heartbeat=None):
-        """Pick the log callable for a desired-state confirmation. A state change
-        logs at INFO the first time the state is entered, and re-arms the heartbeat
-        so the identical DEBUG repeat does not fire on the very next tick. An
-        unchanged repeat logs at DEBUG at most once per RECONCILE_HEARTBEAT_INTERVAL
-        (proof the reconciler is alive and its decision); the ticks in between are
-        dropped, so a steady node does not fill the log file with a per-tick
-        heartbeat and churn the rotation. `heartbeat` defaults to the 0/0 decision's;
-        the backup-egress decision passes its own so the two do not interfere."""
-        hb = heartbeat if heartbeat is not None else self._heartbeat
-        if changed:
-            hb.reset()
-            return LOG.info
-        ok, _ = hb.ready()
-        return LOG.debug if ok else _drop
-
     @staticmethod
     def _no_default_reason(blocked, is_master, holds_lease):
         """Why the desired state is 'no default' -- the informative half of the
@@ -381,30 +386,169 @@ class DefaultRouteReconciler:
         gateway, so there is nothing to install -- state ownership positively
         instead of returning silently."""
         if self._mode == DefaultRouteMode.OBSERVE:
-            self._at(changed)("[observe] default already via %s -- would own", gateway)
+            _at(changed, self._heartbeat)("[observe] default already via %s -- would own", gateway)
         else:
-            self._at(changed)("owning default via %s", gateway)
+            _at(changed, self._heartbeat)("owning default via %s", gateway)
 
     def _confirm_no_default(self, changed, reason):
         """Steady-state no-default heartbeat: there is correctly no default to
         hold (backup / no lease / liveness-gated)."""
         if self._mode == DefaultRouteMode.OBSERVE:
-            self._at(changed)("[observe] no default held (%s) -- as wanted", reason)
+            _at(changed, self._heartbeat)("[observe] no default held (%s) -- as wanted", reason)
         else:
-            self._at(changed)("no default held (%s)", reason)
+            _at(changed, self._heartbeat)("no default held (%s)", reason)
 
-    # ---- backup egress (optional; docs/backup-egress.md) ----
+    def _on_unknown_role(self):
+        """An unreadable (is_master is None) probe: do not install when unsure,
+        but after a bounded number of consecutive unknown probes, withdraw any
+        default we still hold so a former master stops advertising once its role
+        can no longer be confirmed. The warning fires once per unreadable episode
+        (re-armed when the role reads definite again), not every tick."""
+        self._strikes += 1
+        if self._strikes < self._strike_limit:
+            return
+        have = self._fib_default_gateway()
+        if have is None:
+            return
+        first_time = not self._unreadable_warned
+        if first_time:
+            LOG.warning("CARP role unreadable for %d checks -- failing closed on "
+                        "the default", self._strikes)
+            self._unreadable_warned = True
+        self._withdraw(first_time, have, "CARP role unreadable")
+
+    def _liveness_blocks(self):
+        """True only when the liveness probe is present and returns an explicit
+        False. A missing probe or a None result never blocks."""
+        if self._liveness_probe is None:
+            return False
+        try:
+            return self._liveness_probe() is False
+        except Exception:  # pylint: disable=broad-exception-caught
+            # A broken liveness probe must not block routing.
+            return False
+
+    # ---- FIB operations (idempotent, error-tolerant, main-loop only) ----
+
+    def _install(self, changed, gateway, replacing=None):
+        if self._mode == DefaultRouteMode.OBSERVE:
+            _at(changed, self._heartbeat)("[observe] would install default via %s%s", gateway,
+                                          "" if replacing is None else f" (replacing {replacing})")
+            return
+        # Replace atomically with `route change`, not delete-then-add. A bench
+        # check on FreeBSD 14.3 confirmed both halves: `route change` to an on-link
+        # gateway swaps in place (no momentary no-default gap for FRR
+        # redistribute-kernel to flap on), and to an off-link gateway it fails
+        # ("Invalid argument") and leaves the old default intact -- so a still-usable
+        # default is never torn down for one we cannot install (e.g. a cross-subnet
+        # lease whose new gateway is not on-link until the interface moves). A first
+        # install (no prior default) uses `add`: `change` requires the route to
+        # exist. Then CONFIRM the FIB reached the desired state -- reading the result
+        # back is wording-independent, unlike parsing route(8)'s exit/stderr, and a
+        # rejected change simply reads back as the old gateway (surfaced below).
+        verb = RouteCommand.ADD if replacing is None else RouteCommand.CHANGE
+        _route(verb, _DEFAULT, gateway)
+        have = self._fib_default_gateway()
+        if have == gateway:
+            LOG.info("installed default via %s%s", gateway,
+                     "" if replacing is None else f" (was {replacing})")
+        else:
+            LOG.error("failed to install default via %s (the FIB default is now %s)",
+                      gateway, have or "absent")
+
+    def _withdraw(self, changed, current, reason):
+        if self._mode == DefaultRouteMode.OBSERVE:
+            _at(changed, self._heartbeat)("[observe] would withdraw default (currently via %s) -- %s",
+                                          current, reason)
+            return
+        _route(RouteCommand.DELETE, _DEFAULT)
+        # Confirm the FIB, not the exit code: a silently failed delete would leave
+        # a backup advertising a black-hole default -- the one outcome this feature
+        # exists to prevent -- so surface it at ERROR. The level-triggered
+        # reconcile retries the withdraw next tick.
+        if self._fib_default_gateway() is None:
+            LOG.info("withdrew default (was via %s) -- %s", current, reason)
+        else:
+            LOG.error("failed to withdraw default (still via %s) -- this node keeps "
+                      "advertising it", current)
+
+    def _fib_default_gateway(self):
+        """Current IPv4 default gateway, or None when there is no default. Any
+        `route get` failure (an empty table exits non-zero) reads as 'no default'
+        -- the common, quiet steady state on a backup -- rather than an error; a
+        genuinely stuck route op is surfaced by the install/withdraw confirm, not
+        by second-guessing this read."""
+        res = _run([_ROUTE, _NUMERIC, RouteCommand.GET, _AF_INET, _DEFAULT])
+        if res is None or res.returncode != 0:
+            return None
+        for line in res.stdout.splitlines():
+            stripped = line.strip()
+            if stripped.startswith(_GATEWAY_FIELD):
+                return stripped[len(_GATEWAY_FIELD):].strip() or None
+        return None
+
+
+class BackupEgressReconciler:
+    """Reconciles the optional backup-egress route set (docs/backup-egress.md):
+    while a node is the CARP backup (no WAN default) it routes its own internet
+    traffic to the master via a leak-safe /1-split (or configured prefixes), and
+    removes that set while it is master (the inverse of the 0/0 the default-route
+    reconciler manages). Level-triggered and idempotent, main-loop thread only.
+
+    Ownership, not shape, decides what it touches: the /1-split is also the classic
+    full-tunnel-VPN pair, so a foreign next hop is never overwritten or removed."""
+
+    def __init__(self, mode: "str | DefaultRouteMode" = DefaultRouteMode.OFF, *,
+                 backup_egress: "BackupEgressConfig | None" = None):
+        # mode is coerced (as in DefaultRouteReconciler) so an unrecognised value is
+        # inert OFF; the backup set only acts under observe/enforce.
+        self._mode = DefaultRouteMode.coerce(mode)
+        self._backup = backup_egress or BackupEgressConfig()
+        self._last_backup_desired = _UNSET
+        self._backup_heartbeat = _RateLimit(RECONCILE_HEARTBEAT_INTERVAL)
+        self._valid_prefixes = None            # cached validated prefixes (warn-once via the cache)
+        self._backup_installed_gws = set()     # gateways our prefixes are confirmed at (ownership)
+        self._warn = _WarnGates()              # rising-edge one-shot warn flags
+
+    @property
+    def enabled(self):
+        """True when the backup-egress feature is active (mode observe/enforce AND the
+        feature enabled). Lets the caller decide whether the unbound path must probe the
+        real CARP role for backup egress (the 0/0 withdraw there uses a fictional role)."""
+        return (self._mode in (DefaultRouteMode.OBSERVE, DefaultRouteMode.ENFORCE)
+                and self._backup.enabled)
+
+    def withdraw_backup_egress(self):
+        """Remove the backup-egress routes (the /1-split plus any configured prefixes) at a
+        process boundary, so a stopped keeper leaves none that a later master would loop
+        through. A no-op unless the feature is enabled: the /1-split (0.0.0.0/1 +
+        128.0.0.0/1) is also the classic full-tunnel-VPN split, so a keeper that never
+        managed backup egress must not delete a /1 it does not own -- routes are cleaned by
+        ownership, not by matching a shape. observe logs, enforce deletes. Unlike the
+        reconcile loop there is no next tick to retry, so an unconfirmable removal is
+        surfaced loudly here rather than left to a silent re-check.
+
+        Accepted limit: a /1 left by a crashed predecessor whose feature (or mode) is then
+        disabled before restart is not cleaned, because it can no longer be told apart from
+        an unrelated VPN /1. That narrow crash-then-disable case needs manual cleanup (or
+        the deferred persisted-ownership follow-up); see docs/backup-egress.md."""
+        if not self.enabled:
+            return
+        self._backup_remove(self._backup_removal_set(), changed=True, reason="keeper stopping")
+        if self._mode == DefaultRouteMode.ENFORCE and self._fib_routes() is None:
+            LOG.warning("backup egress: could not clean up at shutdown (routing table "
+                        "unreadable) -- a leftover /1 would loop egress if this node is master")
 
     def reconcile_backup_egress(self, is_master):
         """Keep the backup-egress route set present while this node is the CARP
         backup and absent while it is master (the inverse of the 0/0 it manages).
-        Call from the same tick as reconcile(), after it. A no-op unless the feature
-        is enabled and the mode is observe/enforce (off is inert). is_master None (an
-        unreadable role) touches nothing, like the 0/0 side."""
-        if not self.backup_egress_enabled or is_master is None:
+        Call from the same tick as the default-route reconcile, after it. A no-op
+        unless the feature is enabled and the mode is observe/enforce (off is inert).
+        is_master None (an unreadable role) touches nothing, like the 0/0 side."""
+        if not self.enabled or is_master is None:
             return
         if is_master:
-            self._backup_unresolved_warned = False   # re-arm so a returning backup re-warns once
+            self._warn.unresolved = False   # re-arm so a returning backup re-warns once
             desired = (_BackupState.ABSENT, None)
         else:
             gateway = self._resolve_backup_gateway()
@@ -474,7 +618,7 @@ class DefaultRouteReconciler:
         peer of the configured interface. None (warned, rising-edge) when it cannot be
         worked out; a successful resolve re-arms the warning."""
         gateway = self._backup_gateway()
-        self._backup_unresolved_warned = gateway is None
+        self._warn.unresolved = gateway is None
         return gateway
 
     def _backup_gateway(self):
@@ -500,7 +644,7 @@ class DefaultRouteReconciler:
     def _warn_unresolved(self, fmt, *args):
         """Log a gateway-resolution failure at most once per unresolved episode: a node
         can sit as backup for a long time, so the message must not churn the log."""
-        if not self._backup_unresolved_warned:
+        if not self._warn.unresolved:
             LOG.warning(fmt, *args)
 
     def _gateway_is_own(self, gateway):
@@ -511,7 +655,7 @@ class DefaultRouteReconciler:
         not active locally, so it resolves via the real interface, not lo0 -- the
         recommended VIP gateway is not caught. Never cached: a transient route-get failure
         must not permanently disable the guard, so the caller defers on None and re-checks."""
-        res = self._run([_ROUTE, _NUMERIC, RouteCommand.GET, _AF_INET, gateway])
+        res = _run([_ROUTE, _NUMERIC, RouteCommand.GET, _AF_INET, gateway])
         if res is None or res.returncode != 0:
             return None   # could not determine -> caller defers rather than routing blind
         for line in res.stdout.splitlines():
@@ -541,7 +685,7 @@ class DefaultRouteReconciler:
     def _iface_ipv4(self, iface):
         """(address, prefixlen) of the first IPv4 on `iface`, or None. Parses
         `ifconfig <iface> inet` ('inet A netmask 0xMMMMMMMM ...')."""
-        res = self._run([_IFCONFIG, iface, "inet"])
+        res = _run([_IFCONFIG, iface, "inet"])
         if res is None or res.returncode != 0:
             return None
         toks = res.stdout.split()
@@ -582,9 +726,9 @@ class DefaultRouteReconciler:
         intended next hop on install; None on the master-side removal, where an unattributable
         /1 might actually be our own stale leftover looping this node's egress."""
         if not prefixes:
-            self._backup_collision_warned = False
+            self._warn.collision = False
             return
-        if not self._backup_collision_warned:
+        if not self._warn.collision:
             if gateway is None:
                 LOG.warning("backup egress: %s present via a next hop this node does not own "
                             "-- leaving it untouched; if it is a stale backup-egress route this "
@@ -595,7 +739,7 @@ class DefaultRouteReconciler:
                 LOG.warning("backup egress: %s already routed via another next hop (not %s) -- "
                             "leaving it untouched (not managed by this feature)",
                             " ".join(prefixes), gateway)
-            self._backup_collision_warned = True
+            self._warn.collision = True
 
     def _classify_backup_prefixes(self, route_set, gateway, have):
         """Split the desired prefixes against the current FIB `have` into (pending,
@@ -634,7 +778,7 @@ class DefaultRouteReconciler:
         if not route_set:
             return
         if self._mode == DefaultRouteMode.OBSERVE:
-            self._at(changed, self._backup_heartbeat)(
+            _at(changed, self._backup_heartbeat)(
                 "[observe] would route backup egress via %s (%s)", gateway, " ".join(route_set))
             return
         have = self._fib_routes()
@@ -648,14 +792,14 @@ class DefaultRouteReconciler:
         if pending:
             for prefix in pending:
                 verb = RouteCommand.ADD if have.get(self._net(prefix)) is None else RouteCommand.CHANGE
-                self._route(verb, prefix, gateway)
+                _route(verb, prefix, gateway)
             state = self._fib_routes()
             if state is None:
                 return   # writes issued but cannot confirm (already warned); re-check next tick
         self._record_backup_ownership(gateway, state, route_set)
         if not pending:
             if not collisions:
-                self._at(changed, self._backup_heartbeat)(
+                _at(changed, self._backup_heartbeat)(
                     "backup egress via %s (%s)", gateway, " ".join(route_set))
             return
         missing = [p for p in pending if state.get(self._net(p)) != gateway]
@@ -669,7 +813,7 @@ class DefaultRouteReconciler:
         # did not happen: the reconcile master path uses the default, the shutdown
         # boundary passes "keeper stopping".
         if self._mode == DefaultRouteMode.OBSERVE:
-            self._at(changed, self._backup_heartbeat)(
+            _at(changed, self._backup_heartbeat)(
                 "[observe] would remove backup egress (%s)", " ".join(removal_set))
             return
         have = self._fib_routes()
@@ -691,10 +835,10 @@ class DefaultRouteReconciler:
         self._note_backup_collisions(collisions, None)
         if not present:
             self._prune_backup_ownership(have, removal_set)   # nothing of ours here -> drop stale gws
-            self._at(changed, self._backup_heartbeat)("no backup egress (%s)", reason)
+            _at(changed, self._backup_heartbeat)("no backup egress (%s)", reason)
             return
         for prefix in present:
-            self._route(RouteCommand.DELETE, prefix)
+            _route(RouteCommand.DELETE, prefix)
         now = self._fib_routes()
         if now is None:
             return   # deletes issued but cannot confirm (already warned); re-check next tick
@@ -711,16 +855,16 @@ class DefaultRouteReconciler:
         the table cannot be read -- callers must not mistake an unreadable table for 'no
         routes' and skip the master-side removal. A bare host address parses as /32;
         header and default rows that are not a network are skipped."""
-        res = self._run([_NETSTAT, "-rn", "-f", "inet"])
+        res = _run([_NETSTAT, "-rn", "-f", "inet"])
         if res is None or res.returncode != 0:
-            if not self._fib_unreadable_warned:   # once per unreadable episode (re-armed below)
+            if not self._warn.fib_unreadable:   # once per unreadable episode (re-armed below)
                 # Neutral wording: on install this defers the write, but on the master
                 # removal path the deletes ARE issued and only the confirm is deferred.
                 LOG.warning("backup egress: cannot read the routing table (netstat) -- route "
                             "state cannot be confirmed until it is readable")
-                self._fib_unreadable_warned = True
+                self._warn.fib_unreadable = True
             return None
-        self._fib_unreadable_warned = False
+        self._warn.fib_unreadable = False
         routes = {}
         for line in res.stdout.splitlines():
             parts = line.split()
@@ -737,118 +881,3 @@ class DefaultRouteReconciler:
     def _net(prefix):
         """Parse a (pre-validated) prefix string to a network, for FIB comparison."""
         return ipaddress.ip_network(prefix, strict=False)
-
-    # ---- role-unknown handling ----
-
-    def _on_unknown_role(self):
-        """An unreadable (is_master is None) probe: do not install when unsure,
-        but after a bounded number of consecutive unknown probes, withdraw any
-        default we still hold so a former master stops advertising once its role
-        can no longer be confirmed. The warning fires once per unreadable episode
-        (re-armed when the role reads definite again), not every tick."""
-        self._strikes += 1
-        if self._strikes < self._strike_limit:
-            return
-        have = self._fib_default_gateway()
-        if have is None:
-            return
-        first_time = not self._unreadable_warned
-        if first_time:
-            LOG.warning("CARP role unreadable for %d checks -- failing closed on "
-                        "the default", self._strikes)
-            self._unreadable_warned = True
-        self._withdraw(first_time, have, "CARP role unreadable")
-
-    def _liveness_blocks(self):
-        """True only when the liveness probe is present and returns an explicit
-        False. A missing probe or a None result never blocks."""
-        if self._liveness_probe is None:
-            return False
-        try:
-            return self._liveness_probe() is False
-        except Exception:  # pylint: disable=broad-exception-caught
-            # A broken liveness probe must not block routing.
-            return False
-
-    # ---- FIB operations (idempotent, error-tolerant, main-loop only) ----
-
-    def _install(self, changed, gateway, replacing=None):
-        if self._mode == DefaultRouteMode.OBSERVE:
-            self._at(changed)("[observe] would install default via %s%s", gateway,
-                              "" if replacing is None else f" (replacing {replacing})")
-            return
-        # Replace atomically with `route change`, not delete-then-add. A bench
-        # check on FreeBSD 14.3 confirmed both halves: `route change` to an on-link
-        # gateway swaps in place (no momentary no-default gap for FRR
-        # redistribute-kernel to flap on), and to an off-link gateway it fails
-        # ("Invalid argument") and leaves the old default intact -- so a still-usable
-        # default is never torn down for one we cannot install (e.g. a cross-subnet
-        # lease whose new gateway is not on-link until the interface moves). A first
-        # install (no prior default) uses `add`: `change` requires the route to
-        # exist. Then CONFIRM the FIB reached the desired state -- reading the result
-        # back is wording-independent, unlike parsing route(8)'s exit/stderr, and a
-        # rejected change simply reads back as the old gateway (surfaced below).
-        verb = RouteCommand.ADD if replacing is None else RouteCommand.CHANGE
-        self._route(verb, _DEFAULT, gateway)
-        have = self._fib_default_gateway()
-        if have == gateway:
-            LOG.info("installed default via %s%s", gateway,
-                     "" if replacing is None else f" (was {replacing})")
-        else:
-            LOG.error("failed to install default via %s (the FIB default is now %s)",
-                      gateway, have or "absent")
-
-    def _withdraw(self, changed, current, reason):
-        if self._mode == DefaultRouteMode.OBSERVE:
-            self._at(changed)("[observe] would withdraw default (currently via %s) -- %s",
-                              current, reason)
-            return
-        self._route(RouteCommand.DELETE, _DEFAULT)
-        # Confirm the FIB, not the exit code: a silently failed delete would leave
-        # a backup advertising a black-hole default -- the one outcome this feature
-        # exists to prevent -- so surface it at ERROR. The level-triggered
-        # reconcile retries the withdraw next tick.
-        if self._fib_default_gateway() is None:
-            LOG.info("withdrew default (was via %s) -- %s", current, reason)
-        else:
-            LOG.error("failed to withdraw default (still via %s) -- this node keeps "
-                      "advertising it", current)
-
-    def _fib_default_gateway(self):
-        """Current IPv4 default gateway, or None when there is no default. Any
-        `route get` failure (an empty table exits non-zero) reads as 'no default'
-        -- the common, quiet steady state on a backup -- rather than an error; a
-        genuinely stuck route op is surfaced by the install/withdraw confirm, not
-        by second-guessing this read."""
-        res = self._run([_ROUTE, _NUMERIC, RouteCommand.GET, _AF_INET, _DEFAULT])
-        if res is None or res.returncode != 0:
-            return None
-        for line in res.stdout.splitlines():
-            stripped = line.strip()
-            if stripped.startswith(_GATEWAY_FIELD):
-                return stripped[len(_GATEWAY_FIELD):].strip() or None
-        return None
-
-    def _route(self, command, dest, gateway=None):
-        """Issue a `/sbin/route` command (best effort). The caller confirms the
-        resulting FIB state, so a non-zero exit -- an idempotent no-op or a real
-        failure alike -- is only debug-logged and left for that confirm to judge,
-        rather than guessed from route(8)'s wording here."""
-        cmd = [_ROUTE, _NUMERIC, command, _AF_INET, dest]
-        if gateway is not None:
-            cmd.append(gateway)
-        res = self._run(cmd)
-        if res is not None and res.returncode != 0:
-            LOG.debug("route %s %s exit %d: %s", command, dest, res.returncode,
-                      (res.stderr or "").strip())
-
-    def _run(self, cmd):
-        """Run a `/sbin/route` argv, capturing output and bounded by a timeout;
-        return the CompletedProcess, or None if it could not be executed at all
-        (logged)."""
-        try:
-            return subprocess.run(cmd, capture_output=True, errors="replace",
-                                  timeout=_SUBPROC_TIMEOUT, check=False)
-        except (OSError, subprocess.SubprocessError) as e:
-            LOG.warning("route command failed to run (%s): %s", " ".join(cmd), e)
-            return None

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1055,17 +1055,23 @@ def test_backoff_jitter(lk):
 
 # ---- default-route ownership wiring (keeper <-> DefaultRouteReconciler) ----
 
-class _RecordingReconciler:
+class _RecordingReconciler:  # pylint: disable=too-few-public-methods
     """Stand-in for DefaultRouteReconciler that records reconcile() args, so the
-    keeper-side wiring can be asserted without a real route(8) probe."""
+    keeper-side 0/0 wiring can be asserted without a real route(8) probe."""
     def __init__(self, enabled=True):
         self.enabled = enabled
-        self.backup_egress_enabled = enabled
         self.calls = []
-        self.backup_egress_calls = []
 
     def reconcile(self, is_master, bound, gateway):
         self.calls.append((is_master, bound, gateway))
+
+
+class _RecordingBackup:  # pylint: disable=too-few-public-methods
+    """Stand-in for BackupEgressReconciler that records reconcile_backup_egress()
+    args, so the keeper-side backup-egress wiring can be asserted the same way."""
+    def __init__(self, enabled=True):
+        self.enabled = enabled
+        self.backup_egress_calls = []
 
     def reconcile_backup_egress(self, is_master):
         self.backup_egress_calls.append(is_master)
@@ -1085,13 +1091,15 @@ def test_default_route_mode_off_is_inert(lk):
 def test_default_route_forwards_role_bound_gateway(lk):
     k = _keeper(lk, vhid=254, default_route_mode="enforce")
     rec = _RecordingReconciler()
+    brec = _RecordingBackup()
     k._defroute = rec
+    k._backup = brec
     k._dhcp.binding.yiaddr = "100.64.4.7"
     k._dhcp.binding.lease_router = "100.64.4.1"
     k._reconcile_default_route(master=True)
     assert rec.calls == [(True, True, "100.64.4.1")]
     # the same tick also drives the backup-egress reconcile with the CARP role.
-    assert rec.backup_egress_calls == [True]
+    assert brec.backup_egress_calls == [True]
 
 
 def test_backup_egress_uses_real_role_on_unbound_path(lk, monkeypatch):
@@ -1100,11 +1108,13 @@ def test_backup_egress_uses_real_role_on_unbound_path(lk, monkeypatch):
     # backup route (which would black-hole/loop the master's own egress).
     k = _keeper(lk, vhid=254, default_route_mode="enforce")
     rec = _RecordingReconciler()
+    brec = _RecordingBackup()
     k._defroute = rec
+    k._backup = brec
     monkeypatch.setattr(k, "_probe_carp_master", lambda: True)     # actually CARP master
     k._reconcile_default_route(master=False, probe_for_backup=True)
     assert rec.calls[0][0] is False                                # 0/0 got the fiction
-    assert rec.backup_egress_calls == [True]                       # backup egress got the true role
+    assert brec.backup_egress_calls == [True]                      # backup egress got the true role
 
 
 def test_backup_egress_reconciled_before_blocking_acquire_when_unbound(lk, monkeypatch):
@@ -1113,10 +1123,12 @@ def test_backup_egress_reconciled_before_blocking_acquire_when_unbound(lk, monke
     # So the unbound path reconciles backup egress with the real CARP role ahead of acquire.
     k = _keeper(lk, vhid=254, default_route_mode="enforce")
     rec = _RecordingReconciler()
+    brec = _RecordingBackup()
     k._defroute = rec
+    k._backup = brec
     monkeypatch.setattr(k, "_probe_carp_master", lambda: True)     # promoted to master
     order = []
-    monkeypatch.setattr(rec, "reconcile_backup_egress", lambda m: order.append(("backup", m)))
+    monkeypatch.setattr(brec, "reconcile_backup_egress", lambda m: order.append(("backup", m)))
     monkeypatch.setattr(k, "_acquire_step", lambda: order.append(("acquire", None)))
     k._dhcp.binding.yiaddr = None                                 # unbound
     k._maintain_step()
@@ -1128,11 +1140,12 @@ def test_backup_egress_no_pre_acquire_probe_when_disabled(lk, monkeypatch):
     # with it off, the hot unbound loop adds no extra CARP probe or reconcile before acquire.
     k = _keeper(lk, vhid=254, default_route_mode="enforce")
     rec = _RecordingReconciler()
-    rec.backup_egress_enabled = False              # feature off
+    brec = _RecordingBackup(enabled=False)         # feature off
     k._defroute = rec
+    k._backup = brec
     order = []
     monkeypatch.setattr(k, "_probe_carp_master", lambda: (order.append("probe"), True)[1])
-    monkeypatch.setattr(rec, "reconcile_backup_egress", lambda m: order.append(("backup", m)))
+    monkeypatch.setattr(brec, "reconcile_backup_egress", lambda m: order.append(("backup", m)))
     monkeypatch.setattr(k, "_acquire_step", lambda: order.append("acquire"))
     k._dhcp.binding.yiaddr = None                  # unbound
     k._maintain_step()
@@ -1297,7 +1310,8 @@ def test_withdraw_unless_master_withdraws_when_not_master(lk, monkeypatch):
     from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
     fake = FakeRoute(initial=RGW)
     monkeypatch.setattr(lk.subprocess, "run", fake.run)
-    lk.DefaultRouteReconciler("enforce").withdraw_unless_master(lambda: False)
+    lk.withdraw_unless_master(lk.DefaultRouteReconciler("enforce"),
+                              lk.BackupEgressReconciler("enforce"), lambda: False)
     assert "delete" in fake.verbs and fake.gw is None
 
 
@@ -1308,7 +1322,8 @@ def test_withdraw_unless_master_skips_when_master(lk, monkeypatch):
     from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
     fake = FakeRoute(initial=RGW)
     monkeypatch.setattr(lk.subprocess, "run", fake.run)
-    lk.DefaultRouteReconciler("enforce").withdraw_unless_master(lambda: True)
+    lk.withdraw_unless_master(lk.DefaultRouteReconciler("enforce"),
+                              lk.BackupEgressReconciler("enforce"), lambda: True)
     assert fake.gw == RGW and not fake.calls   # kept, no route(8) call at all
 
 
@@ -1319,7 +1334,8 @@ def test_withdraw_unless_master_off_is_inert_without_probing(lk, monkeypatch):
     fake = FakeRoute(initial=RGW)
     monkeypatch.setattr(lk.subprocess, "run", fake.run)
     probed = []
-    lk.DefaultRouteReconciler("off").withdraw_unless_master(lambda: probed.append(1))
+    lk.withdraw_unless_master(lk.DefaultRouteReconciler("off"),
+                              lk.BackupEgressReconciler("off"), lambda: probed.append(1))
     assert fake.gw == RGW and not fake.calls and not probed
 
 
@@ -1365,7 +1381,7 @@ def test_carp_master_standalone_probes_via_ifconfig(lk, monkeypatch):
     assert lk.carp_master("lagg1", "199") is None
 
 
-def test_duplicate_start_guards_before_any_withdraw(lk, monkeypatch):
+def test_duplicate_start_guards_before_any_withdraw(monkeypatch):
     # Regression: the startup fail-stop withdraw must run AFTER the single-instance
     # guard, so a duplicate start (pidfile held by the live owner) exits "already
     # running" WITHOUT deleting the owner's live default. Assert the guard fires and
@@ -1378,8 +1394,8 @@ def test_duplicate_start_guards_before_any_withdraw(lk, monkeypatch):
         raise SystemExit(4)   # another live instance holds the pidfile
     monkeypatch.setattr(lease_keeper, "_setup_logging", lambda _logfile: None)
     monkeypatch.setattr(lease_keeper, "acquire_pidfile", fake_guard)
-    monkeypatch.setattr(lk.DefaultRouteReconciler, "withdraw_unless_master",
-                        lambda _self, _probe: calls.append("withdraw"))
+    monkeypatch.setattr(lease_keeper, "withdraw_unless_master",
+                        lambda _d, _b, _probe: calls.append("withdraw"))
     monkeypatch.setattr("sys.argv", [
         "lease_keeper", "--iface", "eth0", "--chaddr", CHADDR_STR, "--request",
         "100.64.4.7", "--vhid", "254", "--default-route-mode", "enforce"])

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -1,4 +1,5 @@
-"""Unit tests for leasekeeper.route.DefaultRouteReconciler.
+"""Unit tests for leasekeeper.route (DefaultRouteReconciler, BackupEgressReconciler
+and the module-level withdraw_unless_master).
 
 A FakeRoute stands in for /sbin/route (monkeypatched onto subprocess.run) and
 tracks a single default nexthop plus the verbs issued, so tests assert both the
@@ -113,12 +114,41 @@ class FakeRoute:
         return [c[2] for c in self.calls if c[0].endswith("route")]
 
 
+def _fake(lk, monkeypatch, initial=None, **fake_kw):
+    # Build a FakeRoute and route subprocess.run through it -- the setup shared by the
+    # three reconciler factories below.
+    fake = FakeRoute(initial, **fake_kw)
+    monkeypatch.setattr(lk.subprocess, "run", fake.run)
+    return fake
+
+
 def _rec(lk, monkeypatch, mode, initial=None, *,  # pylint: disable=too-many-arguments
          broken=(), lying=(), ifaces=None, netstat_fails=False, local_ips=(), **kw):
-    fake = FakeRoute(initial, broken=broken, lying=lying, ifaces=ifaces,
-                     netstat_fails=netstat_fails, local_ips=local_ips)
-    monkeypatch.setattr(lk.subprocess, "run", fake.run)
+    fake = _fake(lk, monkeypatch, initial, broken=broken, lying=lying, ifaces=ifaces,
+                 netstat_fails=netstat_fails, local_ips=local_ips)
     return lk.DefaultRouteReconciler(mode=mode, **kw), fake
+
+
+def _backup(lk, monkeypatch, mode, initial=None, *,  # pylint: disable=too-many-arguments
+            broken=(), lying=(), ifaces=None, netstat_fails=False, local_ips=(),
+            backup_egress=None):
+    # A BackupEgressReconciler over a FakeRoute (the backup-egress tests). A bare call
+    # (no backup_egress) yields the disabled reconciler for the inert-path tests.
+    fake = _fake(lk, monkeypatch, initial, broken=broken, lying=lying, ifaces=ifaces,
+                 netstat_fails=netstat_fails, local_ips=local_ips)
+    return lk.BackupEgressReconciler(mode, backup_egress=backup_egress or BackupEgressConfig()), fake
+
+
+def _pair(lk, monkeypatch, mode, initial=None, *,  # pylint: disable=too-many-arguments
+          broken=(), lying=(), ifaces=None, netstat_fails=False, local_ips=(),
+          backup_egress=None):
+    # Both reconcilers over one shared FakeRoute, for the cross-cutting paths
+    # (withdraw_unless_master and the 0/0-vs-backup independence check).
+    fake = _fake(lk, monkeypatch, initial, broken=broken, lying=lying, ifaces=ifaces,
+                 netstat_fails=netstat_fails, local_ips=local_ips)
+    default = lk.DefaultRouteReconciler(mode)
+    backup = lk.BackupEgressReconciler(mode, backup_egress=backup_egress or BackupEgressConfig())
+    return default, backup, fake
 
 
 # ---- off / observe never mutate ----
@@ -567,34 +597,34 @@ def _becfg(**kw):
 
 def test_backup_egress_disabled_is_inert(lk, monkeypatch):
     # no backup_egress config -> the reconcile is a no-op, issues nothing.
-    rec, fake = _rec(lk, monkeypatch, "enforce")
+    rec, fake = _backup(lk, monkeypatch, "enforce")
     rec.reconcile_backup_egress(False)
     assert not fake.calls
 
 
 def test_backup_egress_off_mode_inert(lk, monkeypatch):
     # off mode: even with the feature enabled, nothing runs.
-    rec, fake = _rec(lk, monkeypatch, "off", backup_egress=_becfg(gateway=BE_GW))
+    rec, fake = _backup(lk, monkeypatch, "off", backup_egress=_becfg(gateway=BE_GW))
     rec.reconcile_backup_egress(False)
     assert not fake.calls
 
 
 def test_backup_egress_installs_split_on_backup(lk, monkeypatch):
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
     rec.reconcile_backup_egress(False)
     assert fake.routes.get("0.0.0.0/1") == BE_GW
     assert fake.routes.get("128.0.0.0/1") == BE_GW
 
 
 def test_backup_egress_removed_on_master(lk, monkeypatch):
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
     fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = BE_GW
     rec.reconcile_backup_egress(True)
     assert "0.0.0.0/1" not in fake.routes and "128.0.0.0/1" not in fake.routes
 
 
 def test_backup_egress_role_swap(lk, monkeypatch):
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
     rec.reconcile_backup_egress(False)                 # backup -> installed
     assert fake.routes.get("0.0.0.0/1") == BE_GW
     rec.reconcile_backup_egress(True)                  # master -> removed
@@ -604,7 +634,7 @@ def test_backup_egress_role_swap(lk, monkeypatch):
 
 
 def test_backup_egress_idempotent_no_churn(lk, monkeypatch):
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
     rec.reconcile_backup_egress(False)
     n = len(fake.calls)
     rec.reconcile_backup_egress(False)                 # already correct
@@ -615,25 +645,25 @@ def test_backup_egress_idempotent_no_churn(lk, monkeypatch):
 
 
 def test_backup_egress_unknown_role_touches_nothing(lk, monkeypatch):
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
     rec.reconcile_backup_egress(None)
     assert not fake.calls
 
 
 def test_backup_egress_derive_peer_on_ptp(lk, monkeypatch):
     # gateway blank + a /30 interface -> derive the other host as the peer/master.
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(interface="sync0"),
-                     ifaces={"sync0": ("10.168.9.2", 30)})
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(interface="sync0"),
+                        ifaces={"sync0": ("10.168.9.2", 30)})
     rec.reconcile_backup_egress(False)
     assert fake.routes.get("0.0.0.0/1") == "10.168.9.1"
 
 
 def test_backup_egress_derive_non_ptp_inactive(lk, monkeypatch, caplog):
     # a /24 interface has no unique peer -> warn and install nothing.
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(interface="lan0"),
-                     ifaces={"lan0": ("10.168.1.3", 24)})
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(interface="lan0"),
+                        ifaces={"lan0": ("10.168.1.3", 24)})
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)
     assert "0.0.0.0/1" not in fake.routes
@@ -646,9 +676,9 @@ def test_backup_egress_derive_form_master_removes_own_route(lk, monkeypatch):
     # must still remove it on promotion -- else an empty ownership set on the derived-peer
     # master would treat its own leftover as foreign and loop egress. Regression for the
     # ownership-lost-on-restart bug: ownership is recorded on the confirmed-present path.
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(interface="sync0"),
-                     ifaces={"sync0": ("10.168.9.2", 30)})
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(interface="sync0"),
+                        ifaces={"sync0": ("10.168.9.2", 30)})
     fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = "10.168.9.1"   # inherited via the peer
     rec.reconcile_backup_egress(False)             # backup tick confirms the set is ours
     rec.reconcile_backup_egress(True)              # promote -> must remove our own /1
@@ -659,9 +689,9 @@ def test_backup_egress_derive_peer_change_uses_change(lk, monkeypatch):
     # Derive form: when the interface is re-addressed so the derived peer changes, the /1
     # is updated IN PLACE (CHANGE) to the new peer -- the only path that issues CHANGE
     # (its ownership of the old next hop comes from the session-installed gateway).
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(interface="sync0"),
-                     ifaces={"sync0": ("10.168.9.2", 30)})
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(interface="sync0"),
+                        ifaces={"sync0": ("10.168.9.2", 30)})
     rec.reconcile_backup_egress(False)             # install via peer .1
     assert fake.routes.get("0.0.0.0/1") == "10.168.9.1"
     fake.ifaces["sync0"] = ("10.168.9.5", 30)      # re-addressed -> peer becomes .6
@@ -675,9 +705,9 @@ def test_backup_egress_failed_change_keeps_old_ownership(lk, monkeypatch):
     # ownership of A must be preserved (not overwritten by the unconfirmed B) -- else
     # promotion would treat the still-present /1 at A as foreign and loop egress. (Ownership
     # is recorded only for gateways CONFIRMED to host our prefixes.)
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(interface="sync0"),
-                     ifaces={"sync0": ("10.168.9.2", 30)})
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(interface="sync0"),
+                        ifaces={"sync0": ("10.168.9.2", 30)})
     rec.reconcile_backup_egress(False)             # install via peer .1
     assert fake.routes.get("0.0.0.0/1") == "10.168.9.1"
     fake.ifaces["sync0"] = ("10.168.9.5", 30)      # peer becomes .6
@@ -693,9 +723,9 @@ def test_backup_egress_ownership_pruned_after_removal(lk, monkeypatch):
     # After removing our /1 on promotion, the old peer must NOT stay owned: if the peer then
     # changes and a route reappears via the OLD peer (e.g. a VPN takes that address), it must
     # be treated as foreign, not CHANGEd/overwritten (ownership is pruned on removal too).
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(interface="sync0"),
-                     ifaces={"sync0": ("10.168.9.2", 30)})
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(interface="sync0"),
+                        ifaces={"sync0": ("10.168.9.2", 30)})
     rec.reconcile_backup_egress(False)             # backup: install via peer .1 (own .1)
     rec.reconcile_backup_egress(True)              # master: remove -> ownership of .1 pruned
     fake.ifaces["sync0"] = ("10.168.9.5", 30)      # peer changes to .6
@@ -708,7 +738,7 @@ def test_backup_egress_ownership_pruned_after_removal(lk, monkeypatch):
 def test_backup_egress_collision_warns_once_and_rearms(lk, monkeypatch, caplog):
     # A persistent foreign /1 warns once (not per tick); once it clears and re-collides a
     # second warning fires -- rising-edge parity with the unresolved-gateway gate.
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
     fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = "10.9.9.9"   # both foreign
     with caplog.at_level("WARNING", logger="lease-keeper"):
         for _ in range(3):
@@ -725,7 +755,7 @@ def test_backup_egress_collision_warns_once_and_rearms(lk, monkeypatch, caplog):
 
 
 def test_backup_egress_observe_dry_run(lk, monkeypatch, caplog):
-    rec, fake = _rec(lk, monkeypatch, "observe", backup_egress=_becfg(gateway=BE_GW))
+    rec, fake = _backup(lk, monkeypatch, "observe", backup_egress=_becfg(gateway=BE_GW))
     with caplog.at_level("INFO", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)
     assert "0.0.0.0/1" not in fake.routes              # observe never writes
@@ -735,9 +765,9 @@ def test_backup_egress_observe_dry_run(lk, monkeypatch, caplog):
 def test_backup_egress_zero_prefix_dropped_under_enforce(lk, monkeypatch, caplog):
     # a 0.0.0.0/0 inside a specific-prefix list is dropped under enforce (enforce owns
     # the default); the other prefixes still install.
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
-                                          prefixes=("0.0.0.0/0", "192.0.2.0/24")))
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                             prefixes=("0.0.0.0/0", "192.0.2.0/24")))
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)
     assert "0.0.0.0/0" not in fake.routes and fake.routes.get("192.0.2.0/24") == BE_GW
@@ -745,9 +775,9 @@ def test_backup_egress_zero_prefix_dropped_under_enforce(lk, monkeypatch, caplog
 
 
 def test_backup_egress_specific_prefixes(lk, monkeypatch):
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
-                                          prefixes=("192.0.2.0/24",)))
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                             prefixes=("192.0.2.0/24",)))
     rec.reconcile_backup_egress(False)
     assert fake.routes.get("192.0.2.0/24") == BE_GW
     assert "0.0.0.0/1" not in fake.routes
@@ -756,9 +786,9 @@ def test_backup_egress_specific_prefixes(lk, monkeypatch):
 def test_backup_egress_host_prefix_round_trips(lk, monkeypatch):
     # a /32 host prefix prints without a CIDR suffix in netstat; it must still round-
     # trip so we do not re-add + false-ERROR every tick.
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
-                                          prefixes=("192.0.2.5/32",)))
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                             prefixes=("192.0.2.5/32",)))
     rec.reconcile_backup_egress(False)
     assert fake.routes.get("192.0.2.5/32") == BE_GW
     n = len(fake.calls)
@@ -770,7 +800,7 @@ def test_backup_egress_host_prefix_round_trips(lk, monkeypatch):
 def test_backup_egress_partial_install_adds_missing_only(lk, monkeypatch):
     # one /1 already ours, the other absent -> only the absent one is added (ADD); the
     # correct one is left untouched (no CHANGE).
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
     fake.routes["0.0.0.0/1"] = BE_GW                   # already ours
     rec.reconcile_backup_egress(False)
     assert fake.routes["0.0.0.0/1"] == BE_GW and fake.routes["128.0.0.0/1"] == BE_GW
@@ -780,7 +810,7 @@ def test_backup_egress_partial_install_adds_missing_only(lk, monkeypatch):
 def test_backup_egress_install_leaves_foreign_route(lk, monkeypatch, caplog):
     # 0.0.0.0/1 is also the full-tunnel-VPN pair: a /1 already via a FOREIGN next hop is
     # not overwritten (managed by ownership, not by prefix), and the collision is warned.
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
     fake.routes["0.0.0.0/1"] = "10.9.9.9"              # foreign next hop
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)
@@ -793,8 +823,8 @@ def test_backup_egress_install_leaves_foreign_route(lk, monkeypatch, caplog):
 def test_backup_egress_remove_on_unreadable_fib_skips(lk, monkeypatch, caplog):
     # unreadable table -> ownership cannot be verified, and the /1-split is also a VPN
     # full-tunnel pair, so skip rather than blind-delete an unrelated route (retry next tick).
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
-                     netstat_fails=True)
+    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
+                        netstat_fails=True)
     fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = BE_GW
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.reconcile_backup_egress(True)              # master, table unreadable
@@ -805,7 +835,7 @@ def test_backup_egress_remove_on_unreadable_fib_skips(lk, monkeypatch, caplog):
 def test_backup_egress_remove_leaves_foreign_route(lk, monkeypatch, caplog):
     # on the master, a /1 present via a FOREIGN next hop (a VPN's) is left untouched; only
     # our own next hop is removed.
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
     fake.routes["0.0.0.0/1"] = "10.9.9.9"              # foreign
     fake.routes["128.0.0.0/1"] = BE_GW                 # ours
     with caplog.at_level("WARNING", logger="lease-keeper"):
@@ -818,8 +848,8 @@ def test_backup_egress_remove_leaves_foreign_route(lk, monkeypatch, caplog):
 def test_backup_egress_install_defers_on_unreadable_fib(lk, monkeypatch, caplog):
     # unreadable table on the backup: do not blind-add (would miss a needed CHANGE);
     # defer to the next tick.
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
-                     netstat_fails=True)
+    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
+                        netstat_fails=True)
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)
     assert "0.0.0.0/1" not in fake.routes
@@ -829,8 +859,8 @@ def test_backup_egress_install_defers_on_unreadable_fib(lk, monkeypatch, caplog)
 def test_backup_egress_readback_failure_is_error(lk, monkeypatch, caplog):
     # a lying add (exits 0, FIB unchanged) must be caught by the read-back and reported
     # as failed, not success -- the mirror of the 0/0 lying-add test.
-    rec, _ = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
-                  lying=(RouteCommand.ADD,))
+    rec, _ = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
+                     lying=(RouteCommand.ADD,))
     with caplog.at_level("INFO", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)
     assert any(r.levelname == "ERROR" and "failed to route" in r.getMessage()
@@ -840,8 +870,8 @@ def test_backup_egress_readback_failure_is_error(lk, monkeypatch, caplog):
 
 def test_backup_egress_broken_removal_is_error(lk, monkeypatch, caplog):
     # a delete that does not take leaves a looping /1 on the master -> must surface ERROR.
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
-                     broken=(RouteCommand.DELETE,))
+    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
+                        broken=(RouteCommand.DELETE,))
     fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = BE_GW
     with caplog.at_level("ERROR", logger="lease-keeper"):
         rec.reconcile_backup_egress(True)
@@ -852,9 +882,9 @@ def test_backup_egress_broken_removal_is_error(lk, monkeypatch, caplog):
 def test_backup_egress_orphan_from_form_change_cleaned_on_master(lk, monkeypatch):
     # a prefixes-form daemon still removes an orphaned /1-split (left by a prior split
     # form) when it becomes master, via the union removal set.
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
-                                          prefixes=("192.0.2.0/24",)))
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                             prefixes=("192.0.2.0/24",)))
     fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = BE_GW   # orphan from the old form
     rec.reconcile_backup_egress(True)                  # master -> clean the union
     assert "0.0.0.0/1" not in fake.routes and "128.0.0.0/1" not in fake.routes
@@ -863,8 +893,8 @@ def test_backup_egress_orphan_from_form_change_cleaned_on_master(lk, monkeypatch
 def test_backup_egress_rejects_own_ip_gateway(lk, monkeypatch, caplog):
     # the config-sync trap: an explicit gateway equal to this node's own IP would route
     # via self -> reject (route get resolves it to lo0) and install nothing.
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(gateway="10.168.9.2"), local_ips=("10.168.9.2",))
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(gateway="10.168.9.2"), local_ips=("10.168.9.2",))
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)
     assert "0.0.0.0/1" not in fake.routes
@@ -873,16 +903,16 @@ def test_backup_egress_rejects_own_ip_gateway(lk, monkeypatch, caplog):
 
 def test_backup_egress_derive_peer_on_31(lk, monkeypatch):
     # RFC 3021 /31: both addresses are usable; the peer is the other one.
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(interface="sync0"),
-                     ifaces={"sync0": ("10.168.9.2", 31)})
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(interface="sync0"),
+                        ifaces={"sync0": ("10.168.9.2", 31)})
     rec.reconcile_backup_egress(False)
     assert fake.routes.get("0.0.0.0/1") == "10.168.9.3"
 
 
 def test_backup_egress_resolve_warns_once_not_per_tick(lk, monkeypatch, caplog):
     # an unresolvable gateway (no gateway, no interface) must warn once, not every tick.
-    rec, _ = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg())
+    rec, _ = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg())
     with caplog.at_level("WARNING", logger="lease-keeper"):
         for _ in range(3):
             rec.reconcile_backup_egress(False)
@@ -891,7 +921,7 @@ def test_backup_egress_resolve_warns_once_not_per_tick(lk, monkeypatch, caplog):
 
 
 def test_backup_egress_observe_would_remove(lk, monkeypatch, caplog):
-    rec, fake = _rec(lk, monkeypatch, "observe", backup_egress=_becfg(gateway=BE_GW))
+    rec, fake = _backup(lk, monkeypatch, "observe", backup_egress=_becfg(gateway=BE_GW))
     fake.routes["0.0.0.0/1"] = BE_GW
     with caplog.at_level("INFO", logger="lease-keeper"):
         rec.reconcile_backup_egress(True)
@@ -901,17 +931,17 @@ def test_backup_egress_observe_would_remove(lk, monkeypatch, caplog):
 
 def test_backup_egress_independent_of_default_reconcile(lk, monkeypatch):
     # the backup /1-split does not touch the 0/0 decision and vice versa.
-    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW,
-                     backup_egress=_becfg(gateway=BE_GW))
-    rec.reconcile(True, True, GW)                       # master: keeps 0/0 via WAN
-    rec.reconcile_backup_egress(True)                  # master: no /1-split
+    default, backup, fake = _pair(lk, monkeypatch, "enforce", initial=GW,
+                                  backup_egress=_becfg(gateway=BE_GW))
+    default.reconcile(True, True, GW)                   # master: keeps 0/0 via WAN
+    backup.reconcile_backup_egress(True)               # master: no /1-split
     assert fake.routes.get("default") == GW and "0.0.0.0/1" not in fake.routes
 
 
 def test_backup_egress_derive_unreadable_interface_inactive(lk, monkeypatch, caplog):
     # an interface with no readable IPv4 -> no peer, no install (warned).
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(interface="sync0"), ifaces={})
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(interface="sync0"), ifaces={})
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)
     assert "0.0.0.0/1" not in fake.routes
@@ -920,8 +950,8 @@ def test_backup_egress_derive_unreadable_interface_inactive(lk, monkeypatch, cap
 
 def test_backup_egress_resolve_rearms_warning(lk, monkeypatch, caplog):
     # unresolved -> warn; a successful resolve re-arms; unresolved again -> a 2nd warning.
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(interface="sync0"), ifaces={})
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(interface="sync0"), ifaces={})
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)                 # warn #1 (no inet)
         fake.ifaces["sync0"] = ("10.168.9.2", 30)          # now resolvable
@@ -933,9 +963,9 @@ def test_backup_egress_resolve_rearms_warning(lk, monkeypatch, caplog):
 
 
 def test_backup_egress_invalid_prefix_dropped(lk, monkeypatch, caplog):
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
-                                          prefixes=("not-an-ip", "192.0.2.0/24")))
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                             prefixes=("not-an-ip", "192.0.2.0/24")))
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)
     assert fake.routes.get("192.0.2.0/24") == BE_GW
@@ -945,9 +975,9 @@ def test_backup_egress_invalid_prefix_dropped(lk, monkeypatch, caplog):
 def test_backup_egress_ipv6_prefix_dropped(lk, monkeypatch, caplog):
     # ip_network() accepts IPv6, but the FIB ops are IPv4-only (netstat/route -inet); a v6
     # prefix must be dropped at validation rather than retried and failing every tick.
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
-                                          prefixes=("2001:db8::/32", "192.0.2.0/24")))
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                             prefixes=("2001:db8::/32", "192.0.2.0/24")))
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)
     assert fake.routes.get("192.0.2.0/24") == BE_GW
@@ -958,16 +988,16 @@ def test_backup_egress_ipv6_prefix_dropped(lk, monkeypatch, caplog):
 def test_backup_egress_boundary_leaves_unowned_split_when_disabled(lk, monkeypatch):
     # 0.0.0.0/1 + 128.0.0.0/1 is also the classic full-tunnel-VPN split; a keeper that
     # never managed backup egress must NOT delete a pre-existing /1 it does not own.
-    rec, fake = _rec(lk, monkeypatch, "enforce")            # mode enabled, feature OFF
+    default, backup, fake = _pair(lk, monkeypatch, "enforce")   # mode enabled, feature OFF
     fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = BE_GW
-    rec.withdraw_unless_master(lambda: False)
+    lk.withdraw_unless_master(default, backup, lambda: False)
     assert fake.routes.get("0.0.0.0/1") == BE_GW and fake.routes.get("128.0.0.0/1") == BE_GW
 
 
 def test_backup_egress_empty_prefixes_warns_and_installs_nothing(lk, monkeypatch, caplog):
-    rec, fake = _rec(lk, monkeypatch, "enforce",
-                     backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
-                                          prefixes=()))
+    rec, fake = _backup(lk, monkeypatch, "enforce",
+                        backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
+                                             prefixes=()))
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)
     assert not fake.routes                               # nothing routed
@@ -977,8 +1007,8 @@ def test_backup_egress_empty_prefixes_warns_and_installs_nothing(lk, monkeypatch
 def test_backup_egress_own_check_transient_defers_then_recovers(lk, monkeypatch, caplog):
     # a transient own-check (route get) failure must defer (not route via a maybe-own
     # gateway) AND not cache the indeterminate result -- it recovers once route get works.
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
-                     broken=(RouteCommand.GET,))
+    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
+                        broken=(RouteCommand.GET,))
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)               # own-check fails -> defer
     assert "0.0.0.0/1" not in fake.routes
@@ -991,18 +1021,18 @@ def test_backup_egress_own_check_transient_defers_then_recovers(lk, monkeypatch,
 def test_backup_egress_removed_at_shutdown(lk, monkeypatch):
     # the shutdown boundary (withdraw_unless_master) cleans the backup-egress set so no
     # orphan /1 loops if this node later becomes master with no reconciler running.
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
+    default, backup, fake = _pair(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
     fake.routes["0.0.0.0/1"] = fake.routes["128.0.0.0/1"] = BE_GW
-    rec.withdraw_unless_master(lambda: False)            # shutdown as backup
+    lk.withdraw_unless_master(default, backup, lambda: False)   # shutdown as backup
     assert "0.0.0.0/1" not in fake.routes and "128.0.0.0/1" not in fake.routes
 
 
 def test_backup_egress_shutdown_unconfirmed_removal_warns(lk, monkeypatch, caplog):
     # at shutdown there is no next tick to retry; an unconfirmable removal (unreadable
     # table) must warn loudly rather than silently leave a possible orphan /1 that loops.
-    rec, fake = _rec(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
-                     netstat_fails=True)
+    default, backup, fake = _pair(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW),
+                                  netstat_fails=True)
     fake.routes["0.0.0.0/1"] = BE_GW
     with caplog.at_level("WARNING", logger="lease-keeper"):
-        rec.withdraw_unless_master(lambda: False)
+        lk.withdraw_unless_master(default, backup, lambda: False)
     assert any("could not clean up at shutdown" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
Part of the code-quality pass: retire a self-imposed pylint pragma that flagged a class doing two jobs.

## What

`DefaultRouteReconciler` owned two independent decisions and carried a `# pylint: disable=too-many-instance-attributes` because it was two state machines in one object. This splits them into peers:

- `DefaultRouteReconciler` -- the IPv4 `0/0` default route only
- `BackupEgressReconciler` -- the optional backup-egress `/1`-split only

The two share nothing but the stateless `/sbin/route` exec helpers, which become module-level functions (`_run`, `_route`, `_at`). The one cross-cutting sequence -- clean the backup set BEFORE withdrawing `0/0` at a process boundary -- becomes a module-level `withdraw_unless_master(default_route, backup_egress, probe)`, the single tested home for that ordering, used by both the keeper shutdown and the startup fail-stop. The three backup rising-edge warn flags fold into a `_WarnGates` dataclass.

Both classes now hold exactly their own state (7 attributes each), so the `too-many-instance-attributes` pragma is removed. The keeper holds both reconcilers and coerces the mode once (so an unknown mode string warns once, not twice).

## Behaviour

Behaviour-preserving. Method bodies are unchanged apart from the helper-call renames (`self._run` -> `_run` etc.) and the warn-flag renames (`self._backup_*_warned` -> `self._warn.*`). A method-parity check against the pre-split version shows the only removed name is the `backup_egress_enabled` property, renamed to `enabled` on the new backup class. The two failover ordering invariants are preserved: backup egress is cleaned before the `0/0` withdraw at shutdown, and `0/0` reconciles before backup on the steady tick. Every fail-safe path (defer on an unreadable routing table, never touch a foreign next hop, surface a failed withdraw at ERROR) is retained.

## Tests

Adapted, not redesigned: new `_backup`/`_pair` factories share a `_fake` builder; the combined recording stub in the daemon tests splits into a 0/0 recorder and a backup recorder.

## Verification

- unit tests: 274 pass
- flake8 (max-line-length 120): clean
- pylint 10.00/10 with useless-suppression enabled
- pyright: 0 errors