### PR TITLE
Test quality: shared fakes, a DhcpReply builder, and parametrized tables

### DIFF
--- a/net/os-carp-vip-dhcp/tests/fakes.py
+++ b/net/os-carp-vip-dhcp/tests/fakes.py
@@ -1,0 +1,111 @@
+"""Shared test fakes for the route and daemon suites.
+
+FakeRoute is an in-memory stand-in for /sbin/route + /usr/bin/netstat +
+/sbin/ifconfig (monkeypatched onto subprocess.run) plus the WAN gateway
+constants both suites use. It lives here, not in test_route.py, so test_daemon.py
+can share it without importing another test module.
+"""
+# pylint: disable=missing-function-docstring
+import types
+
+from leasekeeper.route import RouteCommand
+
+GW = "185.41.66.1"
+GW2 = "185.41.66.9"
+CGNAT_GW = "100.64.4.1"   # the production case: a 100.64/10 single-IP CGNAT WAN
+
+
+class FakeRoute:
+    """In-memory stand-in for /sbin/route + /usr/bin/netstat + /sbin/ifconfig: a
+    dest->nexthop table (dest 'default' or a CIDR), a verb log, and per-interface
+    (addr, prefixlen) for backup-egress peer derivation. `gw` is the default's
+    nexthop, kept as a property so the default-route tests read it unchanged."""
+
+    def __init__(self, initial=None, *, broken=(), lying=(),  # pylint: disable=too-many-arguments
+                 ifaces=None, netstat_fails=False, local_ips=()):
+        self.routes = {}
+        if initial is not None:
+            self.routes["default"] = initial
+        self.calls = []
+        self.broken = set(broken)  # verbs that fail with a genuine (non-benign) error
+        self.lying = set(lying)    # verbs that exit 0 but do NOT mutate the FIB
+        self.ifaces = dict(ifaces or {})   # iface -> (addr, prefixlen)
+        self.netstat_fails = netstat_fails  # netstat -rn exits non-zero (unreadable table)
+        self.local_ips = set(local_ips)     # addresses a `route get` resolves to lo0 (own IPs)
+
+    @property
+    def gw(self):
+        return self.routes.get("default")
+
+    @gw.setter
+    def gw(self, value):
+        if value is None:
+            self.routes.pop("default", None)
+        else:
+            self.routes["default"] = value
+
+    def run(self, cmd, **_kwargs):  # capture_output / errors / timeout -- ignored
+        self.calls.append(list(cmd))
+        prog = cmd[0]
+        if prog.endswith("netstat"):
+            if self.netstat_fails:
+                return self._reply(1, "", "netstat: routing table unavailable")
+            return self._reply(0, self._netstat_body())
+        if prog.endswith("ifconfig"):
+            return self._ifconfig(cmd[1])
+        return self._route(cmd)
+
+    def _route(self, cmd):
+        # ["/sbin/route","-n",verb,"-inet",dest[,gw]]; single return to keep the verb
+        # branches readable without tripping too-many-return-statements.
+        verb, dest = cmd[2], cmd[4]
+        rc, out, err = 0, "", ""
+        if verb in self.broken:  # a real failure: stuck route / bad socket, not a no-op
+            rc, err = 1, "route: writing to routing socket: permission denied"
+        elif verb == RouteCommand.GET:
+            if dest in self.routes:                 # a known route dest (e.g. "default")
+                out = f"   gateway: {self.routes[dest]}\n   interface: vlan0\n"
+            elif dest == "default":                 # no default installed
+                rc, err = 1, "route: not in table"
+            else:                                   # host lookup (used by _gateway_is_own):
+                iface = "lo0" if dest in self.local_ips else "vlan0"  # own IP resolves to lo0
+                out = f"   gateway: {dest}\n   interface: {iface}\n"
+        elif verb == RouteCommand.ADD:
+            if self.routes.get(dest) is not None:  # FreeBSD: add fails when it exists
+                rc, err = 1, "route: writing to routing socket: File exists"
+            elif verb not in self.lying:  # a lying add exits 0 but leaves the FIB unchanged
+                self.routes[dest] = cmd[-1]
+        elif verb == RouteCommand.CHANGE:
+            if self.routes.get(dest) is None:  # change fails when no route exists
+                rc, err = 1, "route: change: not in table"
+            else:
+                self.routes[dest] = cmd[-1]  # on-link swaps in place; off-link is broken={CHANGE}
+        elif verb == RouteCommand.DELETE:
+            existed = self.routes.pop(dest, None) is not None
+            rc, err = (0, "") if existed else (1, "not in table")
+        return self._reply(rc, out, err)
+
+    def _netstat_body(self):
+        lines = ["Routing tables", "", "Internet:",
+                 "Destination        Gateway            Flags     Netif"]
+        for dest, gw in self.routes.items():
+            shown = dest[:-3] if dest.endswith("/32") else dest  # FreeBSD prints host routes bare
+            lines.append(f"{shown}        {gw}        UGS       vlan0")
+        return "\n".join(lines) + "\n"
+
+    def _ifconfig(self, iface):
+        info = self.ifaces.get(iface)
+        if info is None:
+            return self._reply(1, "", f"ifconfig: interface {iface} does not exist")
+        addr, prefixlen = info
+        mask = (0xffffffff << (32 - prefixlen)) & 0xffffffff if prefixlen else 0
+        body = f"{iface}: flags=8843<UP>\n\tinet {addr} netmask 0x{mask:08x} broadcast 0.0.0.0\n"
+        return self._reply(0, body)
+
+    @staticmethod
+    def _reply(rc, out, err=""):
+        return types.SimpleNamespace(returncode=rc, stdout=out, stderr=err)
+
+    @property
+    def verbs(self):
+        return [c[2] for c in self.calls if c[0].endswith("route")]

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -12,6 +12,7 @@ import types
 import pytest
 
 from conftest import CHADDR, CHADDR_STR
+from fakes import FakeRoute, GW as RGW
 
 
 def _woken(keeper):
@@ -74,14 +75,13 @@ def test_redora_max_bounded(lk):
 
 def test_dhcpreply_giaddr_defaults_none(lk):
     # the new giaddr field defaults, so shorter DhcpReply constructions stay valid.
-    rx = lk.DhcpReply(5, "1.2.3.4", "1.2.3.1", 1800, None, None, None)
+    rx = _reply(lk, 5, "1.2.3.4", server="1.2.3.1")
     assert rx.giaddr is None
 
 
 def test_reboot_request_shape_and_bind(lk):
     c = _client(lk)
