### PR TITLE
Split file IO from parsing in keeperconf and status

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/keeperconf.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/keeperconf.py
@@ -14,20 +14,15 @@ def keeper_id(request_ip):
     return re.sub(r"[^A-Za-z0-9]", "_", request_ip)
 
 
-def keeper_records(path):
-    """Yield each active (non-comment) keeper.conf line as a {key: value} dict.
+def keeper_records_text(text):
+    """Yield each active (non-comment) keeper.conf line in `text` as a {key: value}
+    dict -- the pure parser, with no file IO (keeper_records reads the file).
 
     Each line is a pipe-separated list of KEY=VALUE fields in no fixed order (see
     the template); we dispatch by key, so a missing key is simply absent from the
     dict and the caller supplies its default. Lines without a request= field are
-    skipped, mirroring the rc.d reader. Yields nothing when the file is absent or
-    unreadable."""
-    try:
-        with open(path, encoding="utf-8") as f:
-            lines = f.read().splitlines()
-    except OSError:
-        return
-    for line in lines:
+    skipped, mirroring the rc.d reader."""
+    for line in text.splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
             continue
@@ -38,3 +33,14 @@ def keeper_records(path):
                 record[key] = value
         if record.get("request"):
             yield record
+
+
+def keeper_records(path):
+    """Yield each active keeper.conf record from the file at `path`. Yields nothing
+    when the file is absent or unreadable; the parsing lives in keeper_records_text."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+    except OSError:
+        return
+    yield from keeper_records_text(text)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
@@ -81,18 +81,14 @@ _HB_TOKENS = {
 }
 
 
-def parse_heartbeat(path):
-    """Parse one heartbeat file into the per-keeper status fields (all None /
-    False when the file is absent or unreadable)."""
+def parse_heartbeat_text(raw):
+    """Parse heartbeat text into the per-keeper status fields (all None / False
+    when the text is empty or malformed) -- the pure parser, no file IO
+    (parse_heartbeat reads the file)."""
     result = {"bound": None, "lease": None, "t1": None, "t2": None, "timing_source": None,
               "mismatch": False, "mismatch_got": None, "mismatch_want": None,
               "hb_epoch": None, "hb_age": None, "nudge_epoch": None, "nudge_age": None, "gw": None,
               "arp_reply_epoch": None, "arp_reply_age": None}
-    try:
-        with open(path, encoding="utf-8") as f:
-            raw = f.read().strip()
-    except OSError:
-        return result
     parts = raw.split()
     if not parts:
         return result
@@ -112,6 +108,18 @@ def parse_heartbeat(path):
             fields, parse = spec
             result.update(zip(fields, parse(value)))
     return result
+
+
+def parse_heartbeat(path):
+    """Parse one heartbeat file into the per-keeper status fields (all None /
+    False when the file is absent or unreadable); parsing lives in
+    parse_heartbeat_text."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            raw = f.read()
+    except OSError:
+        raw = ""
+    return parse_heartbeat_text(raw)
 
 
 def carp_states():

--- a/net/os-carp-vip-dhcp/tests/test_keeperconf.py
+++ b/net/os-carp-vip-dhcp/tests/test_keeperconf.py
@@ -27,43 +27,37 @@ def _load_keeperconf():
 keeperconf = _load_keeperconf()
 
 
-def _records(tmp_path, text):
-    conf = tmp_path / "keeper.conf"
-    conf.write_text(text)
-    return list(keeperconf.keeper_records(str(conf)))
+def _records(text):
+    return list(keeperconf.keeper_records_text(text))
 
 
-def test_fields_are_keyed_by_name_not_position(tmp_path):
+def test_fields_are_keyed_by_name_not_position():
     recs = _records(
-        tmp_path,
         "request=100.64.0.7|iface=eth0|chaddr=00:00:5e:00:01:fe|vhid=254\n")
     assert recs == [{
         "request": "100.64.0.7", "iface": "eth0",
         "chaddr": "00:00:5e:00:01:fe", "vhid": "254"}]
 
 
-def test_field_order_does_not_matter(tmp_path):
+def test_field_order_does_not_matter():
     recs = _records(
-        tmp_path,
         "vhid=254|chaddr=aa|iface=eth0|request=100.64.0.7\n")
     assert recs[0] == {
         "request": "100.64.0.7", "iface": "eth0", "chaddr": "aa", "vhid": "254"}
 
 
-def test_unknown_key_is_kept_but_harmless_and_missing_key_absent(tmp_path):
+def test_unknown_key_is_kept_but_harmless_and_missing_key_absent():
     # An added/unknown key round-trips into the dict; a caller reads only the
     # keys it knows and defaults the rest. An empty value stays an empty string.
     recs = _records(
-        tmp_path,
         "request=100.64.0.7|newfield=x|vendorclass=\n")
     assert recs[0]["newfield"] == "x"
     assert recs[0]["vendorclass"] == ""
     assert "arpnudge" not in recs[0]
 
 
