### PR TITLE
Testability: read_keepers params, shared _UNSET sentinel, facade collision guard

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -22,7 +22,7 @@ from .dhcpclient import DhcpClient, DhcpHooks
 from .policy import ArpNudge, FollowHooks, FollowPolicy
 from .route import (BackupEgressReconciler, DefaultRouteMode, DefaultRouteReconciler,
                     withdraw_unless_master)
-from .util import _RateLimit, _atomic_write, _clock_at, _jittered, _sane_ipv4
+from .util import _UNSET, _RateLimit, _atomic_write, _clock_at, _jittered, _sane_ipv4
 from .wire import _parse_reply
 
 LOG = logging.getLogger(LOGGER_NAME)
@@ -34,10 +34,9 @@ CARP_MASTER_FMT = "carp: MASTER vhid {vhid} "
 IFCONFIG_STATUS_ACTIVE = "status: active"    # carrier up
 IFCONFIG_STATUS = "status: "                 # any status line present (up or down)
 
-# "CARP-master value not supplied" sentinel: the maintain loop probes the role
-# once per tick and shares it, but None is a valid probe result, so a distinct
-# sentinel means "probe it now".
-_UNSET = object()
+# _UNSET (shared, from util) marks "CARP-master value not supplied": the maintain
+# loop probes the role once per tick and shares it, but None is a valid probe
+# result, so the sentinel means "probe it now".
 
 
 def _ifconfig_text(iface):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
@@ -13,14 +13,14 @@ from .constants import (
     ARP_NUDGE_MIN, ArpOp, FOLLOW_RETRY_DEADLINE, MIN_FOLLOW_INTERVAL,
     NUDGE_FAIL_LOG_INTERVAL, Phase)
 from .util import (
-    _RateLimit, _atomic_write, _fs_safe, _mask_to_bits, _same_ip_class, _sane_ipv4)
+    _UNSET, _RateLimit, _atomic_write, _fs_safe, _mask_to_bits, _same_ip_class, _sane_ipv4)
 
 LOG = logging.getLogger(LOGGER_NAME)
 
-# "CARP-master value not supplied by the caller" sentinel: the maintain loop
+# _UNSET marks "CARP-master value not supplied by the caller": the maintain loop
 # passes the role it already probed this tick, but None is itself a valid probe
-# result (probe failed), so a distinct sentinel means "probe it yourself".
-_UNSET = object()
+# result (probe failed), so the sentinel means "probe it yourself". Shared via
+# util so the identity check is the same object everywhere (see util._UNSET).
 
 
 class ArpNudge:  # pylint: disable=too-many-instance-attributes

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 from .constants import LOGGER_NAME, RECONCILE_HEARTBEAT_INTERVAL
-from .util import _RateLimit, _sane_ipv4
+from .util import _UNSET, _RateLimit, _sane_ipv4
 
 LOG = logging.getLogger(LOGGER_NAME)
 
@@ -136,11 +136,11 @@ class RouteCommand(StrEnum):
 # leak to gate.
 _DEFAULT = "default"
 
-# Sentinel for "no desired state recorded yet". The first reconcile then reads as
-# a change, so the entry state (owning / no default / would-install / ...) is
-# logged once at INFO -- the mode-entry heartbeat -- and every unchanged repeat
-# after it drops to DEBUG, keeping steady state out of the default INFO view.
-_UNSET = object()
+# _UNSET (shared, from util) marks "no desired state recorded yet". The first
+# reconcile then reads as a change, so the entry state (owning / no default /
+# would-install / ...) is logged once at INFO -- the mode-entry heartbeat -- and
+# every unchanged repeat after it drops to DEBUG, keeping steady state out of the
+# default INFO view.
 
 # Consecutive unreadable CARP-role probes tolerated while we still hold a
 # default before we withdraw it. An unreadable probe (ifconfig failed) is

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/util.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/util.py
@@ -12,6 +12,13 @@ import time
 
 MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
 
+# Shared sentinel: a unique object distinct from every real value AND from None,
+# for the two places None is itself meaningful -- "argument not supplied" keyword
+# defaults (an optional CARP-role probe result) and "no state recorded yet"
+# markers. One canonical object so identity/equality checks agree across modules;
+# policy / route / keeper import it rather than each minting their own.
+_UNSET = object()
+
 
 class _RateLimit:
     """Monotonic-time throttle for noisy, possibly attacker-driven log lines.

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
@@ -154,22 +154,22 @@ def iface_names():
     return names
 
 
-def read_keepers(states, names):
+def read_keepers(states, names, conffile=CONFFILE, run_dir=RUN_DIR):
     """One status entry per keeper.conf line: config, process, CARP role and