-    c._wait_for_dhcp_reply = lambda want, timeout, *a: lk.DhcpReply(
-        lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, None)
+    c._wait_for_dhcp_reply = lambda want, timeout, *a: _reply(lk, lk.ACK, "100.64.4.7")
     assert c.reboot("100.64.4.7") is True
     assert c.binding.yiaddr == "100.64.4.7" and c.binding.server == "100.64.4.1"
     mtype, extra, ciaddr = c.sent[0]
@@ -92,8 +92,7 @@ def test_reboot_request_shape_and_bind(lk):
 
 def test_reboot_nak_falls_through(lk):
     c = _client(lk)
-    c._wait_for_dhcp_reply = lambda want, timeout, *a: lk.DhcpReply(
-        lk.NAK, None, None, None, None, None, None)
+    c._wait_for_dhcp_reply = lambda want, timeout, *a: _reply(lk, lk.NAK, server=None, lease=None)
     assert c.reboot("100.64.4.7") is False
     assert c.binding.yiaddr is None
 
@@ -119,9 +118,9 @@ def test_absorb_reply_floors_lease(lk):
     # A tiny (or spoofed) opt-51 must not drive a tight renew spin: the accepted
     # lease is floored at MIN_LEASE, while a normal lease passes through.
     c = _client(lk)
-    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1, None, None, None))
+    c.adopt(_reply(lk, lk.ACK, "100.64.4.7", lease=1))
     assert c.binding.lease_secs == lk.MIN_LEASE
-    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 3600, None, None, None))
+    c.adopt(_reply(lk, lk.ACK, "100.64.4.7", lease=3600))
     assert c.binding.lease_secs == 3600
 
 
@@ -137,13 +136,12 @@ def test_msg_text_scrubs_control_chars(lk):
 def test_adopt_binds_and_refreshes_server(lk):
     c = _client(lk)
     c.binding.server = "100.64.4.1"   # from the OFFER
-    ack = lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.2", 1800, None, None,
-                       "100.64.4.1", None, "255.255.255.0")
+    ack = _reply(lk, lk.ACK, "100.64.4.7", server="100.64.4.2", router="100.64.4.1", mask="255.255.255.0")
     c.adopt(ack)
     assert c.binding.yiaddr == "100.64.4.7"
     assert c.binding.server == "100.64.4.2"          # ACK's server-id wins...
     assert c.binding.lease_secs == 1800 and c.binding.mask_bits == 24
-    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.8", None, 900, None, None, None))
+    c.adopt(_reply(lk, lk.ACK, "100.64.4.8", server=None, lease=900))
     assert c.binding.server == "100.64.4.2"          # ...and is kept when the ACK has none
 
 
@@ -163,20 +161,18 @@ def test_renew_requires_binding(lk):
 
 def test_feed_wakes_the_waiting_sequence(lk):
     c = _client(lk)
-    rx = lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, None)
+    rx = _reply(lk, lk.ACK, "100.64.4.7")
     c.feed(rx)
     assert c._rx is rx
     assert c._ev.is_set()        # the waiting _wait_for_dhcp_reply returns at once
 
 
 def test_fmt_reply_readable(lk):
-    off = lk.DhcpReply(2, "100.64.4.74", "100.64.4.1", 120, 60, 105, "100.64.4.1",
-                       None, "255.255.255.0", None)
+    off = _reply(lk, 2, "100.64.4.74", lease=120, t1=60, t2=105, router="100.64.4.1", mask="255.255.255.0")
     s = lk._fmt_reply(off)
     assert "OFFER" in s and "yiaddr=100.64.4.74" in s and "server=100.64.4.1" in s
     assert "giaddr=none" in s          # directly attached: no relay in path
-    nak = lk.DhcpReply(6, None, "100.64.4.1", None, None, None, None,
-                       b"no free leases", None, "100.64.4.9")
+    nak = _reply(lk, 6, lease=None, message=b"no free leases", giaddr="100.64.4.9")
     s2 = lk._fmt_reply(nak)
     assert "NAK" in s2 and "giaddr=100.64.4.9" in s2 and "no free leases" in s2
 
@@ -313,8 +309,18 @@ def _follow_keeper(lk, tmp_path):
     return keeper
 
 
+def _reply(lk, mtype, yiaddr: "str | None" = None, *,  # pylint: disable=too-many-arguments
+           server: "str | None" = "100.64.4.1", lease: "int | None" = 1800,
+           t1: "int | None" = None, t2: "int | None" = None, router: "str | None" = None,
+           message: "bytes | str | None" = None, mask: "str | None" = None, giaddr: "str | None" = None):
+    # Keyword builder for DhcpReply so call sites name the field they set instead
+    # of padding positional Nones (the NamedTuple order is mtype, yiaddr, server,
+    # lease, t1, t2, router, message, subnet_mask, giaddr).
+    return lk.DhcpReply(mtype, yiaddr, server, lease, t1, t2, router, message, mask, giaddr)
+
+
 def _ack(lk, yiaddr, server="100.64.4.1"):
-    return lk.DhcpReply(5, yiaddr, server, 1800, None, None, None)
+    return _reply(lk, lk.ACK, yiaddr, server=server)
 
 
 def _dhcp_frame(lk, xid, options, *, yiaddr="100.64.4.7",  # pylint: disable=too-many-arguments
@@ -355,7 +361,7 @@ def test_on_dhcp_reply_captures_option56_message(lk):
 ])
 def test_dhcpnak_logs_reason(lk, caplog, message, expect):
     keeper = _keeper(lk)
-    keeper._dhcp._rx = lk.DhcpReply(lk.NAK, None, "100.64.4.1", None, None, None, None, message)
+    keeper._dhcp._rx = _reply(lk, lk.NAK, lease=None, message=message)
     with caplog.at_level("WARNING", logger="lease-keeper"):
         assert keeper._dhcp._wait_for_dhcp_reply(lk.ACK, 0.2, "DORA").mtype == lk.NAK
     assert any(expect in r.getMessage() for r in caplog.records)
@@ -427,25 +433,19 @@ def test_observed_peer_ack_records_change_and_wakes(lk, tmp_path):
     assert _woken(keeper)       # ...and the maintain-loop sleep is woken at once
 
 
