### PR TITLE
Funnel the daemon's system commands through one syscmd module

### DIFF
--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
@@ -18,4 +18,4 @@ wires up and runs the Keeper defined here. Modules, leaf-first:
 # PLUGIN_VERSION from this line (so the package version and the daemon's own
 # reported version can never drift). Keep the assignment on one line as
 # __version__ = "X.Y.Z" so the Makefile's sed can read it.
-__version__ = "1.13.2"
+__version__ = "1.13.3"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -6,7 +6,6 @@ operator actions.
 import logging
 import select
 import socket
-import subprocess
 import time
 from dataclasses import dataclass
 
@@ -22,6 +21,7 @@ from .dhcpclient import DhcpClient, DhcpHooks
 from .policy import ArpNudge, FollowHooks, FollowPolicy
 from .route import (BackupEgressReconciler, DefaultRouteMode, DefaultRouteReconciler,
                     withdraw_unless_master)
+from .syscmd import ifconfig, spawn
 from .util import _UNSET, _RateLimit, _atomic_write, _clock_at, _jittered, _sane_ipv4
 from .wire import _parse_reply
 
@@ -37,16 +37,6 @@ IFCONFIG_STATUS = "status: "                 # any status line present (up or do
 # _UNSET (shared, from util) marks "CARP-master value not supplied": the maintain
 # loop probes the role once per tick and shares it, but None is a valid probe
 # result, so the sentinel means "probe it now".
-
-
-def _ifconfig_text(iface):
-    """Raw `ifconfig <iface>` text, or None if it could not run (no logging -- each
-    caller adds its own error policy)."""
-    try:
-        out = subprocess.check_output(["/sbin/ifconfig", iface], errors="replace")
-    except (OSError, subprocess.SubprocessError):
-        return None
-    return out.decode(errors="replace") if isinstance(out, bytes) else out
 
 
 def _carp_master(ifconfig_text, vhid):
@@ -65,7 +55,7 @@ def carp_master(iface, vhid):
     fail-stop default withdraw on the role before the Keeper / capture backend
     exist; the Keeper's per-tick probe (_probe_carp_master) shares CARP_MASTER_FMT
     through _carp_master."""
-    return _carp_master(_ifconfig_text(iface), vhid)
+    return _carp_master(ifconfig(iface), vhid)
 
 
 @dataclass
@@ -370,9 +360,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         replaces this daemon with one bound to the new address."""
         cmd = ["/usr/local/sbin/configctl", "-d", "carpvipdhcp", "follow_update", old_ip, new_ip]
         cmd += gw_args   # cross-subnet: [old_gw, new_gw, bits]; empty on a same-subnet move
-        # Fire-and-forget: this configctl triggers a service restart that replaces
-        # this very daemon, so we must not wait on the child (`with` would block).
-        subprocess.Popen(cmd)  # pylint: disable=consider-using-with
+        # Fire-and-forget via syscmd.spawn: this configctl triggers a service restart
+        # that replaces this very daemon, so we must not wait on it. spawn does NOT
+        # swallow a launch failure -- it raises, so FollowPolicy catches it, leaves the
+        # target unadvanced, and defers the follow to the next renewal.
+        spawn(cmd)
 
     # ---- CARP role (master probe, transitions) ----
 
@@ -385,7 +377,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         nudge fails closed, the transition poll skips), so warn once per failure
         episode -- otherwise a wrong --iface or a broken ifconfig looks identical
         to a healthy backup in the log."""
-        out = _ifconfig_text(self._cfg.iface)
+        out = ifconfig(self._cfg.iface)
         if out is None:
             if not self._link.ifconfig_failed:
                 LOG.warning("ifconfig %s probe failed -- CARP role and carrier "

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
@@ -190,7 +190,7 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
         except OSError as e:
             LOG.warning("could not persist follow timestamp: %s", e)
 
-    def on_changed_address(self, got, rx, phase, release_on_enforce):
+    def on_changed_address(self, got, rx, phase, release_on_enforce):  # pylint: disable=too-many-return-statements
         """An ACK arrived whose address differs from the one we hold/request.
 
         In follow mode: validate the address (sane, same routability class, from
@@ -242,11 +242,24 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
                               "interface prefix + System->Gateways by hand", self.target,
                               got, old_router, rx.router)
 
-            self._record_follow()
             # _follow_update reads target as the old address, so remember it
             # (for the retry watchdog) and fire before overwriting target.
             self._attempt.follow_from = self.target
-            self._follow_update(got)
+            if not self._follow_update(got):
+                # The dispatch could not even be launched (e.g. fork/exec failure).
+                # Do NOT advance the target, adopt the binding, or arm the throttle
+                # below: leaving all three untouched means the next renewal ACK for
+                # `got` re-enters here and re-drives the follow promptly. The
+                # throttle is only for real, dispatched follows (a spoof/flap
+                # storm), so a never-dispatched attempt must not delay its own
+                # retry. Advancing would strand the daemon on `got` with the CARP
+                # VIP config still on the old address and no way to re-fire.
+                return False
+            # A real follow was dispatched: arm the spoof-storm throttle now (only
+            # on success -- arming before the dispatch would make a failed launch
+            # throttle its own retry). Persisted so it survives the follow-induced
+            # restart.
+            self._record_follow()
             self.target = got
             self._dhcp.adopt(rx)
             return True