-    heartbeat fields, plus the derived arp_confirmed freshness flag."""
+    heartbeat fields, plus the derived arp_confirmed freshness flag. conffile /
+    run_dir default to the production paths and are parameters so a caller (a
+    test) can point them at a fixture directory without mutating module state."""
     keepers = []
-    for rec in keeper_records(CONFFILE):
+    for rec in keeper_records(conffile):
         # Fields are keyed by name (see keeperconf.keeper_records); a missing key
         # falls back to its default here.
         request = rec.get("request", "")
         iface = rec.get("iface", "")
         chaddr = rec.get("chaddr", "")
-        demote = rec.get("demote", "0")
         vhid = rec.get("vhid", "")
-        follow = rec.get("follow", "0")
         arp_nudge = _int_token(rec.get("arpnudge", "")) or 0
         kid = keeper_id(request)
-        pid = pid_alive(f"{RUN_DIR}/carpvipdhcp-{kid}.pid")
+        pid = pid_alive(f"{run_dir}/carpvipdhcp-{kid}.pid")
         entry = {
             "request": request,
             "iface": iface,
@@ -177,13 +177,13 @@ def read_keepers(states, names):
             "chaddr": chaddr,
             "vhid": vhid,
             "carp_state": states.get(vhid) if vhid else None,
-            "demote_on_lease_loss": demote == "1",
-            "follow_ip": follow == "1",
+            "demote_on_lease_loss": rec.get("demote", "0") == "1",
+            "follow_ip": rec.get("follow", "0") == "1",
             "arp_nudge": arp_nudge,
             "running": pid is not None,
             "pid": pid,
         }
-        entry.update(parse_heartbeat(f"{RUN_DIR}/carpvipdhcp-{kid}.hb"))
+        entry.update(parse_heartbeat(f"{run_dir}/carpvipdhcp-{kid}.hb"))
         age = entry.get("arp_reply_age")
         entry["arp_confirmed"] = (
             age is not None and age <= max(ARP_CONFIRM_FLOOR, arp_nudge * ARP_CONFIRM_INTERVALS))

--- a/net/os-carp-vip-dhcp/tests/conftest.py
+++ b/net/os-carp-vip-dhcp/tests/conftest.py
@@ -50,11 +50,23 @@ def lk():
         keeper, policy, route, util, wire)
 
     ns = types.SimpleNamespace()
-    for mod in (constants, util, wire, codec, capture,
-                capture_bpf, dhcpclient, policy, route, keeper):
-        for name in dir(mod):
-            if not name.startswith("__"):
-                setattr(ns, name, getattr(mod, name))
+    _flatten(ns, (constants, util, wire, codec, capture,
+                  capture_bpf, dhcpclient, policy, route, keeper))
     ns.subprocess = subprocess
     ns.time = time
     return ns
+
+
+def _flatten(ns, mods):
+    """Copy every public name from each module in `mods` onto `ns`, in order.
+    Guards the flatten: a name already bound to a DIFFERENT object means two
+    submodules define distinct symbols under one name and the facade would
+    silently expose only the last (re-exports -- the same object imported into
+    several modules -- are expected and fine)."""
+    for mod in mods:
+        for name in dir(mod):
+            if name.startswith("__"):
+                continue
+            val = getattr(mod, name)
+            assert getattr(ns, name, val) is val, f"lk facade name collision: {name}"
+            setattr(ns, name, val)

--- a/net/os-carp-vip-dhcp/tests/test_status.py
+++ b/net/os-carp-vip-dhcp/tests/test_status.py
@@ -67,14 +67,12 @@ def test_parse_heartbeat_without_nudge_tokens():
     assert result["nudge_age"] is None
 
 
-def test_read_keepers_arp_nudge_field(tmp_path, monkeypatch):
+def test_read_keepers_arp_nudge_field(tmp_path):
     conf = tmp_path / "keeper.conf"
     conf.write_text(
         "request=100.64.4.7|iface=eth0|chaddr=00:00:5e:00:01:fe|demote=0|vhid=254|follow=1|arpnudge=240\n"
         "request=100.64.4.8|iface=eth0|chaddr=00:00:5e:00:01:fd|demote=0|vhid=253|follow=1\n")  # no arpnudge key