-def test_ignored_observation_does_not_wake(lk, tmp_path):
+@pytest.mark.parametrize("frame_factory", [
+    lambda lk: _peer_ack(lk, "100.64.4.7"),                                       # same address -> no change
+    lambda lk: _peer_ack(lk, "100.64.4.60", chaddr=b"\xaa\xbb\xcc\xdd\xee\xff"),  # not our chaddr
+    lambda lk: _dhcp_frame(lk, 0x22222222,
+                           [("message-type", lk.OFFER), ("server_id", "100.64.4.1"), "end"],
+                           yiaddr="100.64.4.60"),                                 # not an ACK
+], ids=["same-address", "wrong-chaddr", "non-ack"])
+def test_observed_peer_ack_ignored(lk, tmp_path, frame_factory):
+    # A peer ACK carrying no follow-worthy change (same address / not our chaddr / not an
+    # ACK) is dropped: no observation recorded and the maintain loop is not woken.
     keeper = _observe_keeper(lk, tmp_path)
-    keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.7"))     # same address -> no change
-    assert keeper._follow._observed is None
-    assert not _woken(keeper)
-
-
-def test_observed_ignores_wrong_chaddr(lk, tmp_path):
-    keeper = _observe_keeper(lk, tmp_path)
-    keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60", chaddr=b"\xaa\xbb\xcc\xdd\xee\xff"))
-    assert keeper._follow._observed is None
-
-
-def test_observed_ignores_non_ack(lk, tmp_path):
-    keeper = _observe_keeper(lk, tmp_path)
-    keeper._on_dhcp_reply(_dhcp_frame(lk, 0x22222222,
-                                      [("message-type", lk.OFFER), ("server_id", "100.64.4.1"), "end"],
-                                      yiaddr="100.64.4.60"))
-    assert keeper._follow._observed is None
+    keeper._on_dhcp_reply(frame_factory(lk))
+    assert keeper._follow._observed is None and not _woken(keeper)
 
 
 def test_observed_ignored_when_not_follow(lk):
@@ -927,7 +927,7 @@ def test_enum_args_accept_unknown_value_without_argparse_rejection():
 # ---- follow across a changed gateway (cross-subnet renumber) ----
 
 def _ack_gw(lk, yiaddr, router, server="100.64.4.1", mask=None):
-    return lk.DhcpReply(5, yiaddr, server, 1800, None, None, router, None, mask)
+    return _reply(lk, lk.ACK, yiaddr, server=server, router=router, mask=mask)
 
 
 def test_follow_across_subnet_with_mask(lk, tmp_path, caplog):
@@ -1017,8 +1017,7 @@ def test_absorb_reply_captures_gw_and_mask(lk):
     # The PRL asks for opt 3 (router) + opt 1 (mask); _absorb_reply keeps both so
     # the BOUND log can surface them (and follow mode can use the mask).
     c = _client(lk)
-    rx = lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None,
-                      "100.64.4.1", None, "255.255.255.0")
+    rx = _reply(lk, lk.ACK, "100.64.4.7", router="100.64.4.1", mask="255.255.255.0")
     c._absorb_reply(rx, lk.DEFAULT_LEASE)
     assert c.binding.router == "100.64.4.1"
     assert c.binding.mask_bits == 24
@@ -1029,8 +1028,7 @@ def test_renew_omits_server_id_and_requested_addr(lk):
     # requested_addr, and ciaddr MUST be the client's address.
     c = _client(lk)
     c.binding.server, c.binding.yiaddr, c.binding.lease_secs = "100.64.4.1", "100.64.4.7", 1800
-    c._wait_for_dhcp_reply = lambda want, timeout, *a: lk.DhcpReply(
-        lk.ACK, c.binding.yiaddr, c.binding.server, 1800, None, None, None)
+    c._wait_for_dhcp_reply = lambda want, timeout, *a: _reply(lk, lk.ACK, c.binding.yiaddr, server=c.binding.server)
     assert c.renew() is True   # RENEW (T1)
     assert c.renew(rebind=True) is True  # REBIND (T2)
     assert c.sent, "renew sent nothing"
@@ -1272,7 +1270,6 @@ def _run_to_shutdown(lk, monkeypatch, *, master, initial):
     # Run a stopped enforcing keeper straight to its shutdown path (real reconciler
     # over a FakeRoute) with the CARP role stubbed; return the FakeRoute so the caller
     # asserts whether the shutdown withdrew the default.
-    from test_route import FakeRoute  # noqa: E402  # pylint: disable=import-outside-toplevel
     monkeypatch.setattr(lk.time, "sleep", lambda *_a, **_k: None)
     fake = FakeRoute(initial=initial)
     monkeypatch.setattr(lk.subprocess, "run", fake.run)
@@ -1285,58 +1282,41 @@ def _run_to_shutdown(lk, monkeypatch, *, master, initial):
     return fake
 
 