-def test_lines_without_request_and_comments_are_skipped(tmp_path):
+def test_lines_without_request_and_comments_are_skipped():
     recs = _records(
-        tmp_path,
         "# a comment\n"
         "iface=eth0|chaddr=aa\n"          # no request key -> skipped
         "request=|iface=eth0\n"           # empty request value -> skipped
@@ -73,6 +67,7 @@ def test_lines_without_request_and_comments_are_skipped(tmp_path):
 
 
 def test_missing_file_yields_nothing(tmp_path):
+    # the file-reading wrapper: an absent/unreadable file yields nothing.
     assert not list(keeperconf.keeper_records(str(tmp_path / "absent.conf")))
 
 

--- a/net/os-carp-vip-dhcp/tests/test_status.py
+++ b/net/os-carp-vip-dhcp/tests/test_status.py
@@ -10,10 +10,9 @@ def test_keeper_id():
     assert status.keeper_id("00:00:5e:00:01:fe") == "00_00_5e_00_01_fe"
 
 
-def test_parse_heartbeat_bound(tmp_path):
-    hb = tmp_path / "hb"
-    hb.write_text("1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived\n")
-    result = status.parse_heartbeat(str(hb))
+def test_parse_heartbeat_bound():
+    result = status.parse_heartbeat_text(
+        "1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived\n")
     assert result["bound"] == "100.64.4.7"
     assert result["lease"] == 1800
     assert result["t1"] == 900
@@ -22,30 +21,27 @@ def test_parse_heartbeat_bound(tmp_path):
     assert not result["mismatch"]
 
 
-def test_parse_heartbeat_unbound(tmp_path):
-    hb = tmp_path / "hb"
-    hb.write_text("1783350773 bound=- lease=1800 t1=900 t2=1575 src=derived\n")
-    assert status.parse_heartbeat(str(hb))["bound"] is None
+def test_parse_heartbeat_unbound():
+    text = "1783350773 bound=- lease=1800 t1=900 t2=1575 src=derived\n"
+    assert status.parse_heartbeat_text(text)["bound"] is None
 
 
-def test_parse_heartbeat_mismatch(tmp_path):
-    hb = tmp_path / "hb"
-    hb.write_text("1783350773 MISMATCH got=1.2.3.4 want=100.64.4.7\n")
-    result = status.parse_heartbeat(str(hb))
+def test_parse_heartbeat_mismatch():
+    result = status.parse_heartbeat_text("1783350773 MISMATCH got=1.2.3.4 want=100.64.4.7\n")
     assert result["mismatch"] is True
     assert result["mismatch_got"] == "1.2.3.4"
     assert result["mismatch_want"] == "100.64.4.7"
 
 
 def test_parse_heartbeat_missing(tmp_path):
+    # the file-reading wrapper: an absent file parses to the empty result.
     assert status.parse_heartbeat(str(tmp_path / "absent"))["bound"] is None
 
 
-def test_parse_heartbeat_nudge_and_arpok(tmp_path):
-    hb = tmp_path / "hb"
-    hb.write_text("1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived"
-                  " nudge=1783350700 arpok=1783350710 gw=100.64.4.1\n")
-    result = status.parse_heartbeat(str(hb))
+def test_parse_heartbeat_nudge_and_arpok():
+    result = status.parse_heartbeat_text(
+        "1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived"
+        " nudge=1783350700 arpok=1783350710 gw=100.64.4.1\n")
     assert result["nudge_epoch"] == 1783350700
     assert isinstance(result["nudge_age"], int) and result["nudge_age"] > 0
     assert result["arp_reply_epoch"] == 1783350710
@@ -53,11 +49,10 @@ def test_parse_heartbeat_nudge_and_arpok(tmp_path):
     assert result["gw"] == "100.64.4.1"
 
 
-def test_parse_heartbeat_nudge_and_arpok_zero(tmp_path):
-    hb = tmp_path / "hb"
-    hb.write_text("1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived"
-                  " nudge=0 arpok=0\n")
-    result = status.parse_heartbeat(str(hb))
+def test_parse_heartbeat_nudge_and_arpok_zero():
+    result = status.parse_heartbeat_text(
+        "1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived"
+        " nudge=0 arpok=0\n")
     assert result["nudge_epoch"] == 0
     assert result["nudge_age"] is None
     assert result["arp_reply_epoch"] == 0
@@ -65,10 +60,9 @@ def test_parse_heartbeat_nudge_and_arpok_zero(tmp_path):
     assert result["gw"] is None
 
 
-def test_parse_heartbeat_without_nudge_tokens(tmp_path):
-    hb = tmp_path / "hb"
-    hb.write_text("1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived\n")
-    result = status.parse_heartbeat(str(hb))
+def test_parse_heartbeat_without_nudge_tokens():
+    result = status.parse_heartbeat_text(
+        "1783350773 bound=100.64.4.7 lease=1800 t1=900 t2=1575 src=derived\n")
     assert result["nudge_epoch"] is None
     assert result["nudge_age"] is None
 


### PR DESCRIPTION
A testability refactor: extract the pure parsers from their file-reading wrappers so the parser tests can feed a string instead of writing and re-reading a temp file.

## What

- `keeperconf.py`: new pure `keeper_records_text(text)`; `keeper_records(path)` now just reads the file (OSError to empty) and delegates.
- `status.py`: new pure `parse_heartbeat_text(raw)`; `parse_heartbeat(path)` now just reads the file (OSError to the empty result) and delegates.
- Tests: the ~10 keeper.conf / heartbeat parse tests feed a literal string via the `_text` parsers and drop their `tmp_path` fixture. `tmp_path` stays only where a file is genuinely the point: the two missing-file wrapper tests and the two `read_keepers` integration tests (which read multiple pid/hb files by path). `tmp_path` uses across the two test files fall from 35 to 13.

## Behaviour

Behaviour-preserving. The wrappers reproduce the old read-then-parse exactly; dropping the old `.strip()` is safe because `str.split()` already ignores leading/trailing whitespace. No routing or failover behaviour is touched, so no bench run is needed.

## Verification

- unit tests: 274 pass
- coverage: `status.py` rises 65 to 67% (the pure parser is now exercised without a file), `keeperconf.py` stays 100%, TOTAL holds at 82%
- flake8 clean, pylint 10.00/10 (useless-suppression enabled), pyright 0 errors