-    monkeypatch.setattr(status, "CONFFILE", str(conf))
-    monkeypatch.setattr(status, "RUN_DIR", str(tmp_path))
-    keepers = status.read_keepers({}, {})
+    keepers = status.read_keepers({}, {}, conffile=str(conf), run_dir=str(tmp_path))
     assert keepers[0]["arp_nudge"] == 240
     assert keepers[1]["arp_nudge"] == 0
 
@@ -85,21 +83,20 @@ def _write_hb(path, arpok_age, now):
         f" nudge={now - 5} arpok={now - arpok_age} gw=100.64.4.1\n")
 
 
-def test_read_keepers_arp_confirmed_fresh_and_stale(tmp_path, monkeypatch):
+def test_read_keepers_arp_confirmed_fresh_and_stale(tmp_path):
     now = int(time.time())
     conf = tmp_path / "keeper.conf"
     conf.write_text(
         "request=100.64.4.7|iface=eth0|chaddr=00:00:5e:00:01:fe|demote=0|vhid=254|follow=1|arpnudge=240\n"  # fresh
         "request=100.64.4.8|iface=eth0|chaddr=00:00:5e:00:01:fd|demote=0|vhid=253|follow=1|arpnudge=240\n"  # stale
         "request=100.64.4.9|iface=eth0|chaddr=00:00:5e:00:01:fc|demote=0|vhid=252|follow=1|arpnudge=240\n")  # no reply
-    monkeypatch.setattr(status, "CONFFILE", str(conf))
-    monkeypatch.setattr(status, "RUN_DIR", str(tmp_path))
     _write_hb(tmp_path / "carpvipdhcp-100_64_4_7.hb", 5, now)       # 5s ago -> fresh
     _write_hb(tmp_path / "carpvipdhcp-100_64_4_8.hb", 5000, now)    # 5000s ago -> stale
     (tmp_path / "carpvipdhcp-100_64_4_9.hb").write_text(
         f"{now} bound=100.64.4.9 lease=1800 t1=900 t2=1575 src=derived"
         f" nudge={now - 5} arpok=0 gw=100.64.4.1\n")   # arpok=0 -> never
-    by_ip = {k["request"]: k for k in status.read_keepers({}, {})}
+    by_ip = {k["request"]: k
+             for k in status.read_keepers({}, {}, conffile=str(conf), run_dir=str(tmp_path))}
     assert by_ip["100.64.4.7"]["arp_confirmed"] is True
     assert by_ip["100.64.4.8"]["arp_confirmed"] is False
     assert by_ip["100.64.4.9"]["arp_confirmed"] is False


### PR DESCRIPTION
Three small behaviour-preserving testability seams. All 274 tests pass, coverage holds at 82%.

## What

- **`status.read_keepers(states, names, conffile=CONFFILE, run_dir=RUN_DIR)`** takes the two paths as parameters (defaulting to the production constants). The two `read_keepers` tests pass a fixture directory directly instead of `monkeypatch.setattr`-ing module globals -- no module-state mutation, parallel-safe.
- **One shared `util._UNSET` sentinel.** `policy`, `route` and `keeper` each minted their own `_UNSET = object()`. They are all just a unique marker distinct from every real value and from None, so they now import one canonical object from `util`. Identity and equality checks are unchanged (still one object per `is`/`!=`), and it removes a latent trap: the `lk` test facade flattens every submodule's public names into one namespace and silently exposed only the last `_UNSET` of the three.
- **The `lk` facade fixture now guards against silent name collisions:** it asserts no two submodules bind the same name to a *different* object (re-exports of the same object are expected and fine). This is what surfaced the `_UNSET` collision; with the sentinel unified, the guard passes clean and protects against a future clash.

## Behaviour

Behaviour-preserving. `_UNSET` is only ever used via `is` / `!=` against a unique object; one shared object satisfies that identically. `read_keepers` defaults reproduce the old module-global reads. No routing/failover paths touched, so no bench run.

## Verification

- unit tests: 274 pass; coverage 82% held (status.py 67%, route/keeper/policy unchanged)
- flake8 clean, pylint 10.00/10 (useless-suppression enabled), pyright 0 errors