-def test_shutdown_withdraws_default_when_not_master(lk, monkeypatch):
-    from test_route import GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
-    # Stopping a NON-master keeper relinquishes its default so it is not left in the
-    # FIB (and redistributed by FRR) with nothing managing it.
-    fake = _run_to_shutdown(lk, monkeypatch, master=False, initial=RGW)
-    assert "delete" in fake.verbs and fake.gw is None
+@pytest.mark.parametrize("master, expect_delete", [
+    (False, True),   # non-master relinquishes its default (not left in the FIB for FRR)
+    (True, False),   # master keeps it across a restart (else redistribute-kernel flaps 0/0)
+])
+def test_shutdown_withdraws_default_only_when_not_master(lk, monkeypatch, master, expect_delete):
+    fake = _run_to_shutdown(lk, monkeypatch, master=master, initial=RGW)
+    if expect_delete:
+        assert "delete" in fake.verbs and fake.gw is None
+    else:
+        assert fake.gw == RGW and "delete" not in fake.verbs
 
 
-def test_shutdown_keeps_default_when_master(lk, monkeypatch):
-    from test_route import GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
-    # A master keeps its default across a keeper restart (config change / upgrade):
-    # shutdown must NOT withdraw, else redistribute-kernel flaps 0/0 and the WAN blips
-    # until the restarted keeper re-adopts the lease.
-    fake = _run_to_shutdown(lk, monkeypatch, master=True, initial=RGW)
-    assert fake.gw == RGW and "delete" not in fake.verbs
-
-
-def test_withdraw_unless_master_withdraws_when_not_master(lk, monkeypatch):
-    # The fail-stop lives on the reconciler (no Keeper, no capture backend), so main()
-    # runs it BEFORE the backend preflight / arg checks -- any of which can exit before
-    # Keeper.run(). A crashed non-master predecessor's default is withdrawn here even
-    # when the backend can no longer load.
-    from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
-    fake = FakeRoute(initial=RGW)
-    monkeypatch.setattr(lk.subprocess, "run", fake.run)
-    lk.withdraw_unless_master(lk.DefaultRouteReconciler("enforce"),
-                              lk.BackupEgressReconciler("enforce"), lambda: False)
-    assert "delete" in fake.verbs and fake.gw is None
-
-
-def test_withdraw_unless_master_skips_when_master(lk, monkeypatch):
-    # A CARP master owns the default and re-adopts it in the maintain loop, so the
-    # fail-stop must NOT withdraw -- otherwise a keeper restart tears the master's
-    # default down before it is re-installed.
-    from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
-    fake = FakeRoute(initial=RGW)
-    monkeypatch.setattr(lk.subprocess, "run", fake.run)
-    lk.withdraw_unless_master(lk.DefaultRouteReconciler("enforce"),
-                              lk.BackupEgressReconciler("enforce"), lambda: True)
-    assert fake.gw == RGW and not fake.calls   # kept, no route(8) call at all
-
-
-def test_withdraw_unless_master_off_is_inert_without_probing(lk, monkeypatch):
-    # off never touches the FIB AND never even spawns the CARP probe (the reconciler
-    # short-circuits on `enabled` before calling `probe`).
-    from test_route import FakeRoute, GW as RGW  # noqa: E402  # pylint: disable=import-outside-toplevel
+@pytest.mark.parametrize("mode, probe_return, expect_delete", [
+    ("enforce", False, True),   # non-master: withdraw a crashed predecessor's default
+    ("enforce", True, False),   # master: keep it (probe ran, no FIB write)
+    ("off", None, False),       # off: inert, and the probe is never even spawned
+])
+def test_withdraw_unless_master_fail_stop(lk, monkeypatch, mode, probe_return, expect_delete):
+    # The startup fail-stop (module withdraw_unless_master, no Keeper/capture): a
+    # non-master withdraws, a master keeps, and off short-circuits on `enabled` before
+    # touching the FIB or even calling the CARP probe.
     fake = FakeRoute(initial=RGW)
     monkeypatch.setattr(lk.subprocess, "run", fake.run)
     probed = []
-    lk.withdraw_unless_master(lk.DefaultRouteReconciler("off"),
-                              lk.BackupEgressReconciler("off"), lambda: probed.append(1))
-    assert fake.gw == RGW and not fake.calls and not probed
+
+    def probe():
+        probed.append(1)
+        return probe_return
+    lk.withdraw_unless_master(lk.DefaultRouteReconciler(mode),
+                              lk.BackupEgressReconciler(mode), probe)
+    assert bool(probed) is (mode != "off")   # off never spawns the probe
+    if expect_delete:
+        assert "delete" in fake.verbs and fake.gw is None
+    else:
+        assert fake.gw == RGW and not fake.calls
 
 
 def test_split_prefixes_accepts_commas_and_whitespace():
@@ -1409,9 +1389,9 @@ def test_lease_router_reset_on_fresh_bind_without_option3(lk):
     # (the route reconciler installs from lease_router; a stale value would route
     # the new lease via the old, possibly wrong-subnet, gateway).
     c = _client(lk)
-    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1"))
+    c.adopt(_reply(lk, lk.ACK, "100.64.4.7", router="100.64.4.1"))
     assert c.binding.lease_router == "100.64.4.1"
-    c.adopt(lk.DhcpReply(lk.ACK, "100.64.5.7", "100.64.5.1", 1800, None, None, None))  # new addr, no opt 3
+    c.adopt(_reply(lk, lk.ACK, "100.64.5.7", server="100.64.5.1"))  # new addr, no opt 3
     assert c.binding.lease_router is None      # reset -> reconciler withdraws, does not install stale
     assert c.binding.router == "100.64.4.1"    # the sticky nudge/log hint is untouched
 
@@ -1419,8 +1399,8 @@ def test_lease_router_reset_on_fresh_bind_without_option3(lk):
 def test_lease_router_kept_across_option3_less_renew(lk):
     # A RENEW of the SAME lease that omits option 3 keeps the current gateway.
     c = _client(lk)
-    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1"))
-    c._absorb_reply(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, None), 1800)
+    c.adopt(_reply(lk, lk.ACK, "100.64.4.7", router="100.64.4.1"))
+    c._absorb_reply(_reply(lk, lk.ACK, "100.64.4.7"), 1800)
     assert c.binding.lease_router == "100.64.4.1"
 
 
