### PR TITLE
Clarify the chaddr-override help text

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/controllers/OPNsense/CarpVipDhcp/forms/dialogKeeper.xml
@@ -9,7 +9,7 @@
         <id>keeper.carpVip</id>
         <label>CARP virtual IP</label>
         <type>dropdown</type>
-        <help>The CARP VirtualIP to keep a lease for. Interface, VHID (chaddr) and IP are derived from it.</help>
+        <help>The CARP virtual IP to keep a lease for. Interface, VHID and IP are derived from it; the DHCP client MAC (chaddr) is the CARP virtual MAC for that VHID, so the lease follows the VIP to the peer on failover.</help>
     </field>
     <field>
         <id>keeper.followIp</id>
@@ -79,7 +79,7 @@
         <label>ARP nudge interval (s)</label>
         <type>text</type>
         <advanced>true</advanced>
-        <help><![CDATA[Periodically broadcast an ARP request from the VIP (with its CARP MAC) for the upstream gateway, so the gateway's ARP entry for the VIP never expires. Use when the upstream ignores gratuitous ARP and never re-ARPs an expired entry — the symptom is that traffic NATed to the VIP works right after a CARP event or DHCP exchange, then silently blackholes some minutes later (outbound packets leave, nothing returns). Only sent while this node is CARP master for the VIP. Default: 120 (on) — one broadcast ARP per interval; lower toward the 30 s floor if a short-ARP-timeout gateway still blackholes the VIP between nudges. Setting 0 disables the nudge entirely: the periodic nudge, the automatic nudge on CARP failover AND the manual nudge button on the status page (the early lease renew on failover is unaffected).]]></help>
+        <help><![CDATA[Periodically broadcast an ARP request from the VIP (with its CARP virtual MAC) for the upstream gateway, so the gateway's ARP entry for the VIP never expires. Use when the upstream ignores gratuitous ARP and never re-ARPs an expired entry. The symptom is that traffic NATed to the VIP works right after a CARP event or DHCP exchange, then silently blackholes some minutes later (outbound packets leave, nothing returns). Only sent while this node is CARP master for the VIP. Default: 120 (on), one broadcast ARP per interval; lower toward the 30 s floor if a short-ARP-timeout gateway still blackholes the VIP between nudges. Setting 0 disables the nudge entirely: the periodic nudge, the automatic nudge on CARP failover AND the manual nudge button on the status page (the early lease renew on failover is unaffected).]]></help>
     </field>
     <field>
         <id>keeper.arpListenPromisc</id>
@@ -90,10 +90,10 @@
     </field>
     <field>
         <id>keeper.chaddrOverride</id>
-        <label>chaddr override</label>
+        <label>Client MAC override (chaddr)</label>
         <type>text</type>
         <advanced>true</advanced>
-        <help><![CDATA[Only if the ISP reservation MAC differs from the CARP virtual MAC. Empty = use the derived CARP MAC.]]></help>
+        <help><![CDATA[Leave blank. By default the keeper's DHCP client uses the CARP virtual MAC, which is what you want: the lease, the ISP's IP-to-MAC binding and the VIP's own outbound traffic all sit on one MAC, and the lease follows the VIP to the peer on failover. Override ONLY if your ISP has a fixed reservation bound to a specific, different MAC that you cannot change. Do NOT enter this node's own interface MAC: the VIP still sends from the CARP virtual MAC, so on an ISP that binds the leased IP to the MAC (IP source guard) the gateway becomes unreachable ("No route to host"). Empty = the derived CARP virtual MAC.]]></help>
     </field>
     <field>
         <id>keeper.vendorClass</id>

--- a/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
+++ b/net/os-carp-vip-dhcp/src/opnsense/mvc/app/models/OPNsense/CarpVipDhcp/CarpVipDhcp.xml
@@ -21,7 +21,9 @@
                     <ValidationMessage>Select a CARP virtual IP.</ValidationMessage>
                 </carpVip>
 
-                <!-- Override the chaddr when the ISP reservation MAC differs from the CARP MAC. -->
+                <!-- DHCP client MAC. Blank (default) = the derived CARP virtual MAC, which HA
+                     needs; override only when the ISP reservation is bound to a specific
+                     different MAC that cannot be changed. See the field help. -->
                 <chaddrOverride type="MacAddressField">
                     <Required>N</Required>
                 </chaddrOverride>

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
@@ -18,4 +18,4 @@ wires up and runs the Keeper defined here. Modules, leaf-first:
 # PLUGIN_VERSION from this line (so the package version and the daemon's own
 # reported version can never drift). Keep the assignment on one line as
 # __version__ = "X.Y.Z" so the Makefile's sed can read it.
-__version__ = "1.13.1"
+__version__ = "1.13.2"


### PR DESCRIPTION
GUI help-text clarity only, no behaviour change.

## Why

The "chaddr override" field is the easiest one in the dialog to misuse. Read quickly, "override the chaddr" invites setting it to the node's own interface MAC, which looks reasonable but breaks outbound routing on an ISP that binds the leased IP to the MAC that did the DHCP: the lease ends up on one MAC while the CARP VIP still sends from the CARP MAC, so the gateway stops answering ARP and traffic dies as "No route to host". The old help ("Only if the ISP reservation MAC differs from the CARP virtual MAC. Empty = use the derived CARP MAC.") did not steer the user away from that.

## What

- **Label**: `Client MAC override (chaddr)` instead of the bare `chaddr override`, so the field has a plain-language anchor.
- **Help**: leads with "Leave blank", explains why the CARP virtual MAC default is the correct choice (one MAC for the lease, the ISP's IP-to-MAC binding and the VIP's own traffic, and it follows the VIP on failover), states the single legitimate reason to override, and warns explicitly against entering the node's own interface MAC with the exact failure it produces.
- **CARP virtual IP** field: note that the derived chaddr is the CARP virtual MAC (quietly reinforces why the override is almost never needed).
- Normalise the two em-dashes in the ARP-nudge help to plain punctuation.

The other advanced fields already open with their default and purpose, so no lead-sentence changes were needed there.

## Verification

XML well-formed; no logic touched.