@@ -264,17 +277,23 @@ class FollowPolicy:  # pylint: disable=too-many-instance-attributes
     def _follow_update(self, new_ip):
         """Ask configd to rewrite the CARP VIP (and this keeper's reference) from
         the target to new_ip, then reconfigure. Fire-and-forget: the resulting
-        service restart replaces this daemon with one bound to the new address."""
+        service restart replaces this daemon with one bound to the new address.
+        Returns True once the request was dispatched (or was already asked for),
+        False if the dispatch failed -- launch failure or any other exception from
+        the dispatch hook -- in which case the caller defers without advancing the
+        target, so the next renewal re-drives (see on_changed_address)."""
         if new_ip == self._attempt.followed_ip:
-            return   # already asked for this address
+            return True   # already asked for this address
         try:
             self._fire_follow_update(self.target, new_ip)
             # Only mark as handled once the request was actually dispatched, so a
-            # spawn failure is retried next cycle instead of getting stuck.
+            # dispatch that could not be launched is retried, not latched.
             self._attempt.followed_ip = new_ip
             LOG.info("requested CARP VIP update %s -> %s", self.target, new_ip)
+            return True
         except Exception as e:  # pylint: disable=broad-exception-caught
-            LOG.error("follow_update request failed: %s", e)
+            LOG.error("follow_update request failed: %s -- deferring to the next renewal", e)
+            return False
 
     def _fire_follow_update(self, old_ip, new_ip):
         """Dispatch the follow_update side effect (old -> new, plus any

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -27,11 +27,11 @@ collapsed onto one boolean flag -- converges quietly rather than raising.
 """
 import ipaddress
 import logging
-import subprocess
 from dataclasses import dataclass
 from enum import StrEnum
 
 from .constants import LOGGER_NAME, RECONCILE_HEARTBEAT_INTERVAL
+from .syscmd import run
 from .util import _UNSET, _RateLimit, _sane_ipv4
 
 LOG = logging.getLogger(LOGGER_NAME)
@@ -156,7 +156,6 @@ _IFCONFIG = "/sbin/ifconfig"
 _NUMERIC = "-n"              # numeric output, no name resolution
 _AF_INET = "-inet"          # IPv4 address family modifier; the v6 twin: -inet6
 _GATEWAY_FIELD = "gateway:"  # the field label parsed from `route get` output
-_SUBPROC_TIMEOUT = 5
 
 # The /1-split: two half-internet routes that together cover 0.0.0.0/0 but are each
 # more specific than it (so they win over any default) and are not the default (so
@@ -168,19 +167,7 @@ _DEFAULT_NET = ipaddress.ip_network("0.0.0.0/0")
 _PTP_PREFIXLENS = (30, 31)
 
 
-# ---- /sbin/route exec helpers (stateless; shared by both reconcilers) ----
-
-def _run(cmd):
-    """Run a `/sbin/route` argv, capturing output and bounded by a timeout;
-    return the CompletedProcess, or None if it could not be executed at all
-    (logged)."""
-    try:
-        return subprocess.run(cmd, capture_output=True, errors="replace",
-                              timeout=_SUBPROC_TIMEOUT, check=False)
-    except (OSError, subprocess.SubprocessError) as e:
-        LOG.warning("route command failed to run (%s): %s", " ".join(cmd), e)
-        return None
-
+# ---- /sbin/route helpers (stateless; wrap syscmd.run; shared by both reconcilers) ----
 
 def _route(command, dest, gateway=None):
     """Issue a `/sbin/route` command (best effort). The caller confirms the
@@ -190,7 +177,7 @@ def _route(command, dest, gateway=None):
     cmd = [_ROUTE, _NUMERIC, command, _AF_INET, dest]
     if gateway is not None:
         cmd.append(gateway)
-    res = _run(cmd)
+    res = run(cmd)
     if res is not None and res.returncode != 0:
         LOG.debug("route %s %s exit %d: %s", command, dest, res.returncode,
                   (res.stderr or "").strip())
@@ -478,7 +465,7 @@ class DefaultRouteReconciler:
         -- the common, quiet steady state on a backup -- rather than an error; a
         genuinely stuck route op is surfaced by the install/withdraw confirm, not
         by second-guessing this read."""
-        res = _run([_ROUTE, _NUMERIC, RouteCommand.GET, _AF_INET, _DEFAULT])
+        res = run([_ROUTE, _NUMERIC, RouteCommand.GET, _AF_INET, _DEFAULT])
         if res is None or res.returncode != 0:
             return None
         for line in res.stdout.splitlines():
@@ -655,7 +642,7 @@ class BackupEgressReconciler:
         not active locally, so it resolves via the real interface, not lo0 -- the
         recommended VIP gateway is not caught. Never cached: a transient route-get failure
         must not permanently disable the guard, so the caller defers on None and re-checks."""
-        res = _run([_ROUTE, _NUMERIC, RouteCommand.GET, _AF_INET, gateway])
+        res = run([_ROUTE, _NUMERIC, RouteCommand.GET, _AF_INET, gateway])
         if res is None or res.returncode != 0:
             return None   # could not determine -> caller defers rather than routing blind
         for line in res.stdout.splitlines():
@@ -685,7 +672,7 @@ class BackupEgressReconciler:
     def _iface_ipv4(self, iface):
         """(address, prefixlen) of the first IPv4 on `iface`, or None. Parses
         `ifconfig <iface> inet` ('inet A netmask 0xMMMMMMMM ...')."""
-        res = _run([_IFCONFIG, iface, "inet"])
+        res = run([_IFCONFIG, iface, "inet"])
         if res is None or res.returncode != 0:
             return None
         toks = res.stdout.split()
@@ -855,7 +842,7 @@ class BackupEgressReconciler:
         the table cannot be read -- callers must not mistake an unreadable table for 'no
         routes' and skip the master-side removal. A bare host address parses as /32;
         header and default rows that are not a network are skipped."""
-        res = _run([_NETSTAT, "-rn", "-f", "inet"])
+        res = run([_NETSTAT, "-rn", "-f", "inet"])
         if res is None or res.returncode != 0:
             if not self._warn.fib_unreadable:   # once per unreadable episode (re-armed below)
                 # Neutral wording: on install this defers the write, but on the master

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/syscmd.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/syscmd.py
@@ -1,0 +1,64 @@
+"""One place the lease keeper runs system commands.
+
+Every shell-out goes through here, argv only -- never a shell, so there is no
+injection surface -- in one of two named shapes:
+
+  * run() -- synchronous (route / netstat / ifconfig / sysctl): wait, capture
+    output, bounded by a timeout; a failure to LAUNCH returns None rather than
+    raising, so callers branch on None. A non-zero exit is not a launch failure:
+    run() still returns the CompletedProcess so the caller reads the code/output.
+  * spawn() -- fire-and-forget (the configctl dispatch that restarts this very
+    daemon): return at once, no wait, detached; a launch failure RAISES so the
+    caller keeps its retry policy.
+
+The raw /dev/bpf capture/inject (capture_bpf: ioctl + os.read/write) is the one
+system boundary not funnelled here: it is packet IO, not a command, and lives in
+BpfCapture.
+"""
+import logging
+import subprocess
+
+from .constants import LOGGER_NAME
+
+LOG = logging.getLogger(LOGGER_NAME)
+SUBPROC_TIMEOUT = 5
+
+
+def run(cmd, *, timeout=SUBPROC_TIMEOUT, quiet=False):
+    """Run argv `cmd`, capturing output, bounded by `timeout`; return the
+    CompletedProcess, or None if it could not be executed at all. A launch
+    failure is logged at WARNING unless `quiet` -- the per-tick ifconfig probes
+    keep their own throttled, warn-once error policy and want silence here.
+    text=True (implied by errors= but stated) so stdout/stderr are str."""
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, errors="replace",
+                              timeout=timeout, check=False)
+    except (OSError, subprocess.SubprocessError) as e:
+        if not quiet:
+            LOG.warning("command failed to run (%s): %s", " ".join(cmd), e)
+        return None
+
+
+def spawn(cmd):
+    """Launch argv `cmd` fire-and-forget: return immediately, do not wait, capture
+    nothing. For a command that will outlive or REPLACE this process -- the
+    configctl follow_update restarts the daemon -- where run() (which waits) would
+    block until we are killed. Detached into its own session (start_new_session)
+    so our own restart/termination cannot race-kill the in-flight child, with all
+    stdio to /dev/null so nothing leaks into the daemon's log as it is torn down.
+    A launch failure PROPAGATES (Popen raises -- OSError on fork/exec failure,
+    ValueError on invalid argv -- and spawn does not catch it), unlike run's None:
+    the caller owns the retry policy, because a follow that could not be dispatched
+    must be re-driven, not silently marked done."""
+    subprocess.Popen(cmd, stdin=subprocess.DEVNULL,  # pylint: disable=consider-using-with
+                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                     start_new_session=True)
+
+
+def ifconfig(iface=None, *, quiet=True):
+    """`ifconfig [iface]` stdout, or None if it could not run or exited non-zero.
+    Quiet by default: the callers (CARP-role probe, CARP-state map) each apply
+    their own error policy, and the caller parses the field it needs -- the CARP
+    line, the inet address -- from the text."""
+    res = run(["/sbin/ifconfig"] + ([iface] if iface else []), quiet=quiet)
+    return res.stdout if res is not None and res.returncode == 0 else None

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
@@ -14,11 +14,11 @@ The heartbeat file is written by lease_keeper.py in one of two forms:
 import json
 import os
 import re
-import subprocess
 import time
 import xml.etree.ElementTree as ET
 
 from keeperconf import CONFFILE, keeper_id, keeper_records
+from leasekeeper.syscmd import ifconfig, run
 
 CONFIG_XML = "/conf/config.xml"
 RUN_DIR = "/var/run"
@@ -125,12 +125,9 @@ def parse_heartbeat(path):
 def carp_states():
     """Map vhid -> live CARP role (MASTER/BACKUP/INIT) from ifconfig."""
     states = {}
-    try:
-        out = subprocess.check_output(["/sbin/ifconfig"], errors="replace")
-    except (OSError, subprocess.SubprocessError):
+    out = ifconfig()
+    if out is None:
         return states
-    if isinstance(out, bytes):
-        out = out.decode(errors="replace")
     for match in re.finditer(r"carp:\s+(\w+)\s+vhid\s+(\d+)", out):
         states[match.group(2)] = match.group(1)
     return states
@@ -193,10 +190,12 @@ def read_keepers(states, names, conffile=CONFFILE, run_dir=RUN_DIR):
 
 def carp_demotion():
     """The kernel CARP demotion counter, or None when unreadable."""
+    res = run(["/sbin/sysctl", "-n", "net.inet.carp.demotion"], quiet=True)
+    if res is None or res.returncode != 0:
+        return None
     try:
-        out = subprocess.check_output(["/sbin/sysctl", "-n", "net.inet.carp.demotion"])
-        return int(out.strip())
-    except (OSError, ValueError, subprocess.SubprocessError):
+        return int(res.stdout.strip())
+    except ValueError:
         return None
 
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -187,21 +187,24 @@ def _link_keeper(lk):
     return _keeper(lk)
 
 
+def _ifc(monkeypatch, lk, text):
+    # Stub the shared syscmd.run (via subprocess.run) with one ifconfig text output.
+    monkeypatch.setattr(lk.subprocess, "run",
+                        lambda *a, **kw: types.SimpleNamespace(returncode=0, stdout=text))
+
+
 def test_iface_link_up_parsing(lk, monkeypatch):
     k = _link_keeper(lk)
-    monkeypatch.setattr(lk.subprocess, "check_output",
-                        lambda *a, **kw: "igc1: flags=...\n\tstatus: active\n")
+    _ifc(monkeypatch, lk, "igc1: flags=...\n\tstatus: active\n")
     assert k._iface_link_up() is True
-    monkeypatch.setattr(lk.subprocess, "check_output",
-                        lambda *a, **kw: "igc1: flags=...\n\tstatus: no carrier\n")
+    _ifc(monkeypatch, lk, "igc1: flags=...\n\tstatus: no carrier\n")
     assert k._iface_link_up() is False
-    monkeypatch.setattr(lk.subprocess, "check_output",
-                        lambda *a, **kw: "igc1: flags=...\n\t(no status line)\n")
+    _ifc(monkeypatch, lk, "igc1: flags=...\n\t(no status line)\n")
     assert k._iface_link_up() is None
 
     def boom(*a, **kw):
         raise OSError("iface gone")
-    monkeypatch.setattr(lk.subprocess, "check_output", boom)
+    monkeypatch.setattr(lk.subprocess, "run", boom)
     assert k._iface_link_up() is None
 
 
@@ -303,7 +306,13 @@ def _follow_keeper(lk, tmp_path):
     keeper._dhcp.binding.server = "100.64.4.1"
     keeper._dhcp.binding.yiaddr = "100.64.4.7"
     keeper.fired = []
-    keeper._follow._follow_update = keeper.fired.append
+
+    # Record the dispatched address and report success (True), matching the real
+    # _follow_update's bool contract that on_changed_address now branches on.
+    def _rec_follow_update(ip):
+        keeper.fired.append(ip)
+        return True
+    keeper._follow._follow_update = _rec_follow_update
     keeper._follow._hb_mismatch = lambda got, want: None
     keeper._dhcp.release = lambda *a: None
     return keeper
@@ -647,6 +656,107 @@ def test_dispatch_follow_update_builds_configctl_command(lk, monkeypatch):
     assert calls[1][-3:] == ["100.64.4.1", "203.0.113.1", "24"]   # gw args appended
 
 
+def test_follow_deferred_when_dispatch_launch_fails(lk, tmp_path, monkeypatch):
+    # END-TO-END through the REAL seam (keeper._dispatch_follow_update ->
+    # syscmd.spawn -> subprocess.Popen): if configctl cannot even be launched, the
+    # follow must be DEFERRED, not lost. The daemon must not advance the target or
+    # adopt the binding, or it would strand itself on the new address with the CARP
+    # VIP config still on the old one and no way to re-fire. The next renewal (with
+    # a working launch) then completes the follow. This is the outcome the whole
+    # spawn-raises contract exists for -- not just that _dispatch_follow_update
+    # propagates the OSError, but that FollowPolicy turns it into a retry.
+    keeper = _keeper(lk, follow=True)
+    keeper._follow._state_file = str(tmp_path / "follow_state")   # REAL throttle, tmp-backed
+    keeper._dhcp.binding.server = "100.64.4.1"
+    keeper._dhcp.binding.yiaddr = "100.64.4.7"
+
+    launched = []
+
+    def boom(cmd, *_a, **_k):
+        launched.append(cmd)
+        raise OSError("fork/exec failed")
+    monkeypatch.setattr(lk.subprocess, "Popen", boom)
+
+    assert keeper._follow.on_changed_address(
+        "100.64.4.60", _ack(lk, "100.64.4.60"), "DORA", True) is False   # deferred
+    assert launched                                        # the real Popen seam was reached
+    assert keeper._follow.target == "100.64.4.7"           # target NOT advanced
+    assert keeper._dhcp.binding.yiaddr == "100.64.4.7"     # binding NOT adopted
+    assert keeper._follow._attempt.followed_ip is None     # not latched -> watchdog stays inert
+    # The failed dispatch must NOT arm the follow throttle, or it would delay its
+    # own retry by MIN_FOLLOW_INTERVAL. With the real throttle in place, the
+    # immediate retry below only completes if the throttle was left disarmed.
+    assert keeper._follow._last_follow_time() == 0.0
+
+    ok = []
+    monkeypatch.setattr(lk.subprocess, "Popen", lambda cmd, *a, **k: ok.append(cmd))
+    assert keeper._follow.on_changed_address(
+        "100.64.4.60", _ack(lk, "100.64.4.60"), "DORA", True) is True    # prompt retry completes it
+    assert ok and ok[0][4:6] == ["100.64.4.7", "100.64.4.60"]   # dispatched old -> new
+    assert keeper._follow.target == "100.64.4.60"          # now advanced
+    assert keeper._dhcp.binding.yiaddr == "100.64.4.60"
+    assert keeper._follow._last_follow_time() > 0.0        # a real follow DID arm the throttle
+
+
+def test_watchdog_redrives_stalled_follow(lk, tmp_path, monkeypatch):
+    # The second re-drive mechanism: a follow that WAS dispatched but whose service
+    # restart never replaced us (still alive past FOLLOW_RETRY_DEADLINE) is
+    # re-dispatched through the real seam. Guarded by followed_ip + follow_from.
+    keeper = _keeper(lk, follow=True)
+    keeper._follow._state_file = str(tmp_path / "follow_state")
+    calls = []
+    monkeypatch.setattr(lk.subprocess, "Popen", lambda cmd, *a, **k: calls.append(cmd))
+    att = keeper._follow._attempt
+    att.follow_from = "100.64.4.7"
+    att.followed_ip = "100.64.4.60"
+    att.fired_at = 0.0                                     # long past the retry deadline
+    keeper._follow.watchdog()
+    assert calls and calls[0][:4] == ["/usr/local/sbin/configctl", "-d", "carpvipdhcp", "follow_update"]
+    assert calls[0][4:6] == ["100.64.4.7", "100.64.4.60"]   # re-driven old -> new
+
+
+def test_watchdog_waits_within_deadline(lk, tmp_path, monkeypatch):
+    # A dispatched follow that is still WITHIN FOLLOW_RETRY_DEADLINE must be left
+    # alone: re-driving early would restart the daemon every maintain tick. This is
+    # the negative of test_watchdog_redrives_stalled_follow.
+    keeper = _keeper(lk, follow=True)
+    keeper._follow._state_file = str(tmp_path / "follow_state")
+    calls = []
+    monkeypatch.setattr(lk.subprocess, "Popen", lambda cmd, *a, **k: calls.append(cmd))
+    att = keeper._follow._attempt
+    att.follow_from = "100.64.4.7"
+    att.followed_ip = "100.64.4.60"
+    att.fired_at = time.time()                             # just fired -> inside the deadline
+    keeper._follow.watchdog()
+    assert not calls                                       # no premature re-drive
+
+
+def test_watchdog_inert_without_dispatched_follow(lk, tmp_path, monkeypatch):
+    # The guard: with no dispatched follow in flight (fresh _attempt, followed_ip
+    # None -- e.g. after a launch failure), the watchdog must not fire anything.
+    keeper = _keeper(lk, follow=True)
+    keeper._follow._state_file = str(tmp_path / "follow_state")
+    calls = []
+    monkeypatch.setattr(lk.subprocess, "Popen", lambda cmd, *a, **k: calls.append(cmd))
+    keeper._follow.watchdog()                              # fresh _attempt
+    assert not calls
+
+
+def test_follow_update_idempotent_for_same_address(lk, tmp_path, monkeypatch):
+    # _follow_update's guard: once we have asked configd for an address, asking
+    # again returns True WITHOUT a second dispatch/restart (the watchdog owns retry
+    # via _fire_follow_update, which bypasses this guard).
+    keeper = _keeper(lk, follow=True)
+    keeper._follow._state_file = str(tmp_path / "follow_state")
+    keeper._follow.target = "100.64.4.7"
+    calls = []
+    monkeypatch.setattr(lk.subprocess, "Popen", lambda cmd, *a, **k: calls.append(cmd))
+    assert keeper._follow._follow_update("100.64.4.60") is True   # dispatched once
+    assert len(calls) == 1
+    assert keeper._follow._follow_update("100.64.4.60") is True   # already asked -> no 2nd dispatch
+    assert len(calls) == 1
+
+
 def test_nudge_interval_floor(lk):
     keeper = _keeper(lk, arp_nudge=1)
     assert keeper._nudge.interval == lk.ARP_NUDGE_MIN
@@ -703,7 +813,7 @@ def test_probe_failure_skips_nudge(lk, monkeypatch):
 
     def boom(*a, **k):
         raise OSError("ifconfig unavailable")
-    monkeypatch.setattr(lk.subprocess, "check_output", boom)
+    monkeypatch.setattr(lk.subprocess, "run", boom)
     assert keeper._probe_carp_master() is None
     keeper._arp_nudge(force=True)
     assert keeper._nudge.last_nudge == 0.0
@@ -719,8 +829,8 @@ def test_ifconfig_probe_failure_warns_once_then_logs_recovery(lk, monkeypatch, c
     def flaky(*_a, **_k):
         if calls["fail"]:
             raise OSError("ifconfig unavailable")
-        return "\tcarp: MASTER vhid 199 advbase 1\n\tstatus: active\n"
-    monkeypatch.setattr(lk.subprocess, "check_output", flaky)
+        return types.SimpleNamespace(returncode=0, stdout="\tcarp: MASTER vhid 199 advbase 1\n\tstatus: active\n")
+    monkeypatch.setattr(lk.subprocess, "run", flaky)
 
     with caplog.at_level("INFO", logger="lease-keeper"):
         assert keeper._ifconfig() is None      # first failure
@@ -1351,13 +1461,12 @@ def test_carp_master_vhid_is_word_bounded(lk):
 def test_carp_master_standalone_probes_via_ifconfig(lk, monkeypatch):
     # carp_master(iface, vhid) runs ifconfig itself (no Keeper) and applies the same
     # decision; a probe failure reads as None.
-    monkeypatch.setattr(lk.subprocess, "check_output",
-                        lambda *_a, **_k: b"\tcarp: MASTER vhid 199 advbase 1 advskew 0\n")
+    _ifc(monkeypatch, lk, "\tcarp: MASTER vhid 199 advbase 1 advskew 0\n")
     assert lk.carp_master("lagg1", "199") is True
 
     def boom(*_a, **_k):
         raise OSError("no ifconfig")
-    monkeypatch.setattr(lk.subprocess, "check_output", boom)
+    monkeypatch.setattr(lk.subprocess, "run", boom)
     assert lk.carp_master("lagg1", "199") is None
 
 

--- a/net/os-carp-vip-dhcp/tests/test_status.py
+++ b/net/os-carp-vip-dhcp/tests/test_status.py
@@ -1,8 +1,10 @@
 """Unit tests for status.py heartbeat / keeper-id parsing (comments over docstrings)."""
 # pylint: disable=missing-function-docstring
 import time
+import types
 
 import status  # sys.path via conftest  # type: ignore
+from leasekeeper import syscmd  # status runs commands through it  # type: ignore
 
 
 def test_keeper_id():
@@ -100,3 +102,66 @@ def test_read_keepers_arp_confirmed_fresh_and_stale(tmp_path):
     assert by_ip["100.64.4.7"]["arp_confirmed"] is True
     assert by_ip["100.64.4.8"]["arp_confirmed"] is False
     assert by_ip["100.64.4.9"]["arp_confirmed"] is False
+
+
+# ---- carp_states / carp_demotion: the two functions that shell out via syscmd.
+# Stub subprocess.run (what syscmd calls) so the real syscmd layer is exercised.
+
+def test_carp_states_maps_vhid_to_role(monkeypatch):
+    text = ("em0: flags=8843\n\tcarp: MASTER vhid 149 advbase 1 advskew 0\n"
+            "em1: flags=8843\n\tcarp: BACKUP vhid 20 advbase 1 advskew 100\n")
+    monkeypatch.setattr(syscmd.subprocess, "run",
+                        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout=text))
+    assert status.carp_states() == {"149": "MASTER", "20": "BACKUP"}
+
+
+def test_carp_states_empty_when_ifconfig_unavailable(monkeypatch):
+    # ifconfig probe fails -> syscmd.ifconfig returns None -> no roles, not a crash.
+    def boom(*_a, **_k):
+        raise OSError("no ifconfig")
+    monkeypatch.setattr(syscmd.subprocess, "run", boom)
+    assert not status.carp_states()
+
+
+def test_carp_demotion_parses_counter(monkeypatch):
+    monkeypatch.setattr(syscmd.subprocess, "run",
+                        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="2\n"))
+    assert status.carp_demotion() == 2
+
+
+def test_carp_demotion_none_on_nonzero_exit(monkeypatch):
+    monkeypatch.setattr(syscmd.subprocess, "run",
+                        lambda *a, **k: types.SimpleNamespace(returncode=1, stdout=""))
+    assert status.carp_demotion() is None
+
+
+def test_carp_demotion_none_on_garbled_value(monkeypatch):
+    monkeypatch.setattr(syscmd.subprocess, "run",
+                        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="not-an-int\n"))
+    assert status.carp_demotion() is None
+
+
+def test_carp_demotion_none_on_launch_failure(monkeypatch):
+    # sysctl could not be launched -> syscmd.run returns None -> the `res is None`
+    # guard arm (distinct from the non-zero-exit arm), no AttributeError.
+    def boom(*_a, **_k):
+        raise OSError("no sysctl")
+    monkeypatch.setattr(syscmd.subprocess, "run", boom)
+    assert status.carp_demotion() is None
+
+
+def test_carp_states_includes_init_and_ignores_non_carp(monkeypatch):
+    # INIT is a real role (docstring lists MASTER/BACKUP/INIT); non-CARP lines are skipped.
+    text = ("em0: flags\n\tcarp: INIT vhid 30 advbase 1 advskew 0\n"
+            "em1: flags\n\tstatus: active\n")
+    monkeypatch.setattr(syscmd.subprocess, "run",
+                        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout=text))
+    assert status.carp_states() == {"30": "INIT"}
+
+
+def test_carp_states_empty_when_no_carp_interfaces(monkeypatch):
+    # ifconfig succeeds but the box has no CARP configured -> {} (distinct from the
+    # ifconfig-unavailable case), never a crash.
+    monkeypatch.setattr(syscmd.subprocess, "run",
+                        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="em0: flags\n\tstatus: active\n"))
+    assert not status.carp_states()

--- a/net/os-carp-vip-dhcp/tests/test_syscmd.py
+++ b/net/os-carp-vip-dhcp/tests/test_syscmd.py
@@ -1,0 +1,139 @@
+"""Unit tests for syscmd, the daemon's single system-command boundary.
+
+run() (synchronous, None on launch failure) and spawn() (fire-and-forget, RAISES
+on launch failure) have opposite failure contracts on purpose; the callers depend
+on the difference (route/status branch on None; FollowPolicy re-drives on a raise),
+so both are pinned here alongside the ifconfig() helper. Comments over docstrings.
+"""
+# pylint: disable=missing-function-docstring
+import subprocess
+import types
+
+import pytest
+
+from leasekeeper import syscmd  # sys.path via conftest  # type: ignore
+
+
+def _cp(returncode=0, stdout=""):
+    # Stand-in for subprocess.run's CompletedProcess (only the fields syscmd reads).
+    return types.SimpleNamespace(returncode=returncode, stdout=stdout)
+
+
+def test_run_returns_completedprocess_on_success(monkeypatch):
+    monkeypatch.setattr(syscmd.subprocess, "run", lambda *a, **k: _cp(0, "ok"))
+    res = syscmd.run(["/bin/true"])
+    assert res is not None and res.returncode == 0 and res.stdout == "ok"
+
+
+def test_run_returns_completedprocess_on_nonzero(monkeypatch):
+    # A non-zero exit is NOT a launch failure: the caller still gets the object
+    # so it can read the code and output.
+    monkeypatch.setattr(syscmd.subprocess, "run", lambda *a, **k: _cp(1, "boom"))
+    res = syscmd.run(["/bin/false"])
+    assert res is not None and res.returncode == 1
+
+
+def test_run_returns_none_on_launch_failure_and_warns(monkeypatch, caplog):
+    def boom(*_a, **_k):
+        raise OSError("no such binary")
+    monkeypatch.setattr(syscmd.subprocess, "run", boom)
+    with caplog.at_level("WARNING", logger=syscmd.LOG.name):
+        assert syscmd.run(["/nope"]) is None
+    assert any("command failed to run" in r.getMessage() for r in caplog.records)
+
+
+def test_run_none_on_timeout(monkeypatch):
+    def boom(*_a, **_k):
+        raise subprocess.TimeoutExpired(cmd="x", timeout=5)
+    monkeypatch.setattr(syscmd.subprocess, "run", boom)
+    assert syscmd.run(["/slow"]) is None
+
+
+def test_run_quiet_suppresses_the_warning(monkeypatch, caplog):
+    def boom(*_a, **_k):
+        raise OSError("nope")
+    monkeypatch.setattr(syscmd.subprocess, "run", boom)
+    with caplog.at_level("WARNING", logger=syscmd.LOG.name):
+        assert syscmd.run(["/nope"], quiet=True) is None
+    assert not caplog.records
+
+
+def test_run_arms_timeout_and_captures_text(monkeypatch):
+    # The timeout bound is the anti-hang safety property (a stuck ifconfig/route/
+    # sysctl must not wedge the maintain loop); capture_output + text give callers
+    # str. A regression dropping any of these would otherwise pass every other test.
+    seen = {}
+
+    def capture(cmd, **kw):
+        seen["cmd"] = cmd
+        seen["kw"] = kw
+        return _cp(0, "")
+    monkeypatch.setattr(syscmd.subprocess, "run", capture)
+    syscmd.run(["/sbin/route", "-n", "get", "default"])
+    assert seen["cmd"] == ["/sbin/route", "-n", "get", "default"]
+    assert seen["kw"]["timeout"] == syscmd.SUBPROC_TIMEOUT
+    assert seen["kw"]["capture_output"] is True
+    assert seen["kw"]["text"] is True
+    assert seen["kw"]["check"] is False
+    assert seen["kw"]["errors"] == "replace"   # non-UTF-8 output must not raise into the loop
+    syscmd.run(["/x"], timeout=2)
+    assert seen["kw"]["timeout"] == 2   # caller override is honoured
+
+
+def test_spawn_launches_detached_with_devnull_stdio(monkeypatch):
+    seen = {}
+
+    def fake_popen(cmd, **kw):
+        seen["cmd"] = cmd
+        seen["kw"] = kw
+    monkeypatch.setattr(syscmd.subprocess, "Popen", fake_popen)
+    syscmd.spawn(["/usr/local/sbin/configctl", "x"])
+    assert seen["cmd"] == ["/usr/local/sbin/configctl", "x"]
+    # Detached into its own session, all stdio to /dev/null: the follow dispatch
+    # must survive this daemon's own restart and leak nothing into the log.
+    assert seen["kw"]["start_new_session"] is True
+    assert seen["kw"]["stdin"] == subprocess.DEVNULL
+    assert seen["kw"]["stdout"] == subprocess.DEVNULL
+    assert seen["kw"]["stderr"] == subprocess.DEVNULL
+
+
+def test_spawn_raises_on_launch_failure(monkeypatch):
+    # Unlike run's None, a spawn launch failure RAISES so the caller owns the
+    # retry policy (a follow that could not be dispatched must be re-driven).
+    def boom(*_a, **_k):
+        raise OSError("cannot exec")
+    monkeypatch.setattr(syscmd.subprocess, "Popen", boom)
+    with pytest.raises(OSError):
+        syscmd.spawn(["/nope"])
+
+
+def test_ifconfig_builds_argv(monkeypatch):
+    # No arg -> all interfaces; an iface -> that iface only (the per-interface CARP
+    # probe depends on the passthrough). Every other fake ignores argv, so pin it.
+    seen = {}
+
+    def capture(cmd, **_k):
+        seen["cmd"] = cmd
+        return _cp(0, "out")
+    monkeypatch.setattr(syscmd.subprocess, "run", capture)
+    syscmd.ifconfig()
+    assert seen["cmd"] == ["/sbin/ifconfig"]
+    syscmd.ifconfig("igb0")
+    assert seen["cmd"] == ["/sbin/ifconfig", "igb0"]
+
+
+def test_ifconfig_returns_stdout_on_success(monkeypatch):
+    monkeypatch.setattr(syscmd.subprocess, "run", lambda *a, **k: _cp(0, "igb0: flags\n"))
+    assert syscmd.ifconfig("igb0") == "igb0: flags\n"
+
+
+def test_ifconfig_none_on_nonzero_exit(monkeypatch):
+    monkeypatch.setattr(syscmd.subprocess, "run", lambda *a, **k: _cp(1, ""))
+    assert syscmd.ifconfig("nope0") is None
+
+
+def test_ifconfig_none_on_launch_failure(monkeypatch):
+    def boom(*_a, **_k):
+        raise OSError("no ifconfig")
+    monkeypatch.setattr(syscmd.subprocess, "run", boom)
+    assert syscmd.ifconfig() is None


### PR DESCRIPTION
Behaviour-preserving refactor: give the daemon's system-command execution a single interface, in two named shapes (synchronous and fire-and-forget).

## Why

The daemon's shell-outs were spread across four call sites with four shapes: `route.py` had its own `_run`, `keeper.py` ran `ifconfig` via `subprocess.check_output`, `status.py` ran `ifconfig` + `sysctl` via `check_output`, and `keeper.py` launched the `configctl` follow dispatch with a bare `subprocess.Popen`. `ifconfig` alone was invoked from three places.

## What

New `leasekeeper/syscmd.py`, the single system-command boundary:
- `run(cmd, *, timeout, quiet)` -> `CompletedProcess | None`: synchronous (route / netstat / ifconfig / sysctl), argv only (never a shell, so no injection surface), bounded by a timeout; a failure to *launch* returns `None` rather than raising, so callers branch on `None`. A non-zero exit still returns the `CompletedProcess`. `text=True` so stdout/stderr are `str`.
- `spawn(cmd)`: fire-and-forget for the `configctl follow_update` dispatch, which triggers a service restart that replaces this very daemon. Returns at once (`run` would block until we are killed), detached into its own session so our own restart cannot race-kill the in-flight child, with stdio to `/dev/null`. A launch failure *raises* (unlike `run`'s `None`) so the caller keeps its retry policy: `FollowPolicy` re-drives a follow that could not be dispatched.
- `ifconfig(iface=None, *, quiet=True)`: the one `ifconfig` runner; callers parse the field they need.

Routed through it:
- `route.py`: dropped the local `_run` (+ its timeout constant); `_route` and the FIB reads call `syscmd.run`.
- `keeper.py`: dropped `_ifconfig_text`; the CARP-role helpers call `syscmd.ifconfig`; `_dispatch_follow_update` calls `syscmd.spawn` (was a bare `subprocess.Popen`).
- `status.py`: `carp_states` / `carp_demotion` call `syscmd.ifconfig` / `run`.

The `quiet` flag preserves `keeper`'s silent, warn-once probe policy: the throttled warning stays at the caller, `syscmd` stays quiet (verified by the existing warn-once test).

## Deliberately left out (packet IO, not a command)

The raw `/dev/bpf` capture/inject (`capture_bpf`: `ioctl` + `os.read`/`write`) stays at its own call site. It is packet IO, not a shell-out, so it does not belong behind `run`/`spawn`.

## Also: fix a latent follow re-drive gap (behaviour change)

Making `spawn()`'s raise-on-failure contract explicit surfaced a pre-existing gap in `policy.py`: if the follow dispatch could not even be **launched** (a `configctl` fork/exec failure), `on_changed_address` still advanced `self.target` and adopted the binding, so the daemon believed it held the new address while the CARP VIP config stayed on the old one. Neither re-drive path could recover it: the `watchdog()` is gated on `followed_ip` (left unset by the failed dispatch), and `on_changed_address` could not re-fire because `target` had already advanced. The two HA nodes would silently diverge until a third ISP address or an operator.

Fix: `_follow_update` now returns a bool, and `on_changed_address` **defers** (does not advance the target, does not adopt) on a launch failure, exactly the way the follow throttle above it already does, so the next renewal re-drives. This is a behaviour change confined to the dispatch-launch-failure path; the success path is unchanged.

## Notes / trade-off

- `status.py` (a standalone configd script) now imports `leasekeeper.syscmd`, a light new dependency (`syscmd` pulls only `constants` + stdlib) so the whole plugin shares one exec path.
- After this change `subprocess` is used in exactly one module, `syscmd`.
- `spawn` also hardens the follow dispatch (detached + DEVNULL) over the previous bare `Popen`; that hardening guards a theoretical restart-vs-child race, it is not a fix for a reproduced bug.

## Verification

- 293 tests pass. New `tests/test_syscmd.py` pins the `run` (None / CompletedProcess / timeout-armed / quiet) and `spawn` (detached + DEVNULL + raises) contracts and the `ifconfig` argv; `test_status.py` covers `carp_states`/`carp_demotion` (now via `syscmd`); `test_daemon.py` drives the follow deferral end to end through the real `Popen` seam and adds a `watchdog()` re-drive test. The `ifconfig`/CARP-role probe tests moved from stubbing `check_output` to stubbing `run`.
- coverage held (`syscmd.py` 100%, `status.py` `carp_*` now covered); flake8 clean; pylint 10.00/10 (useless-suppression enabled, exit 0); pyright 0 errors.
- Isolated two-node-clone bench (real OPNsense configd): the real `syscmd.spawn()` drove `follow_update` through configd (the CARP VIP followed and was reapplied on the interface) and completed after the launching python process had already exited, confirming the detached child survives its parent. An A/B against the old bare `Popen` produced the identical outcome, so detach + DEVNULL is behaviour-neutral on the follow path.
- Version bumped to 1.13.3.