@@ -1431,8 +1411,8 @@ def test_failed_dora_clears_unconfirmed_offer(lk):
     c = _client(lk)
     c._ensure_sniffer = lambda: None
     replies = iter([
-        lk.DhcpReply(lk.OFFER, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1"),  # OFFER
-        lk.DhcpReply(lk.NAK, None, "100.64.4.1", None, None, None, None),                     # REQUEST -> NAK
+        _reply(lk, lk.OFFER, "100.64.4.7", router="100.64.4.1"),  # OFFER
+        _reply(lk, lk.NAK, lease=None),                     # REQUEST -> NAK
     ])
     c._wait_for_dhcp_reply = lambda want, timeout, *a: next(replies, None)
     assert c.dora("100.64.4.7") is False
@@ -1452,7 +1432,7 @@ def test_failed_dora_after_offer_timeout_clears_yiaddr(lk, monkeypatch):
         calls["n"] += 1
         # the first wait is the DISCOVER's OFFER; every REQUEST wait after it times out
         if calls["n"] == 1:
-            return lk.DhcpReply(lk.OFFER, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1")
+            return _reply(lk, lk.OFFER, "100.64.4.7", router="100.64.4.1")
         return None
     c._wait_for_dhcp_reply = reply
     assert c.dora("100.64.4.7") is False
@@ -1465,11 +1445,10 @@ def test_renew_keeps_lease_router_when_ack_omits_option3(lk):
     # would clear lease_router mid-lease -> reconcile sees gateway None -> withdraws
     # the default under a still-healthy master. Drives renew(), not _absorb_reply.
     c = _client(lk)
-    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1"))
+    c.adopt(_reply(lk, lk.ACK, "100.64.4.7", router="100.64.4.1"))
     assert c.binding.lease_router == "100.64.4.1"
     c._ensure_sniffer = lambda: None
-    c._wait_for_dhcp_reply = lambda _want, _timeout, *a: lk.DhcpReply(
-        lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, None)   # same lease, no opt 3
+    c._wait_for_dhcp_reply = lambda _want, _timeout, *a: _reply(lk, lk.ACK, "100.64.4.7")   # same lease, no opt 3
     assert c.renew() is True
     assert c.binding.lease_router == "100.64.4.1"
 
@@ -1506,10 +1485,9 @@ def test_renew_nak_forgets_binding(lk):
     # forgotten so the caller withdraws the default and re-acquires, rather than
     # REBINDing an address the server refused. Hints stay for the re-DORA (expire()).
     c = _client(lk)
-    c.adopt(lk.DhcpReply(lk.ACK, "100.64.4.7", "100.64.4.1", 1800, None, None, "100.64.4.1"))
+    c.adopt(_reply(lk, lk.ACK, "100.64.4.7", router="100.64.4.1"))
     c._ensure_sniffer = lambda: None
-    c._wait_for_dhcp_reply = lambda _want, _timeout, *a: lk.DhcpReply(
-        lk.NAK, None, "100.64.4.1", None, None, None, None)
+    c._wait_for_dhcp_reply = lambda _want, _timeout, *a: _reply(lk, lk.NAK, lease=None)
     assert c.renew() is False
     assert c.binding.yiaddr is None          # forgotten -> reconcile withdraws, next step re-acquires
     assert c.binding.server == "100.64.4.1"  # hint kept

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -6,112 +6,13 @@ tracks a single default nexthop plus the verbs issued, so tests assert both the
 resulting FIB and that idempotent / observe / off paths issue no mutation.
 
 Tests reach into private state by design; comments over per-test docstrings."""
-# pylint: disable=protected-access, missing-function-docstring, too-many-lines
+# pylint: disable=protected-access, missing-function-docstring
 import types
 
 import pytest
 
 from leasekeeper.route import BackupEgressConfig, BackupEgressForm, RouteCommand
-
-GW = "185.41.66.1"
-GW2 = "185.41.66.9"
-CGNAT_GW = "100.64.4.1"   # the production case: a 100.64/10 single-IP CGNAT WAN
-
-
-class FakeRoute:
-    """In-memory stand-in for /sbin/route + /usr/bin/netstat + /sbin/ifconfig: a
-    dest->nexthop table (dest 'default' or a CIDR), a verb log, and per-interface
-    (addr, prefixlen) for backup-egress peer derivation. `gw` is the default's
-    nexthop, kept as a property so the default-route tests read it unchanged."""
-
-    def __init__(self, initial=None, *, broken=(), lying=(),  # pylint: disable=too-many-arguments
-                 ifaces=None, netstat_fails=False, local_ips=()):
-        self.routes = {}
-        if initial is not None:
-            self.routes["default"] = initial
-        self.calls = []
-        self.broken = set(broken)  # verbs that fail with a genuine (non-benign) error
-        self.lying = set(lying)    # verbs that exit 0 but do NOT mutate the FIB
-        self.ifaces = dict(ifaces or {})   # iface -> (addr, prefixlen)
-        self.netstat_fails = netstat_fails  # netstat -rn exits non-zero (unreadable table)
-        self.local_ips = set(local_ips)     # addresses a `route get` resolves to lo0 (own IPs)
-
-    @property
-    def gw(self):
-        return self.routes.get("default")
-
-    @gw.setter
-    def gw(self, value):
-        if value is None:
-            self.routes.pop("default", None)
-        else:
-            self.routes["default"] = value
-
-    def run(self, cmd, **_kwargs):  # capture_output / errors / timeout -- ignored
-        self.calls.append(list(cmd))
-        prog = cmd[0]
-        if prog.endswith("netstat"):
-            if self.netstat_fails:
-                return self._reply(1, "", "netstat: routing table unavailable")
-            return self._reply(0, self._netstat_body())
-        if prog.endswith("ifconfig"):
-            return self._ifconfig(cmd[1])
-        return self._route(cmd)
-
-    def _route(self, cmd):
-        # ["/sbin/route","-n",verb,"-inet",dest[,gw]]; single return to keep the verb
-        # branches readable without tripping too-many-return-statements.
-        verb, dest = cmd[2], cmd[4]
-        rc, out, err = 0, "", ""
-        if verb in self.broken:  # a real failure: stuck route / bad socket, not a no-op
-            rc, err = 1, "route: writing to routing socket: permission denied"
-        elif verb == RouteCommand.GET:
-            if dest in self.routes:                 # a known route dest (e.g. "default")
-                out = f"   gateway: {self.routes[dest]}\n   interface: vlan0\n"
-            elif dest == "default":                 # no default installed
-                rc, err = 1, "route: not in table"
-            else:                                   # host lookup (used by _gateway_is_own):
-                iface = "lo0" if dest in self.local_ips else "vlan0"  # own IP resolves to lo0
-                out = f"   gateway: {dest}\n   interface: {iface}\n"
-        elif verb == RouteCommand.ADD:
-            if self.routes.get(dest) is not None:  # FreeBSD: add fails when it exists
-                rc, err = 1, "route: writing to routing socket: File exists"
-            elif verb not in self.lying:  # a lying add exits 0 but leaves the FIB unchanged
-                self.routes[dest] = cmd[-1]
-        elif verb == RouteCommand.CHANGE:
-            if self.routes.get(dest) is None:  # change fails when no route exists
-                rc, err = 1, "route: change: not in table"
-            else:
-                self.routes[dest] = cmd[-1]  # on-link swaps in place; off-link is broken={CHANGE}
-        elif verb == RouteCommand.DELETE:
-            existed = self.routes.pop(dest, None) is not None
-            rc, err = (0, "") if existed else (1, "not in table")
-        return self._reply(rc, out, err)
-
-    def _netstat_body(self):
-        lines = ["Routing tables", "", "Internet:",
-                 "Destination        Gateway            Flags     Netif"]
-        for dest, gw in self.routes.items():
-            shown = dest[:-3] if dest.endswith("/32") else dest  # FreeBSD prints host routes bare
-            lines.append(f"{shown}        {gw}        UGS       vlan0")
-        return "\n".join(lines) + "\n"
-
-    def _ifconfig(self, iface):
-        info = self.ifaces.get(iface)
-        if info is None:
-            return self._reply(1, "", f"ifconfig: interface {iface} does not exist")
-        addr, prefixlen = info
-        mask = (0xffffffff << (32 - prefixlen)) & 0xffffffff if prefixlen else 0
-        body = f"{iface}: flags=8843<UP>\n\tinet {addr} netmask 0x{mask:08x} broadcast 0.0.0.0\n"
-        return self._reply(0, body)
-
-    @staticmethod
-    def _reply(rc, out, err=""):
-        return types.SimpleNamespace(returncode=rc, stdout=out, stderr=err)
-
-    @property
-    def verbs(self):
-        return [c[2] for c in self.calls if c[0].endswith("route")]
+from fakes import CGNAT_GW, GW, GW2, FakeRoute
 
 
 def _fake(lk, monkeypatch, initial=None, **fake_kw):
@@ -244,13 +145,20 @@ def test_enforce_backup_absent_is_noop(lk, monkeypatch):
     assert fake.verbs == [RouteCommand.GET]  # nothing to withdraw
 
 
-def test_master_without_lease_withdraws_despite_sticky_gateway(lk, monkeypatch):
-    # bound=False even though a (sticky) gateway is still known: must not keep
-    # the default -- this is the MasterNoLease fail-stop.
+@pytest.mark.parametrize("is_master, bound, gateway", [
+    (True, False, GW),        # master but no lease -- a sticky gateway lingers (MasterNoLease fail-stop)
+    (True, True, "0.0.0.0"),  # master+bound but an unusable gateway it cannot honour
+    (True, True, None),       # bound but no router option -- _sane_ipv4(None) must be handled, not raise
+    (None, False, None),      # unreadable role, unbound -- withdraw now, not after the strike tolerance
+    (None, True, "0.0.0.0"),  # unreadable role, unusable gateway -- same immediate withdraw
+])
+def test_reconcile_withdraws_existing_default(lk, monkeypatch, is_master, bound, gateway):
+    # Every one of these states cannot back a default, so an existing one is withdrawn.
+    # The two unreadable-role rows withdraw immediately (the strike tolerance is reserved
+    # for a bound node that might still legitimately be master).
     rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW)
-    rec.reconcile(True, False, GW)
-    assert fake.gw is None
-    assert RouteCommand.DELETE in fake.verbs
+    rec.reconcile(is_master, bound, gateway)
+    assert fake.gw is None and RouteCommand.DELETE in fake.verbs
 
 
 # ---- unreadable role: fail-safe install, fail-closed withdraw ----
@@ -272,24 +180,6 @@ def test_unreadable_role_withdraws_after_strike_limit(lk, monkeypatch):
     rec.reconcile(None, True, GW)     # third strike -> fail closed
     assert fake.gw is None
     assert RouteCommand.DELETE in fake.verbs
-
-
-def test_unreadable_role_but_unbound_withdraws_immediately(lk, monkeypatch):
-    # Role unreadable AND no lease held: nothing to be master of, so withdraw at
-    # once instead of holding the default through the strike tolerance (which is
-    # reserved for a bound node that might still legitimately be master).
-    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, unreadable_role_strikes=3)
-    rec.reconcile(None, False, None)   # probe failed, but we hold no lease
-    assert fake.gw is None             # withdrawn on the first call, not after 3 strikes
-    assert RouteCommand.DELETE in fake.verbs
-
-
-def test_unreadable_role_with_unusable_gateway_withdraws_immediately(lk, monkeypatch):
-    # Same: an unusable (0.0.0.0) gateway is not a lease to be master of, so an
-    # unreadable role does not earn the strike tolerance -- withdraw now.
-    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW, unreadable_role_strikes=3)
-    rec.reconcile(None, True, "0.0.0.0")
-    assert fake.gw is None and RouteCommand.DELETE in fake.verbs
 
 
 def test_definite_role_resets_strikes(lk, monkeypatch):
@@ -405,24 +295,21 @@ def test_mode_is_read_only(lk, monkeypatch):
         rec.mode = lk.DefaultRouteMode.ENFORCE  # set-once, no setter
 
 
-def test_default_route_mode_coerce(lk, caplog):
-    # Valid values (string or member) pass through; anything else is inert OFF + a warning,
-    # so a hand-edited config never activates a mode nor crash-loops the daemon.
-    assert lk.DefaultRouteMode.coerce("enforce") is lk.DefaultRouteMode.ENFORCE
-    assert lk.DefaultRouteMode.coerce(lk.DefaultRouteMode.OBSERVE) is lk.DefaultRouteMode.OBSERVE
+@pytest.mark.parametrize("enum, valid_str, str_member, id_member, fallback, warn_needle", [
+    ("DefaultRouteMode", "enforce", "ENFORCE", "OBSERVE", "OFF", "unknown default-route mode"),
+    ("BackupEgressForm", "prefixes", "PREFIXES", "SPLIT", "SPLIT", "unknown backup-egress form"),
+])
+def test_strenum_coerce(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        lk, caplog, enum, valid_str, str_member, id_member, fallback, warn_needle):
+    # coerce maps a valid string or member through unchanged; anything else falls back to a
+    # safe default (inert OFF / leak-safe SPLIT) with a warning, so a hand-edited config
+    # never activates an unintended value nor crash-loops the supervised daemon.
+    cls = getattr(lk, enum)
+    assert cls.coerce(valid_str) is getattr(cls, str_member)
+    assert cls.coerce(getattr(cls, id_member)) is getattr(cls, id_member)   # member in, member out
     with caplog.at_level("WARNING", logger="lease-keeper"):
-        assert lk.DefaultRouteMode.coerce("bogus") is lk.DefaultRouteMode.OFF
-    assert any("unknown default-route mode" in r.getMessage() for r in caplog.records)
-
-
-def test_backup_egress_form_coerce(lk, caplog):
-    # Same contract for the egress form: unrecognised -> leak-safe SPLIT + a warning
-    # (previously a bad value raised and crash-looped the supervised daemon).
-    assert lk.BackupEgressForm.coerce("prefixes") is lk.BackupEgressForm.PREFIXES
-    assert lk.BackupEgressForm.coerce(lk.BackupEgressForm.SPLIT) is lk.BackupEgressForm.SPLIT
-    with caplog.at_level("WARNING", logger="lease-keeper"):
-        assert lk.BackupEgressForm.coerce("bogus") is lk.BackupEgressForm.SPLIT
-    assert any("unknown backup-egress form" in r.getMessage() for r in caplog.records)
+        assert cls.coerce("bogus") is getattr(cls, fallback)
+    assert any(warn_needle in r.getMessage() for r in caplog.records)
 
 
 def test_strike_limit_must_be_positive(lk):
@@ -436,21 +323,6 @@ def test_bogus_gateway_is_not_installed(lk, monkeypatch):
     rec, fake = _rec(lk, monkeypatch, "enforce")
     rec.reconcile(True, True, "0.0.0.0")  # rogue / malformed option 3
     assert fake.gw is None and RouteCommand.ADD not in fake.verbs
-
-
-def test_bogus_gateway_withdraws_existing(lk, monkeypatch):
-    # master+bound but an unusable gateway must not KEEP a default it can't honour.
-    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW)
-    rec.reconcile(True, True, "0.0.0.0")
-    assert fake.gw is None and RouteCommand.DELETE in fake.verbs
-
-
-def test_bound_without_gateway_withdraws(lk, monkeypatch):
-    # a lease with no router option (gateway None) cannot back a default -> withdraw,
-    # and _sane_ipv4(None) must be handled, not raise.
-    rec, fake = _rec(lk, monkeypatch, "enforce", initial=GW)
-    rec.reconcile(True, True, None)
-    assert fake.gw is None and RouteCommand.DELETE in fake.verbs
 
 
 # ---- a genuine route-command failure is surfaced, not buried as a no-op ----
@@ -497,43 +369,22 @@ def _levels_for(caplog, needle):
     return [r.levelname for r in caplog.records if needle in r.getMessage()]
 
 
-def test_enforce_owning_heartbeat_states_at_info(lk, monkeypatch, caplog):
-    # a steady, already-correct master states ownership positively (not silence) at
-    # INFO on entry; the immediate per-tick repeat is throttled away.
-    rec, _ = _rec(lk, monkeypatch, "enforce", initial=GW)
+@pytest.mark.parametrize("mode, initial, reconcile_args, needle", [
+    ("enforce", GW, (True, True, GW), f"owning default via {GW}"),           # steady master owns
+    ("enforce", None, (False, True, GW), "no default held (CARP backup)"),   # backup names the reason
+    ("observe", None, (True, True, GW), "would install default"),            # observe would-install persists
+    ("observe", GW, (False, False, None), "would withdraw default"),         # observe would-withdraw persists
+])
+def test_reconcile_heartbeat_states_once_at_info(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        lk, monkeypatch, caplog, mode, initial, reconcile_args, needle):
+    # A steady decision states itself positively at INFO on entry (owning / no-default /
+    # would-install / would-withdraw), then the identical per-tick repeat is throttled
+    # away -- exactly one INFO line for the needle.
+    rec, _ = _rec(lk, monkeypatch, mode, initial=initial)
     with caplog.at_level("DEBUG", logger="lease-keeper"):
-        rec.reconcile(True, True, GW)   # already correct -> entry
-        rec.reconcile(True, True, GW)   # unchanged repeat -> throttled
-    assert _levels_for(caplog, f"owning default via {GW}") == ["INFO"]
-
-
-def test_enforce_no_default_heartbeat_names_reason(lk, monkeypatch, caplog):
-    # a backup that holds the (shared-vMAC) lease but is not master confirms it has
-    # correctly no default, with the reason, at INFO on entry (the repeat throttled).
-    rec, _ = _rec(lk, monkeypatch, "enforce")
-    with caplog.at_level("DEBUG", logger="lease-keeper"):
-        rec.reconcile(False, True, GW)
-        rec.reconcile(False, True, GW)
-    msgs = [r for r in caplog.records if "no default held (CARP backup)" in r.getMessage()]
-    assert [r.levelname for r in msgs] == ["INFO"]
-
-
-def test_observe_would_install_states_at_info(lk, monkeypatch, caplog):
-    # observe never writes the FIB, so the would-install condition persists every
-    # tick; log it once at INFO instead of forever (the repeat throttled).
-    rec, _ = _rec(lk, monkeypatch, "observe")
-    with caplog.at_level("DEBUG", logger="lease-keeper"):
-        rec.reconcile(True, True, GW)
-        rec.reconcile(True, True, GW)
-    assert _levels_for(caplog, "would install default") == ["INFO"]
-
-
-def test_observe_would_withdraw_states_at_info(lk, monkeypatch, caplog):
-    rec, _ = _rec(lk, monkeypatch, "observe", initial=GW)
-    with caplog.at_level("DEBUG", logger="lease-keeper"):
-        rec.reconcile(False, False, None)
-        rec.reconcile(False, False, None)
-    assert _levels_for(caplog, "would withdraw default") == ["INFO"]
+        rec.reconcile(*reconcile_args)
+        rec.reconcile(*reconcile_args)
+    assert _levels_for(caplog, needle) == ["INFO"]
 
 
 def test_reconcile_heartbeat_throttle_cycle(lk, monkeypatch, caplog):
@@ -595,17 +446,15 @@ def _becfg(**kw):
     return BackupEgressConfig(**kw)
 
 
-def test_backup_egress_disabled_is_inert(lk, monkeypatch):
-    # no backup_egress config -> the reconcile is a no-op, issues nothing.
-    rec, fake = _backup(lk, monkeypatch, "enforce")
-    rec.reconcile_backup_egress(False)
-    assert not fake.calls
-
-
-def test_backup_egress_off_mode_inert(lk, monkeypatch):
-    # off mode: even with the feature enabled, nothing runs.
-    rec, fake = _backup(lk, monkeypatch, "off", backup_egress=_becfg(gateway=BE_GW))
-    rec.reconcile_backup_egress(False)
+@pytest.mark.parametrize("mode, backup_egress, role", [
+    ("enforce", None, False),                  # feature not configured -> disabled
+    ("off", _becfg(gateway=BE_GW), False),     # off mode: even when configured, inert
+    ("enforce", _becfg(gateway=BE_GW), None),  # unreadable role (None) -> touch nothing
+])
+def test_backup_egress_inert(lk, monkeypatch, mode, backup_egress, role):
+    # No FIB calls at all when the reconcile must do nothing (disabled / off / unknown role).
+    rec, fake = _backup(lk, monkeypatch, mode, backup_egress=backup_egress)
+    rec.reconcile_backup_egress(role)
     assert not fake.calls
 
 
@@ -642,12 +491,6 @@ def test_backup_egress_idempotent_no_churn(lk, monkeypatch):
     mutations = [c for c in fake.calls[n:] if c[0].endswith("route")
                  and c[2] in (RouteCommand.ADD, RouteCommand.CHANGE, RouteCommand.DELETE)]
     assert fake.calls[n:] and not mutations
-
-
-def test_backup_egress_unknown_role_touches_nothing(lk, monkeypatch):
-    rec, fake = _backup(lk, monkeypatch, "enforce", backup_egress=_becfg(gateway=BE_GW))
-    rec.reconcile_backup_egress(None)
-    assert not fake.calls
 
 
 def test_backup_egress_derive_peer_on_ptp(lk, monkeypatch):
@@ -762,16 +605,22 @@ def test_backup_egress_observe_dry_run(lk, monkeypatch, caplog):
     assert any("would route backup egress" in r.getMessage() for r in caplog.records)
 
 
-def test_backup_egress_zero_prefix_dropped_under_enforce(lk, monkeypatch, caplog):
-    # a 0.0.0.0/0 inside a specific-prefix list is dropped under enforce (enforce owns
-    # the default); the other prefixes still install.
+@pytest.mark.parametrize("bad_prefix, warn_needle", [
+    ("0.0.0.0/0", "0.0.0.0/0 is owned by enforce"),   # enforce owns the default
+    ("not-an-ip", "ignoring invalid prefix"),          # not a network at all
+    ("2001:db8::/32", "non-IPv4 prefix"),              # FIB ops are IPv4-only (netstat/route -inet)
+])
+def test_backup_egress_prefix_dropped(lk, monkeypatch, caplog, bad_prefix, warn_needle):
+    # An unusable prefix in a PREFIXES list is dropped at validation (not retried every
+    # tick); the good prefix still installs and the drop is warned.
     rec, fake = _backup(lk, monkeypatch, "enforce",
                         backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
-                                             prefixes=("0.0.0.0/0", "192.0.2.0/24")))
+                                             prefixes=(bad_prefix, "192.0.2.0/24")))
     with caplog.at_level("WARNING", logger="lease-keeper"):
         rec.reconcile_backup_egress(False)
-    assert "0.0.0.0/0" not in fake.routes and fake.routes.get("192.0.2.0/24") == BE_GW
-    assert any("0.0.0.0/0 is owned by enforce" in r.getMessage() for r in caplog.records)
+    assert fake.routes.get("192.0.2.0/24") == BE_GW
+    assert bad_prefix not in fake.routes
+    assert any(warn_needle in r.getMessage() for r in caplog.records)
 
 
 def test_backup_egress_specific_prefixes(lk, monkeypatch):
@@ -960,29 +809,6 @@ def test_backup_egress_resolve_rearms_warning(lk, monkeypatch, caplog):
         rec.reconcile_backup_egress(False)                 # warn #2
     warns = [r for r in caplog.records if "cannot read an IPv4 address" in r.getMessage()]
     assert len(warns) == 2
-
-
-def test_backup_egress_invalid_prefix_dropped(lk, monkeypatch, caplog):
-    rec, fake = _backup(lk, monkeypatch, "enforce",
-                        backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
-                                             prefixes=("not-an-ip", "192.0.2.0/24")))
-    with caplog.at_level("WARNING", logger="lease-keeper"):
-        rec.reconcile_backup_egress(False)
-    assert fake.routes.get("192.0.2.0/24") == BE_GW
-    assert any("ignoring invalid prefix" in r.getMessage() for r in caplog.records)
-
-
-def test_backup_egress_ipv6_prefix_dropped(lk, monkeypatch, caplog):
-    # ip_network() accepts IPv6, but the FIB ops are IPv4-only (netstat/route -inet); a v6
-    # prefix must be dropped at validation rather than retried and failing every tick.
-    rec, fake = _backup(lk, monkeypatch, "enforce",
-                        backup_egress=_becfg(gateway=BE_GW, form=BackupEgressForm.PREFIXES,
-                                             prefixes=("2001:db8::/32", "192.0.2.0/24")))
-    with caplog.at_level("WARNING", logger="lease-keeper"):
-        rec.reconcile_backup_egress(False)
-    assert fake.routes.get("192.0.2.0/24") == BE_GW
-    assert "2001:db8::/32" not in fake.routes
-    assert any("non-IPv4 prefix" in r.getMessage() for r in caplog.records)
 
 
 def test_backup_egress_boundary_leaves_unowned_split_when_disabled(lk, monkeypatch):


### PR DESCRIPTION
First pass of a test-quality cleanup (production code untouched). Every change is behaviour- and coverage-preserving, verified before and after: 274 tests pass, per-file coverage is identical (route.py 98%, TOTAL 82% over 1997 statements), and the collected case count is unchanged at 223 (parametrize expands to the same scenarios).

## What

- **Shared fakes.** `FakeRoute` and the WAN gateway constants move to a new `tests/fakes.py`, so `tests/test_daemon.py` imports them normally instead of reaching into `tests/test_route.py` (six in-function `from test_route import ...` statements, each with a `noqa`/`pylint` suppression, are gone).
- **A `_reply()` builder for `DhcpReply`.** The ~24 positional constructions padded with trailing `None`s become keyword calls that name the field they set. A field reorder in the `DhcpReply` NamedTuple now breaks one line instead of two dozen.
- **Parametrized tables** for near-identical clusters, each input kept as a readable row:
  - `test_route.py`: withdraw-existing (5 tests to 1), prefix-drop (3 to 1), heartbeat-states-once (4 to 1), StrEnum coerce (2 to 1), inert (3 to 1).
  - `test_daemon.py`: shutdown withdraw/keep (2 to 1), fail-stop withdraw (3 to 1), ignored peer-ACK (3 to 1).

The default-route-forwarding tests were deliberately left as focused tests: their setups and extra assertions differ enough that a table would need conditional logic and read worse.

## Not in this pass

Deferred testability refactors that touch production code (an injectable clock to retire the one `_heartbeat._deadline` reach; splitting IO from parsing in `status`/`keeperconf` to drop `tmp_path` from the parser tests; a declared `leasekeeper` public API to replace the `lk` facade) are noted for a follow-up so this PR stays test-only.

## Verification

- unit tests: 274 pass, 223 cases collected (unchanged)
- coverage: identical per-file before/after
- flake8 (max-line 120): clean
- pylint 10.00/10 with useless-suppression enabled
- pyright: 0 errors