### PR TITLE
Lease-keeper refactor: shared ifprobe parser, renames, and concurrency/log hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ build/
 work/
 dist/
 
+# test / coverage artifacts
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+
 # release signing: never commit a private key
 *.key
 *.sec

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -209,14 +209,14 @@ def _setup_logging(logfile):
 
 def main():
     """CLI entry point: parse args, wire up the Keeper and signals, run."""
-    a = _build_arg_parser().parse_args()
-    _setup_logging(a.logfile)
+    args = _build_arg_parser().parse_args()
+    _setup_logging(args.logfile)
 
     # Validate the two free-string enum args now that logging is up: an unknown
     # value (only reachable via a hand-edited config.xml) falls back to a safe
     # default with a warning instead of crash-looping under daemon(8) -r.
-    a.default_route_mode = DefaultRouteMode.coerce(a.default_route_mode)
-    a.backup_egress_form = BackupEgressForm.coerce(a.backup_egress_form)
+    args.default_route_mode = DefaultRouteMode.coerce(args.default_route_mode)
+    args.backup_egress_form = BackupEgressForm.coerce(args.backup_egress_form)
 
     # Single-instance guard BEFORE any FIB mutation: the startup fail-stop withdraw
     # below deletes a default, so a duplicate start (pidfile held by the live owner)
@@ -224,17 +224,17 @@ def main():
     # and only then discover it is the duplicate. Held across the withdraw and the
     # backend/arg checks; the finally releases it on every exit. --once is a wiring
     # test: no guard and no FIB mutation, so it takes neither (pf stays None).
-    pf = None if a.once else acquire_pidfile(a.pidfile)
+    pf = None if args.once else acquire_pidfile(args.pidfile)
     try:
         # Built before the fail-stop so the startup reconciler can clean the backup-egress
         # routes this feature manages when it is enabled (else a node coming up as master
         # with a stale /1 a crashed predecessor left would loop its egress).
         backup_egress = BackupEgressConfig(
-            enabled=a.backup_egress,
-            form=a.backup_egress_form,
-            gateway=a.backup_egress_gateway or None,
-            interface=a.backup_egress_interface or None,
-            prefixes=_split_prefixes(a.backup_egress_prefixes))
+            enabled=args.backup_egress,
+            form=args.backup_egress_form,
+            gateway=args.backup_egress_gateway or None,
+            interface=args.backup_egress_interface or None,
+            prefixes=_split_prefixes(args.backup_egress_prefixes))
 
         # Fail-stop: a crashed predecessor (backend now missing, or a bad arg) may
         # have left a default in the FIB, still redistributed by FRR. Drop it here --
@@ -242,14 +242,14 @@ def main():
         # arg checks, each of which can return before Keeper.run() would. The gate
         # (a master keeps its default, a backup withdraws; probe only when the mode
         # acts) lives in withdraw_unless_master. Skipped for --once and no vhid.
-        if not a.once and a.vhid:
-            # a.default_route_mode is already coerced (above), so both reconcilers take
+        if not args.once and args.vhid:
+            # args.default_route_mode is already coerced (above), so both reconcilers take
             # it verbatim; the backup set is cleaned before the 0/0 withdraw inside
             # withdraw_unless_master, the one sequence that spans the two reconcilers.
             withdraw_unless_master(
-                DefaultRouteReconciler(a.default_route_mode),
-                BackupEgressReconciler(a.default_route_mode, backup_egress=backup_egress),
-                lambda: carp_master(a.iface, a.vhid))
+                DefaultRouteReconciler(args.default_route_mode),
+                BackupEgressReconciler(args.default_route_mode, backup_egress=backup_egress),
+                lambda: carp_master(args.iface, args.vhid))
 
         # Fail fast (with a logged reason) if the raw /dev/bpf backend cannot run
         # on this host (e.g. fcntl missing off FreeBSD).
@@ -258,33 +258,33 @@ def main():
             LOG.critical("capture backend cannot run: %s -- the lease keeper cannot start", reason)
             return 3
 
-        for label, mac in (("chaddr", a.chaddr), ("eth-src", a.eth_src)):
+        for label, mac in (("chaddr", args.chaddr), ("eth-src", args.eth_src)):
             if mac and not MAC_RE.match(mac):
                 LOG.critical("invalid %s MAC address %r -- the lease keeper cannot start", label, mac)
                 return 2
 
-        k = Keeper(a.iface, a.chaddr, a.request, a.eth_src,
-                   hbfile=a.hbfile, release_on_exit=a.release_on_exit or a.once,
-                   vhid=a.vhid, follow=a.follow,
-                   vendor_class=a.vendor_class, client_id=a.client_id, hostname=a.hostname,
-                   arp_nudge=a.arp_nudge, arp_listen_promisc=a.arp_listen_promisc,
-                   default_route_mode=a.default_route_mode,
-                   backup_egress=backup_egress)
+        keeper = Keeper(args.iface, args.chaddr, args.request, args.eth_src,
+                        hbfile=args.hbfile, release_on_exit=args.release_on_exit or args.once,
+                        vhid=args.vhid, follow=args.follow,
+                        vendor_class=args.vendor_class, client_id=args.client_id, hostname=args.hostname,
+                        arp_nudge=args.arp_nudge, arp_listen_promisc=args.arp_listen_promisc,
+                        default_route_mode=args.default_route_mode,
+                        backup_egress=backup_egress)
 
         # Warn only when promiscuous capture is ACTUALLY in effect: it is gated on the ARP
         # nudge (see Keeper.__init__), so a stale flag with the nudge disabled is ignored,
         # not promiscuous -- warning off the raw flag would contradict that and misstate the
         # node's security posture.
-        if a.arp_listen_promisc and a.arp_nudge > 0:
+        if args.arp_listen_promisc and args.arp_nudge > 0:
             LOG.warning("ARP listen: PROMISCUOUS capture enabled on %s -- the daemon now "
                         "sees all traffic on the segment (opt-in fallback for NICs that "
-                        "drop the gateway's unicast ARP reply otherwise)", a.iface)
+                        "drop the gateway's unicast ARP reply otherwise)", args.iface)
 
         def _sig(*_):
             # Flag only -- no logging or other non-async-signal-safe work in the
             # handler (like the SIGUSR1/2 handlers below). set_wakeup_fd wakes the
             # loop at once; run() logs "stopped" when it exits.
-            k.request_stop()
+            keeper.request_stop()
         signal.signal(signal.SIGINT, _sig)
         signal.signal(signal.SIGTERM, _sig)
 
@@ -293,24 +293,24 @@ def main():
         # suppression that is then flagged as useless where the attributes do exist.
         def _sig_arp_nudge(*_):
             # Operator-requested immediate ARP nudge (configd action / kill -USR1).
-            k.trigger_nudge()
+            keeper.trigger_nudge()
         signal.signal(getattr(signal, "SIGUSR1"), _sig_arp_nudge)
 
         def _sig_carp(*_):
             # CARP transition (rc.syshook.d/carp/50-carpvipdhcp sends SIGUSR2).
-            k.recheck_carp_role()
+            keeper.recheck_carp_role()
         signal.signal(getattr(signal, "SIGUSR2"), _sig_carp)
 
-        if a.once:
-            return k.claim_once()
+        if args.once:
+            return keeper.claim_once()
 
         # Wake the maintain-loop sleep the instant a signal is delivered: Python's
         # C-level signal machinery writes the signal number to this fd, which is
         # async-signal-safe and needs no work in the handler (the _sig* handlers
         # above only set a flag). The loop selects on the read end and drains it.
-        signal.set_wakeup_fd(k.wake_fileno())
+        signal.set_wakeup_fd(keeper.wake_fileno())
         try:
-            return k.run()
+            return keeper.run()
         finally:
             # Stop the C-level signal machinery from writing to the wake socket
             # before run() closes it; otherwise a signal in the shutdown window

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -302,7 +302,13 @@ def main():
         signal.signal(getattr(signal, "SIGUSR2"), _sig_carp)
 
         if args.once:
-            return keeper.claim_once()
+            # --once does not arm set_wakeup_fd, but the Keeper still opened its wake
+            # socketpair in __init__, so close it here too -- otherwise a repeated
+            # in-process main(--once) leaks two fds per call.
+            try:
+                return keeper.claim_once()
+            finally:
+                keeper.close()
 
         # Wake the maintain-loop sleep the instant a signal is delivered: Python's
         # C-level signal machinery writes the signal number to this fd, which is

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -312,10 +312,13 @@ def main():
         try:
             return keeper.run()
         finally:
-            # Stop the C-level signal machinery from writing to the wake socket
-            # before run() closes it; otherwise a signal in the shutdown window
-            # writes to a closed fd (harmless, but noisy on stderr).
+            # Order matters: unregister the C-level signal wakeup fd BEFORE
+            # closing the wake socket it points at. Otherwise a signal in the
+            # shutdown window makes the C machinery write to a closed (or, in the
+            # worst case, a reused) fd. keeper.close() therefore runs only after
+            # set_wakeup_fd(-1).
             signal.set_wakeup_fd(-1)
+            keeper.close()
     finally:
         if pf and os.path.exists(pf):
             try:

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/lease_keeper.py
@@ -271,59 +271,59 @@ def main():
                         default_route_mode=args.default_route_mode,
                         backup_egress=backup_egress)
 
-        # Warn only when promiscuous capture is ACTUALLY in effect: it is gated on the ARP
-        # nudge (see Keeper.__init__), so a stale flag with the nudge disabled is ignored,
-        # not promiscuous -- warning off the raw flag would contradict that and misstate the
-        # node's security posture.
-        if args.arp_listen_promisc and args.arp_nudge > 0:
-            LOG.warning("ARP listen: PROMISCUOUS capture enabled on %s -- the daemon now "
-                        "sees all traffic on the segment (opt-in fallback for NICs that "
-                        "drop the gateway's unicast ARP reply otherwise)", args.iface)
-
-        def _sig(*_):
-            # Flag only -- no logging or other non-async-signal-safe work in the
-            # handler (like the SIGUSR1/2 handlers below). set_wakeup_fd wakes the
-            # loop at once; run() logs "stopped" when it exits.
-            keeper.request_stop()
-        signal.signal(signal.SIGINT, _sig)
-        signal.signal(signal.SIGTERM, _sig)
-
-        # SIGUSR1/SIGUSR2 are POSIX-only (the daemon runs on FreeBSD); access them
-        # dynamically so a non-POSIX static-analysis host neither errors nor needs a
-        # suppression that is then flagged as useless where the attributes do exist.
-        def _sig_arp_nudge(*_):
-            # Operator-requested immediate ARP nudge (configd action / kill -USR1).
-            keeper.trigger_nudge()
-        signal.signal(getattr(signal, "SIGUSR1"), _sig_arp_nudge)
-
-        def _sig_carp(*_):
-            # CARP transition (rc.syshook.d/carp/50-carpvipdhcp sends SIGUSR2).
-            keeper.recheck_carp_role()
-        signal.signal(getattr(signal, "SIGUSR2"), _sig_carp)
-
-        if args.once:
-            # --once does not arm set_wakeup_fd, but the Keeper still opened its wake
-            # socketpair in __init__, so close it here too -- otherwise a repeated
-            # in-process main(--once) leaks two fds per call.
-            try:
-                return keeper.claim_once()
-            finally:
-                keeper.close()
-
-        # Wake the maintain-loop sleep the instant a signal is delivered: Python's
-        # C-level signal machinery writes the signal number to this fd, which is
-        # async-signal-safe and needs no work in the handler (the _sig* handlers
-        # above only set a flag). The loop selects on the read end and drains it.
-        signal.set_wakeup_fd(keeper.wake_fileno())
+        # The Keeper is constructed, so its wake socketpair is now open: guarantee
+        # keeper.close() on EVERY path from here -- the --once return, a normal run,
+        # or an exception during signal setup -- via one outer finally, not a
+        # per-path close. Otherwise a path that skips it leaks the socketpair (a
+        # repeated in-process main() would leak two fds per call).
         try:
-            return keeper.run()
+            # Warn only when promiscuous capture is ACTUALLY in effect: it is gated on the ARP
+            # nudge (see Keeper.__init__), so a stale flag with the nudge disabled is ignored,
+            # not promiscuous -- warning off the raw flag would contradict that and misstate the
+            # node's security posture.
+            if args.arp_listen_promisc and args.arp_nudge > 0:
+                LOG.warning("ARP listen: PROMISCUOUS capture enabled on %s -- the daemon now "
+                            "sees all traffic on the segment (opt-in fallback for NICs that "
+                            "drop the gateway's unicast ARP reply otherwise)", args.iface)
+
+            def _sig(*_):
+                # Flag only -- no logging or other non-async-signal-safe work in the
+                # handler (like the SIGUSR1/2 handlers below). set_wakeup_fd wakes the
+                # loop at once; run() logs "stopped" when it exits.
+                keeper.request_stop()
+            signal.signal(signal.SIGINT, _sig)
+            signal.signal(signal.SIGTERM, _sig)
+
+            # SIGUSR1/SIGUSR2 are POSIX-only (the daemon runs on FreeBSD); access them
+            # dynamically so a non-POSIX static-analysis host neither errors nor needs a
+            # suppression that is then flagged as useless where the attributes do exist.
+            def _sig_arp_nudge(*_):
+                # Operator-requested immediate ARP nudge (configd action / kill -USR1).
+                keeper.trigger_nudge()
+            signal.signal(getattr(signal, "SIGUSR1"), _sig_arp_nudge)
+
+            def _sig_carp(*_):
+                # CARP transition (rc.syshook.d/carp/50-carpvipdhcp sends SIGUSR2).
+                keeper.recheck_carp_role()
+            signal.signal(getattr(signal, "SIGUSR2"), _sig_carp)
+
+            if args.once:
+                return keeper.claim_once()   # --once never arms set_wakeup_fd; outer finally closes
+
+            # Wake the maintain-loop sleep the instant a signal is delivered: Python's
+            # C-level signal machinery writes the signal number to this fd, which is
+            # async-signal-safe and needs no work in the handler (the _sig* handlers
+            # above only set a flag). The loop selects on the read end and drains it.
+            signal.set_wakeup_fd(keeper.wake_fileno())
+            try:
+                return keeper.run()
+            finally:
+                # Order matters: unregister the C-level signal wakeup fd BEFORE the
+                # outer finally closes the wake socket it points at. Otherwise a signal
+                # in the shutdown window makes the C machinery write to a closed (or, in
+                # the worst case, a reused) fd. This inner finally runs first.
+                signal.set_wakeup_fd(-1)
         finally:
-            # Order matters: unregister the C-level signal wakeup fd BEFORE
-            # closing the wake socket it points at. Otherwise a signal in the
-            # shutdown window makes the C machinery write to a closed (or, in the
-            # worst case, a reused) fd. keeper.close() therefore runs only after
-            # set_wakeup_fd(-1).
-            signal.set_wakeup_fd(-1)
             keeper.close()
     finally:
         if pf and os.path.exists(pf):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
@@ -18,4 +18,4 @@ wires up and runs the Keeper defined here. Modules, leaf-first:
 # PLUGIN_VERSION from this line (so the package version and the daemon's own
 # reported version can never drift). Keep the assignment on one line as
 # __version__ = "X.Y.Z" so the Makefile's sed can read it.
-__version__ = "1.13.3"
+__version__ = "1.13.4"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/__init__.py
@@ -18,4 +18,4 @@ wires up and runs the Keeper defined here. Modules, leaf-first:
 # PLUGIN_VERSION from this line (so the package version and the daemon's own
 # reported version can never drift). Keep the assignment on one line as
 # __version__ = "X.Y.Z" so the Makefile's sed can read it.
-__version__ = "1.13.4"
+__version__ = "1.13.5"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/capture_bpf.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/capture_bpf.py
@@ -42,10 +42,11 @@ except ImportError:
 
 @dataclass
 class _ReaderGeneration:
-    """One reader generation (one start()): the bpf fd, the reader thread, its
-    stop signal, and the write end of its wake pipe. start() installs the whole
-    generation and stop() clears it as a unit; a reader that outlives its stop()
-    keeps its own fd/wake_reader copies, so nothing here is reused under it."""
+    """One reader generation (one start()): the bpf fd, the reader thread, its stop
+    signal, and the write end of its wake pipe. start() installs the whole generation
+    and stop() clears it as a unit; a reader that outlives its stop() keeps its own
+    fd/wake_reader copies (and its read size, a thread arg -- see BpfCapture), so
+    nothing here is reused under it."""
     fd: int
     thread: threading.Thread
     stop_event: threading.Event
@@ -63,14 +64,17 @@ class BpfCapture:
     stop latency). The stop signal and the wake pipe are created fresh per
     start(), and the reader owns and closes its own bpf fd on exit, so a reader
     that outlives its stop() (e.g. stalled in a slow log write) can neither be
-    revived by the next start() nor have its fd number reused underneath it."""
+    revived by the next start() nor have its fd number reused underneath it.
+    Every per-generation input the reader needs -- fd, wake pipe, stop signal
+    AND the bpf read size -- is handed to it as a thread argument, never read
+    back off the shared instance, so a concurrent restart's _configure cannot
+    disturb a still-running old reader."""
 
     def __init__(self, iface, promisc, on_bootp, on_arp):
         self.iface = iface
         self.promisc = promisc
         self._on_bootp = on_bootp
         self._on_arp = on_arp
-        self._buflen = 0               # kernel buffer size, from BIOCGBLEN in _configure
         self._gen = None               # the current _ReaderGeneration, or None when stopped
         # Throttle the untrusted-input parse-error line: a malformed/spoof storm
         # must not churn the log (DEBUG still hits disk regardless of the view).
@@ -102,7 +106,7 @@ class BpfCapture:
             LOG.error("bpf open /dev/bpf failed (iface %s): %s", self.iface, e)
             return False
         try:
-            self._configure(fd)
+            buflen = self._configure(fd)
         except OSError as e:
             os.close(fd)
             os.close(wake_reader)
@@ -110,16 +114,20 @@ class BpfCapture:
             LOG.error("bpf configure failed on %s: %s", self.iface, e)
             return False
         stop_event = threading.Event()
-        # The reader owns fd and wake_reader and closes them when it exits.
+        # The reader owns fd and wake_reader and closes them when it exits; buflen
+        # rides along as an arg so a later start()'s _configure never rebinds the
+        # read size under a still-running old reader.
         thread = threading.Thread(
-            target=self._read_loop, args=(fd, wake_reader, stop_event),
+            target=self._read_loop, args=(fd, wake_reader, stop_event, buflen),
             name="bpf-capture", daemon=True)
-        self._gen = _ReaderGeneration(fd=fd, thread=thread, stop_event=stop_event, wake_writer=wake_writer)
+        self._gen = _ReaderGeneration(
+            fd=fd, thread=thread, stop_event=stop_event, wake_writer=wake_writer)
         thread.start()
         return True
 
     def _configure(self, fd):
-        """Bind, tune and filter a fresh bpf descriptor.
+        """Bind, tune and filter a fresh bpf descriptor; returns the kernel
+        buffer size (BIOCGBLEN) the reader must request per read(2).
 
         BIOCSETIF (bind) has to come first -- it is what libpcap does and what
         BIOCGDLT needs -- so the filter is attached immediately after, keeping
@@ -152,7 +160,7 @@ class BpfCapture:
         if self.promisc:
             fcntl.ioctl(fd, BIOCPROMISC)
         # bpf read(2) calls must request exactly the kernel buffer size.
-        self._buflen = struct.unpack("I", fcntl.ioctl(fd, BIOCGBLEN, b"\x00" * 4))[0]
+        return struct.unpack("I", fcntl.ioctl(fd, BIOCGBLEN, b"\x00" * 4))[0]
 
     def stop(self):
         """Ask the current reader to exit and wait briefly for it. The reader
@@ -183,11 +191,12 @@ class BpfCapture:
         """True while the descriptor is open and the reader thread runs."""
         return self._gen is not None and self._gen.thread.is_alive()
 
-    def _read_loop(self, fd, wake_reader, stop_event):
+    def _read_loop(self, fd, wake_reader, stop_event, buflen):
         """Reader thread: block in select() on the bpf fd and the wake pipe;
         stop() writes to the pipe to end the wait. Owns fd and wake_reader and
         closes both on exit, so the fd's lifetime ends exactly when this thread
-        does."""
+        does. buflen is this generation's own read size (an arg, not read off the
+        instance), so a concurrent restart cannot change it under us."""
         try:
             while not stop_event.is_set():
                 try:
@@ -197,7 +206,7 @@ class BpfCapture:
                 if wake_reader in readable:      # stop() rang -- loop condition ends us
                     continue
                 try:
-                    data = os.read(fd, self._buflen)
+                    data = os.read(fd, buflen)
                 except (OSError, ValueError):
                     if not stop_event.is_set():
                         LOG.warning("bpf read failed on %s -- capture thread exiting", self.iface)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/capture_bpf.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/capture_bpf.py
@@ -41,7 +41,7 @@ except ImportError:
 
 
 @dataclass
-class _ReaderGen:
+class _ReaderGeneration:
     """One reader generation (one start()): the bpf fd, the reader thread, its
     stop signal, and the write end of its wake pipe. start() installs the whole
     generation and stop() clears it as a unit; a reader that outlives its stop()
@@ -71,7 +71,7 @@ class BpfCapture:
         self._on_bootp = on_bootp
         self._on_arp = on_arp
         self._buflen = 0               # kernel buffer size, from BIOCGBLEN in _configure
-        self._gen = None               # the current _ReaderGen, or None when stopped
+        self._gen = None               # the current _ReaderGeneration, or None when stopped
         # Throttle the untrusted-input parse-error line: a malformed/spoof storm
         # must not churn the log (DEBUG still hits disk regardless of the view).
         self._parse_errs = _RateLimit(PARSE_ERROR_LOG_INTERVAL)
@@ -114,7 +114,7 @@ class BpfCapture:
         thread = threading.Thread(
             target=self._read_loop, args=(fd, wake_reader, stop_event),
             name="bpf-capture", daemon=True)
-        self._gen = _ReaderGen(fd=fd, thread=thread, stop_event=stop_event, wake_writer=wake_writer)
+        self._gen = _ReaderGeneration(fd=fd, thread=thread, stop_event=stop_event, wake_writer=wake_writer)
         thread.start()
         return True
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/constants.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/constants.py
@@ -186,3 +186,11 @@ class Phase(StrEnum):
     RENEW = "RENEW"
     REBIND = "REBIND"
     OBSERVED = "OBSERVED"
+
+
+class TimingSource(StrEnum):
+    """Where the lease timers (T1/T2) came from: the heartbeat 'src' token and the
+    log label. A StrEnum (like Phase) so the member both is its wire token and
+    formats to that token in the heartbeat / log lines status.py parses."""
+    SERVER = "server"     # DHCP option 58/59 supplied them
+    DERIVED = "derived"   # RFC 0.5 / 0.875 of the lease

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
@@ -14,7 +14,8 @@ from .constants import (
     ACK, ATTEMPT_BACKOFF_CAP, BROADCAST_FLAG, DEFAULT_LEASE, DhcpOptName, DORA_ATTEMPTS,
     IPV4_BROADCAST, MIN_LEASE, MIN_T1, NAK, OFFER, Phase, REBIND_MARGIN,
     REBOOT_ATTEMPTS, RENEW_ATTEMPTS,
-    RENEW_TIMEOUT, REPLY_TIMEOUT, SEND_RETRY_DELAY, SendMsgType, T1_FACTOR, T2_FACTOR)
+    RENEW_TIMEOUT, REPLY_TIMEOUT, SEND_RETRY_DELAY, SendMsgType, T1_FACTOR, T2_FACTOR,
+    TimingSource)
 from .util import _jittered, _mask_to_bits, _new_xid, mac2raw
 from .wire import DhcpReply, DhcpSend, _dhcp_options, _fmt_reply, _msg_text
 
@@ -399,5 +400,6 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         if lease > MIN_T1:
             t1 = max(MIN_T1, t1)
         t2 = min(max(t1 + REBIND_MARGIN, t2), lease)
-        src = "server" if (self.binding.t1_server or self.binding.t2_server) else "derived"
+        src = (TimingSource.SERVER if (self.binding.t1_server or self.binding.t2_server)
+               else TimingSource.DERIVED)
         return t1, t2, src

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/dhcpclient.py
@@ -83,14 +83,14 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         self._tried_reboot = False     # the first acquire tries INIT-REBOOT before a full DISCOVER
 
         self._rx = None                # latest DhcpReply snapshot (set via feed(), sniffer thread)
-        self._ev = threading.Event()
+        self._reply_ready = threading.Event()
 
     def feed(self, rx):
         """Hand a first-party (xid-matched) DhcpReply to the waiting sequence.
         Called on the sniffer thread; a lone ref-assign plus the event set."""
         self._rx = rx
         LOG.debug("DHCP reply: %s", _fmt_reply(rx))
-        self._ev.set()
+        self._reply_ready.set()
 
     def _send_dhcp(self, mtype, extra, ciaddr="0.0.0.0"):
         # ciaddr is set for RENEW/REBIND (the client already owns the address);
@@ -109,8 +109,8 @@ class DhcpClient:  # pylint: disable=too-many-instance-attributes
         operator's actual context (which exchange, which address was refused)."""
         end = time.time() + timeout
         while time.time() < end and not self._should_stop():
-            self._ev.clear()
-            self._ev.wait(min(1.0, max(0.05, end - time.time())))
+            self._reply_ready.clear()
+            self._reply_ready.wait(min(1.0, max(0.05, end - time.time())))
 
             rx = self._rx
             if rx and rx.mtype == want:

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/ifprobe.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/ifprobe.py
@@ -61,23 +61,25 @@ def carrier_up(ifconfig_text):
 
 
 def iface_ipv4(ifconfig_text):
-    """(address, prefixlen) of the first IPv4 in `ifconfig <iface> inet` text
-    ('inet A netmask 0xMMMMMMMM ...'), or None when the text is missing or has no
-    valid inet+netmask pair."""
+    """(address, prefixlen) of the first IPv4 in `ifconfig -f inet:cidr <iface> inet`
+    text ('inet A.B.C.D/NN ...'), or None when the text is missing or has no valid inet
+    address with a prefix length.
+
+    The caller (route._iface_ipv4) always requests `-f inet:cidr`, so the address carries
+    its prefix length inline -- no hex netmask (0xMMMMMMMM) to convert. Text without a
+    /NN (an ifconfig that did not honour -f) returns None, and the caller defers."""
     if not ifconfig_text:
         return None
     toks = ifconfig_text.split()
-    addr = mask = None
     for i, tok in enumerate(toks):
-        if tok == "inet" and addr is None and i + 1 < len(toks):
-            addr = toks[i + 1]
-        elif tok == "netmask" and mask is None and i + 1 < len(toks):
-            mask = toks[i + 1]
-    if addr is None or mask is None:
-        return None
-    try:
-        bits = bin(int(mask, 16)).count("1")
-        ipaddress.ip_address(addr)
-    except ValueError:
-        return None
-    return addr, bits
+        if tok == "inet" and i + 1 < len(toks):
+            addr, slash, bits = toks[i + 1].partition("/")
+            if not slash:
+                return None            # not the -f inet:cidr form -> no prefix length
+            try:
+                prefixlen = int(bits)
+                ipaddress.ip_address(addr)
+            except ValueError:
+                return None
+            return (addr, prefixlen) if 0 <= prefixlen <= 32 else None
+    return None

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/ifprobe.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/ifprobe.py
@@ -10,9 +10,11 @@ import ipaddress
 import re
 from enum import StrEnum
 
-# One regex owns the CARP line shape ("carp: <ROLE> vhid <N> ..."). Capturing the
-# whole vhid number (not a substring) is what keeps vhid 199 from matching 19/1990.
-_CARP_LINE = re.compile(r"carp:\s+(\w+)\s+vhid\s+(\d+)")
+# One regex owns the CARP line shape ("carp: <ROLE> vhid <N> ..."). The role is a
+# complete whitespace-bounded token (\S+, so the lossless contract holds even for a
+# token with non-word characters), and the vhid is the whole number bounded by \b, so
+# vhid 199 matches neither 19, 1990, nor a malformed "199x".
+_CARP_LINE = re.compile(r"carp:\s+(\S+)\s+vhid\s+(\d+)\b")
 _STATUS_ACTIVE = "status: active"    # carrier up
 _STATUS_ANY = "status: "             # a status line is present at all (up or down)
 
@@ -78,7 +80,7 @@ def iface_ipv4(ifconfig_text):
                 return None            # not the -f inet:cidr form -> no prefix length
             try:
                 prefixlen = int(bits)
-                ipaddress.ip_address(addr)
+                ipaddress.IPv4Address(addr)   # IPv4 only: reject an inet6 slipping through
             except ValueError:
                 return None
             return (addr, prefixlen) if 0 <= prefixlen <= 32 else None

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/ifprobe.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/ifprobe.py
@@ -12,9 +12,10 @@ from enum import StrEnum
 
 # One regex owns the CARP line shape ("carp: <ROLE> vhid <N> ..."). The role is a
 # complete whitespace-bounded token (\S+, so the lossless contract holds even for a
-# token with non-word characters), and the vhid is the whole number bounded by \b, so
-# vhid 199 matches neither 19, 1990, nor a malformed "199x".
-_CARP_LINE = re.compile(r"carp:\s+(\S+)\s+vhid\s+(\d+)\b")
+# token with non-word characters). The vhid is the whole number followed by (?!\S) --
+# whitespace or end of text -- so vhid 199 matches neither 19, 1990, nor a malformed
+# "199x" / "199-foo" (a bare \b would still accept a trailing non-word char like '-').
+_CARP_LINE = re.compile(r"carp:\s+(\S+)\s+vhid\s+(\d+)(?!\S)")
 _STATUS_ACTIVE = "status: active"    # carrier up
 _STATUS_ANY = "status: "             # a status line is present at all (up or down)
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/ifprobe.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/ifprobe.py
@@ -1,0 +1,59 @@
+"""Parse ifconfig(8) output text.
+
+The counterpart to syscmd, which *runs* ifconfig: this module *reads* its text,
+so keeper.py and status.py agree on exactly how a CARP line and a status line
+are interpreted instead of each carrying its own parser (they used to -- keeper
+matched the CARP role by substring, status by a separate regex). Pure text in,
+values out; no IO.
+"""
+import re
+from enum import StrEnum
+
+# One regex owns the CARP line shape ("carp: <ROLE> vhid <N> ..."). Capturing the
+# whole vhid number (not a substring) is what keeps vhid 199 from matching 19/1990.
+_CARP_LINE = re.compile(r"carp:\s+(\w+)\s+vhid\s+(\d+)")
+_STATUS_ACTIVE = "status: active"    # carrier up
+_STATUS_ANY = "status: "             # a status line is present at all (up or down)
+
+
+class CarpRole(StrEnum):
+    """The CARP states ifconfig(8) reports. StrEnum (like constants.Phase) so a
+    member is its own ifconfig token; used as the typed MASTER constant below."""
+    MASTER = "MASTER"
+    BACKUP = "BACKUP"
+    INIT = "INIT"
+
+
+def carp_roles(ifconfig_text):
+    """Map vhid (str) -> role token (str) for every CARP line in `ifconfig_text`
+    (empty dict when the text is None/empty). The role token is passed through
+    verbatim -- an unrecognised state is kept, not dropped, so the status view
+    never loses a VIP (CarpRole names the three states carp(4) actually emits)."""
+    roles = {}
+    if not ifconfig_text:
+        return roles
+    for role, vhid in _CARP_LINE.findall(ifconfig_text):
+        roles[vhid] = role
+    return roles
+
+
+def is_carp_master(ifconfig_text, vhid):
+    """True/False whether `vhid` is CARP MASTER in `ifconfig_text`, or None when
+    the text is missing (probe failed) -- distinct from present-but-not-master
+    (False). vhid is matched exactly, so 199 never reads as 19 or 1990."""
+    if ifconfig_text is None:
+        return None
+    return carp_roles(ifconfig_text).get(str(vhid)) == CarpRole.MASTER
+
+
+def carrier_up(ifconfig_text):
+    """Interface carrier from `ifconfig_text`: True on 'status: active', False on
+    a present-but-inactive status line, None when it cannot be read (text missing,
+    or the NIC reports no status line at all)."""
+    if ifconfig_text is None:
+        return None
+    if _STATUS_ACTIVE in ifconfig_text:
+        return True
+    if _STATUS_ANY in ifconfig_text:
+        return False
+    return None

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/ifprobe.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/ifprobe.py
@@ -6,6 +6,7 @@ are interpreted instead of each carrying its own parser (they used to -- keeper
 matched the CARP role by substring, status by a separate regex). Pure text in,
 values out; no IO.
 """
+import ipaddress
 import re
 from enum import StrEnum
 
@@ -57,3 +58,26 @@ def carrier_up(ifconfig_text):
     if _STATUS_ANY in ifconfig_text:
         return False
     return None
+
+
+def iface_ipv4(ifconfig_text):
+    """(address, prefixlen) of the first IPv4 in `ifconfig <iface> inet` text
+    ('inet A netmask 0xMMMMMMMM ...'), or None when the text is missing or has no
+    valid inet+netmask pair."""
+    if not ifconfig_text:
+        return None
+    toks = ifconfig_text.split()
+    addr = mask = None
+    for i, tok in enumerate(toks):
+        if tok == "inet" and addr is None and i + 1 < len(toks):
+            addr = toks[i + 1]
+        elif tok == "netmask" and mask is None and i + 1 < len(toks):
+            mask = toks[i + 1]
+    if addr is None or mask is None:
+        return None
+    try:
+        bits = bin(int(mask, 16)).count("1")
+        ipaddress.ip_address(addr)
+    except ValueError:
+        return None
+    return addr, bits

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -592,6 +592,14 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         delivered signal wakes the maintain-loop sleep at once."""
         return self._wake_w.fileno()
 
+    def close(self):
+        """Release the wake socketpair. The entry point calls this in its finally
+        AFTER signal.set_wakeup_fd(-1), so the C-level signal writer can never
+        target this fd once it is closed -- a signal in the shutdown window would
+        otherwise write to a closed (or, astronomically, a reused) fd."""
+        self._wake_r.close()
+        self._wake_w.close()
+
     def _wake_loop(self):
         """Wake the maintain-loop sleep by sending one byte to the wake socket.
         Called from the capture thread (a normal thread) on a peer-ACK
@@ -757,8 +765,6 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         if self._cfg.release_on_exit:
             self._dhcp.release()
         self._capture.stop()
-        self._wake_r.close()
-        self._wake_w.close()
         LOG.info("stopped (lease-keeper %s)", __version__)
         return 0
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -187,8 +187,8 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
 
         # ARP nudge component: owns the pacing and reachability state; the
         # keeper supplies the lease binding per nudge (_arp_nudge) and the
-        # CARP-role probe (via the _carp_master_probe shim).
-        self._nudge = ArpNudge(self._capture, self._cfg.chaddr, arp_nudge, self._carp_master_probe)
+        # CARP-role probe (via the _nudge_is_master shim).
+        self._nudge = ArpNudge(self._capture, self._cfg.chaddr, arp_nudge, self._nudge_is_master)
 
         self._was_master = None        # CARP role at the last nudge check (None = unknown yet)
 
@@ -238,7 +238,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         self._link = _LinkState()
 
         # Wake pipe for the maintain-loop sleep: _sleep_interruptible selects on
-        # the read end, and _signal_wake() writes one byte to make it return at
+        # the read end, and _wake_loop() writes one byte to make it return at
         # once instead of waiting out the 1s tick. Woken from two places: the
         # capture thread on an observed peer ACK (so the follow fires in
         # milliseconds), and the operator signal handlers (SIGTERM/USR1/USR2) so
@@ -309,7 +309,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         if (rx.mtype == ACK and rx.yiaddr and rx.yiaddr != self._dhcp.binding.yiaddr
                 and _sane_ipv4(rx.yiaddr)):
             self._follow.observe(rx)
-            self._signal_wake()   # wake the maintain-loop sleep now, don't wait for the tick
+            self._wake_loop()   # wake the maintain-loop sleep now, don't wait for the tick
 
     # ---- heartbeat / status file ----
 
@@ -391,7 +391,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         Uses the warn-once _ifconfig(), unlike the standalone carp_master()."""
         return _carp_master(self._ifconfig(), self._cfg.vhid)
 
-    def _carp_master_probe(self) -> "bool | None":
+    def _nudge_is_master(self) -> "bool | None":
         """ArpNudge's is_master hook -> the CARP probe (late-bound through the
         attribute so tests can stub _probe_carp_master)."""
         return self._probe_carp_master()
@@ -584,7 +584,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
     # ---- operator/signal API (signal handlers set a flag only -- see the
     # _SignalFlags invariant for why that rule is load-bearing; the
     # loop wakes via the wake socket -- from the capture thread through
-    # _signal_wake, and from signal delivery through signal.set_wakeup_fd(
+    # _wake_loop, and from signal delivery through signal.set_wakeup_fd(
     # wake_fileno) wired in main(), which is async-signal-safe C-level machinery) ----
 
     def wake_fileno(self):
@@ -592,7 +592,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         delivered signal wakes the maintain-loop sleep at once."""
         return self._wake_w.fileno()
 
-    def _signal_wake(self):
+    def _wake_loop(self):
         """Wake the maintain-loop sleep by sending one byte to the wake socket.
         Called from the capture thread (a normal thread) on a peer-ACK
         observation; socket.send works on every platform. The operator SIGNAL

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -490,8 +490,8 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             return
         if master is _UNSET:
             master = self._probe_carp_master()
-        b = self._dhcp.binding
-        self._defroute.reconcile(master, b.yiaddr is not None, b.lease_router)
+        binding = self._dhcp.binding
+        self._defroute.reconcile(master, binding.yiaddr is not None, binding.lease_router)
         # Backup egress needs the REAL CARP role: the unbound path drives the 0/0
         # withdraw with a fictional master=False (role-independent for 0/0), which would
         # wrongly install a backup route on a master-without-lease. probe_for_backup
@@ -517,8 +517,8 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         server T1/T2. The lease length is deliberately excluded -- many servers
         jitter option 51 by a second or two each renew, which is not an operationally
         meaningful change and would otherwise force every renew to INFO."""
-        b = self._dhcp.binding
-        return (b.lease_router, b.t1_server, b.t2_server)
+        binding = self._dhcp.binding
+        return (binding.lease_router, binding.t1_server, binding.t2_server)
 
     def _lease_changes(self, prior):
         """A short 'what changed' summary of the current binding against `prior`, or
@@ -527,11 +527,11 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         lease length; see _lease_facts. The current lease length is still shown in
         the renew line itself, just not treated as a change."""
         old_gw, old_t1, old_t2 = prior
-        b = self._dhcp.binding
+        binding = self._dhcp.binding
         parts = []
-        if b.lease_router != old_gw:
-            parts.append(f"gw {old_gw or 'none'}->{b.lease_router or 'none'}")
-        if (b.t1_server, b.t2_server) != (old_t1, old_t2):
+        if binding.lease_router != old_gw:
+            parts.append(f"gw {old_gw or 'none'}->{binding.lease_router or 'none'}")
+        if (binding.t1_server, binding.t2_server) != (old_t1, old_t2):
             parts.append("renew timers changed")
         return ", ".join(parts)
 
@@ -543,15 +543,15 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         notable) -- logs at INFO stating what changed. The default route is
         reconciled by the loop-head reconcile on the next _maintain_step entry (a
         renewed lease can carry a new option-3 gateway), so it is not repeated here."""
-        b = self._dhcp.binding
+        binding = self._dhcp.binding
         changes = self._lease_changes(prior)
         if phase == Phase.RENEW and not changes:
-            LOG.debug("DHCP RENEW ok %s (lease=%ss, expires ~%s)", b.yiaddr, b.lease_secs,
-                      _clock_at(b.lease_secs))
+            LOG.debug("DHCP RENEW ok %s (lease=%ss, expires ~%s)", binding.yiaddr, binding.lease_secs,
+                      _clock_at(binding.lease_secs))
         else:
             suffix = f" [{changes}]" if changes else ""
-            LOG.info("DHCP %s ok %s (lease=%ss, expires ~%s)%s", phase, b.yiaddr, b.lease_secs,
-                     _clock_at(b.lease_secs), suffix)
+            LOG.info("DHCP %s ok %s (lease=%ss, expires ~%s)%s", phase, binding.yiaddr, binding.lease_secs,
+                     _clock_at(binding.lease_secs), suffix)
         self._hb()
         self._arp_nudge(force=True)
 
@@ -705,12 +705,12 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         logs nothing at INFO between renews (routine renews are DEBUG), so this
         periodic line shows it is alive without per-tick spam. Not master-gated: a
         backup holds the same lease and is just as 'healthy'."""
-        b = self._dhcp.binding
-        if not b.yiaddr:
+        binding = self._dhcp.binding
+        if not binding.yiaddr:
             return
         ok, _ = self._pulse.ready()
         if ok:
-            LOG.info("lease healthy: %s on %s (lease %ss)", b.yiaddr, self._cfg.iface, b.lease_secs)
+            LOG.info("lease healthy: %s on %s (lease %ss)", binding.yiaddr, self._cfg.iface, binding.lease_secs)
 
     def run(self):
         """The daemon main loop: capture up, then maintain the lease until
@@ -780,8 +780,8 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         """One iteration of the maintain loop. Returns to run() (which loops again)
         on every state transition; any exception it raises is caught by run() and
         retried, so a transient fault can never terminate the keeper."""
-        b = self._dhcp.binding
-        if not b.yiaddr:
+        binding = self._dhcp.binding
+        if not binding.yiaddr:
             # Unbound: (re)acquire FIRST, then withdraw only if that did not bind. A
             # keeper restart re-adopts its still-valid lease here (INIT-REBOOT, a few
             # ms), so a master keeps its inherited default -- no 0/0 flap -- instead of
@@ -798,7 +798,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             if self._backup.enabled:
                 self._backup.reconcile_backup_egress(self._probe_carp_master())
             self._acquire_step()
-            if not b.yiaddr:
+            if not binding.yiaddr:
                 # master=False is the fictional role for the role-independent 0/0
                 # withdraw; backup egress needs the true role (a master-without-lease
                 # must not get a backup route), so probe when the feature is enabled.
@@ -819,14 +819,14 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         # "RENEW ok" already carries the lease + expiry. Raise the keeper's log
         # level to see it.
         LOG.debug("DHCP lease %ds; renew at T1=%ds (~%s), rebind by T2=%ds (~%s) (timing source: %s)",
-                  b.lease_secs, t1, _clock_at(t1), t2, _clock_at(t2), src)
+                  binding.lease_secs, t1, _clock_at(t1), t2, _clock_at(t2), src)
         if not self._hold_lease(t1):
             return
         prior = self._lease_facts()   # snapshot to report what a renew changed
         if self._dhcp.renew():
             self._on_lease_extended(Phase.RENEW, prior)
             return
-        if not b.yiaddr:            # renew() drew a NAK and forgot the binding
+        if not binding.yiaddr:            # renew() drew a NAK and forgot the binding
             self._on_lease_revoked(Phase.RENEW)
             return
         LOG.warning("DHCP %s failed at T1 -- trying %s until T2", Phase.RENEW, Phase.REBIND)
@@ -852,7 +852,7 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             if self._dhcp.renew(rebind=True):
                 ok = True
                 break
-            if not b.yiaddr:            # a NAK during REBIND likewise revoked the lease
+            if not binding.yiaddr:            # a NAK during REBIND likewise revoked the lease
                 self._on_lease_revoked(Phase.REBIND)
                 return
         if ok:
@@ -898,13 +898,13 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
             self._wait_unbound(REDORA_MIN)
             return
 
-        b = self._dhcp.binding
+        binding = self._dhcp.binding
         if self._dhcp.acquire(self._follow.target):
             self._link.up = True   # a completed DORA proves carrier
             LOG.info("DHCP BOUND %s (lease=%ss, expires ~%s, server=%s, gw=%s, mask=%s)",
-                     b.yiaddr, b.lease_secs, _clock_at(b.lease_secs),
-                     b.server, b.router or "?",
-                     f"/{b.mask_bits}" if b.mask_bits else "none")
+                     binding.yiaddr, binding.lease_secs, _clock_at(binding.lease_secs),
+                     binding.server, binding.router or "?",
+                     f"/{binding.mask_bits}" if binding.mask_bits else "none")
             self._hb()
             self._arp_nudge(force=True)
             self.redora_wait = REDORA_MIN

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/keeper.py
@@ -18,6 +18,7 @@ from .constants import (
     LINK_POLL_STEP, LOOP_ERROR_BACKOFF, Phase, REBIND_POLL_STEP, REDORA_MAX, REDORA_MIN,
     SNIFFER_RETRY, SNIFFER_WARMUP)
 from .dhcpclient import DhcpClient, DhcpHooks
+from .ifprobe import carrier_up, is_carp_master
 from .policy import ArpNudge, FollowHooks, FollowPolicy
 from .route import (BackupEgressReconciler, DefaultRouteMode, DefaultRouteReconciler,
                     withdraw_unless_master)
@@ -27,13 +28,6 @@ from .wire import _parse_reply
 
 LOG = logging.getLogger(LOGGER_NAME)
 
-# The keeper's dependency on ifconfig(8) output text, named in one place. The
-# trailing space in the CARP format is load-bearing: it stops vhid 1 matching
-# "vhid 11".
-CARP_MASTER_FMT = "carp: MASTER vhid {vhid} "
-IFCONFIG_STATUS_ACTIVE = "status: active"    # carrier up
-IFCONFIG_STATUS = "status: "                 # any status line present (up or down)
-
 # _UNSET (shared, from util) marks "CARP-master value not supplied": the maintain
 # loop probes the role once per tick and shares it, but None is a valid probe
 # result, so the sentinel means "probe it now".
@@ -41,20 +35,20 @@ IFCONFIG_STATUS = "status: "                 # any status line present (up or do
 
 def _carp_master(ifconfig_text, vhid):
     """CARP-master decision from ifconfig text: True/False for the vhid, None when
-    the text is missing (probe failed), True when no vhid (nothing to gate on)."""
+    the text is missing (probe failed), True when no vhid (nothing to gate on).
+    Parsing lives in ifprobe.is_carp_master; this adds only the keeper policy that
+    a keeper with no vhid has nothing to gate on."""
     if not vhid:
         return True
-    if ifconfig_text is None:
-        return None
-    return CARP_MASTER_FMT.format(vhid=vhid) in ifconfig_text
+    return is_carp_master(ifconfig_text, vhid)
 
 
 def carp_master(iface, vhid):
     """CARP-master role for `vhid` on `iface` (True/False, None on probe failure).
     Standalone -- no Keeper -- so the daemon entry point can gate its startup
     fail-stop default withdraw on the role before the Keeper / capture backend
-    exist; the Keeper's per-tick probe (_probe_carp_master) shares CARP_MASTER_FMT
-    through _carp_master."""
+    exist; the Keeper's per-tick probe (_probe_carp_master) shares the same
+    ifprobe parse through _carp_master."""
     return _carp_master(ifconfig(iface), vhid)
 
 
@@ -407,15 +401,9 @@ class Keeper:  # pylint: disable=too-many-instance-attributes
         present-but-inactive status (no carrier / no link), None when it cannot be
         read (probe failed, or the NIC reports no status line). Used by the
         unbound link-return fast path and the acquire carrier gate; a None
-        result never disturbs the backoff and never holds an acquire."""
-        out = self._ifconfig()
-        if out is None:
-            return None
-        if IFCONFIG_STATUS_ACTIVE in out:
-            return True
-        if IFCONFIG_STATUS in out:
-            return False
-        return None
+        result never disturbs the backoff and never holds an acquire. Parsing
+        lives in ifprobe.carrier_up; _ifconfig supplies the warn-once text."""
+        return carrier_up(self._ifconfig())
 
     def _check_link_returned(self):
         """While UNBOUND, detect a carrier down->up edge so the keeper re-DORAs at

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/policy.py
@@ -43,7 +43,7 @@ class ArpNudge:  # pylint: disable=too-many-instance-attributes
         # Reachability: the sniffer stamps last_reply when the gateway answers
         # a nudge (a lone atomic float write); the status page surfaces its age.
         self.last_reply = 0.0          # epoch of the gateway's last ARP reply (0 = none)
-        self._gw = None                # last nudge target we logged (log again on change)
+        self._logged_gw = None                # last nudge target we logged (log again on change)
         self._warned = False           # warned once about a missing nudge target
         # Throttle a failing send so a persistent fault stays periodically visible
         # (with a suppressed count) instead of spamming or latching fully silent.
@@ -90,10 +90,10 @@ class ArpNudge:  # pylint: disable=too-many-instance-attributes
             # shows the nudge is active; routine repeats at DEBUG (they fire oftener
             # than DHCP renews). Whether the gateway actually answered is surfaced by
             # age on the status page (via last_reply -> the heartbeat's arpok=).
-            if gateway != self._gw:
+            if gateway != self._logged_gw:
                 LOG.info("ARP nudge active: who-has %s tell %s (src %s) every %ds",
                          gateway, yiaddr, self.chaddr, self.interval)
-                self._gw = gateway
+                self._logged_gw = gateway
             else:
                 LOG.debug("ARP nudge sent: who-has %s tell %s", gateway, yiaddr)
         except Exception as e:  # pylint: disable=broad-exception-caught

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -672,8 +672,10 @@ class BackupEgressReconciler:
 
     def _iface_ipv4(self, iface):
         """(address, prefixlen) of the first IPv4 on `iface`, or None. Runs
-        `ifconfig <iface> inet`; ifprobe.iface_ipv4 does the parse."""
-        res = run([_IFCONFIG, iface, "inet"])
+        `ifconfig -f inet:cidr <iface> inet` so the address prints as A.B.C.D/NN
+        (a direct prefix length) instead of the default hex netmask (0xffffff00),
+        which ifprobe.iface_ipv4 then parses."""
+        res = run([_IFCONFIG, "-f", "inet:cidr", iface, "inet"])
         if res is None or res.returncode != 0:
             return None
         return iface_ipv4(res.stdout)
@@ -828,7 +830,12 @@ class BackupEgressReconciler:
         """{network: gateway} for the IPv4 FIB from one `netstat -rn` pass, or None when
         the table cannot be read -- callers must not mistake an unreadable table for 'no
         routes' and skip the master-side removal. A bare host address parses as /32;
-        header and default rows that are not a network are skipped."""
+        header and default rows that are not a network are skipped.
+
+        Parses the plain-text table on purpose: the destination/gateway column layout of
+        `netstat -rn` has been stable for decades, whereas netstat's libxo(3) JSON key
+        names are explicitly NOT a stable API across FreeBSD releases -- so the text is
+        the more robust substrate for this one parse, not the less."""
         res = run([_NETSTAT, "-rn", "-f", "inet"])
         if res is None or res.returncode != 0:
             if not self._warn.fib_unreadable:   # once per unreadable episode (re-armed below)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 from .constants import LOGGER_NAME, RECONCILE_HEARTBEAT_INTERVAL
+from .ifprobe import iface_ipv4
 from .syscmd import run
 from .util import _UNSET, _RateLimit, _sane_ipv4
 
@@ -670,26 +671,12 @@ class BackupEgressReconciler:
         return next((str(host) for host in net.hosts() if str(host) != own), None)
 
     def _iface_ipv4(self, iface):
-        """(address, prefixlen) of the first IPv4 on `iface`, or None. Parses
-        `ifconfig <iface> inet` ('inet A netmask 0xMMMMMMMM ...')."""
+        """(address, prefixlen) of the first IPv4 on `iface`, or None. Runs
+        `ifconfig <iface> inet`; ifprobe.iface_ipv4 does the parse."""
         res = run([_IFCONFIG, iface, "inet"])
         if res is None or res.returncode != 0:
             return None
-        toks = res.stdout.split()
-        addr = mask = None
-        for i, tok in enumerate(toks):
-            if tok == "inet" and addr is None and i + 1 < len(toks):
-                addr = toks[i + 1]
-            elif tok == "netmask" and mask is None and i + 1 < len(toks):
-                mask = toks[i + 1]
-        if addr is None or mask is None:
-            return None
-        try:
-            bits = bin(int(mask, 16)).count("1")
-            ipaddress.ip_address(addr)
-        except ValueError:
-            return None
-        return addr, bits
+        return iface_ipv4(res.stdout)
 
     # ---- backup-egress FIB operations (idempotent, fail-safe on an unreadable table) ----
 

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -491,7 +491,7 @@ class BackupEgressReconciler:
         # mode is coerced (as in DefaultRouteReconciler) so an unrecognised value is
         # inert OFF; the backup set only acts under observe/enforce.
         self._mode = DefaultRouteMode.coerce(mode)
-        self._backup = backup_egress or BackupEgressConfig()
+        self._cfg = backup_egress or BackupEgressConfig()
         self._last_backup_desired = _UNSET
         self._backup_heartbeat = _RateLimit(RECONCILE_HEARTBEAT_INTERVAL)
         self._valid_prefixes = None            # cached validated prefixes (warn-once via the cache)
@@ -504,7 +504,7 @@ class BackupEgressReconciler:
         feature enabled). Lets the caller decide whether the unbound path must probe the
         real CARP role for backup egress (the 0/0 withdraw there uses a fictional role)."""
         return (self._mode in (DefaultRouteMode.OBSERVE, DefaultRouteMode.ENFORCE)
-                and self._backup.enabled)
+                and self._cfg.enabled)
 
     def withdraw_backup_egress(self):
         """Remove the backup-egress routes (the /1-split plus any configured prefixes) at a
@@ -560,7 +560,7 @@ class BackupEgressReconciler:
     def _backup_route_set(self):
         """The prefixes to install for the configured form. SPLIT (and any unrecognised
         form) is the leak-safe /1-split; PREFIXES is the validated configured list."""
-        if self._backup.form == BackupEgressForm.PREFIXES:
+        if self._cfg.form == BackupEgressForm.PREFIXES:
             return self._backup_prefixes()
         return _SPLIT_PREFIXES
 
@@ -579,7 +579,7 @@ class BackupEgressReconciler:
         prefix, 0.0.0.0/0 under enforce, empty prefixes list) each fire once."""
         if self._valid_prefixes is None:
             valid = []
-            for prefix in self._backup.prefixes:
+            for prefix in self._cfg.prefixes:
                 try:
                     net = ipaddress.ip_network(prefix, strict=False)
                 except ValueError:
@@ -593,7 +593,7 @@ class BackupEgressReconciler:
                                 "a backup-egress route -- ignoring it (use the /1-split)")
                     continue
                 valid.append(prefix)
-            if self._backup.form == BackupEgressForm.PREFIXES and not valid:
+            if self._cfg.form == BackupEgressForm.PREFIXES and not valid:
                 LOG.warning("backup egress: form is 'prefixes' but no valid prefixes are set")
             self._valid_prefixes = tuple(valid)
         return self._valid_prefixes
@@ -610,7 +610,7 @@ class BackupEgressReconciler:
         return gateway
 
     def _backup_gateway(self):
-        cfg = self._backup
+        cfg = self._cfg
         if cfg.gateway:
             own = self._gateway_is_own(cfg.gateway)   # True / False / None (could not check)
             if own is None:
@@ -690,8 +690,8 @@ class BackupEgressReconciler:
         peer on a fresh master), which makes cleanup best-effort there rather than risk
         clobbering an unrelated route."""
         gateways = set(self._backup_installed_gws)
-        if self._backup.gateway:
-            gateways.add(self._backup.gateway)
+        if self._cfg.gateway:
+            gateways.add(self._cfg.gateway)
         return gateways
 
     def _note_backup_collisions(self, prefixes, gateway):

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -817,12 +817,12 @@ class BackupEgressReconciler:
         if now is None:
             return   # deletes issued but cannot confirm (already warned); re-check next tick
         self._prune_backup_ownership(now, removal_set)        # removed routes -> retire their gws
-        still = [p for p in present if now.get(self._net(p)) in owned]
-        if not still:
+        still_present = [p for p in present if now.get(self._net(p)) in owned]
+        if not still_present:
             LOG.info("removed backup egress -- %s", reason)
         else:
             LOG.error("backup egress: failed to remove %s -- this node would loop its egress",
-                      " ".join(still))
+                      " ".join(still_present))
 
     def _fib_routes(self):
         """{network: gateway} for the IPv4 FIB from one `netstat -rn` pass, or None when

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -39,7 +39,7 @@ LOG = logging.getLogger(LOGGER_NAME)
 
 
 def _drop(*_args, **_kwargs):
-    """A log-callable that discards its call: what _at returns for a throttled
+    """A log-callable that discards its call: what _log_at returns for a throttled
     steady-state repeat, so a suppressed heartbeat is a no-op with the same
     call shape as LOG.debug/LOG.info."""
 
@@ -184,7 +184,7 @@ def _route(command, dest, gateway=None):
                   (res.stderr or "").strip())
 
 
-def _at(changed, heartbeat):
+def _log_at(changed, heartbeat):
     """Pick the log callable for a desired-state confirmation. A state change
     logs at INFO the first time the state is entered, and re-arms the heartbeat
     so the identical DEBUG repeat does not fire on the very next tick. An
@@ -264,11 +264,11 @@ class DefaultRouteReconciler:
         self._strikes = 0
         self._unreadable_warned = False   # rising-edge gate for the fail-closed warning
         # Last (want, gateway) we logged, so a steady desired state is confirmed
-        # once at INFO then repeats at DEBUG (see _at / _UNSET).
+        # once at INFO then repeats at DEBUG (see _log_at / _UNSET).
         self._last_desired = _UNSET
         # Throttle for the unchanged steady-state DEBUG heartbeat, so a quiet
         # backup/master does not log its (identical) decision every tick and churn
-        # the log rotation. A change re-arms it (see _at).
+        # the log rotation. A change re-arms it (see _log_at).
         self._heartbeat = _RateLimit(RECONCILE_HEARTBEAT_INTERVAL)
 
     @property
@@ -374,17 +374,17 @@ class DefaultRouteReconciler:
         gateway, so there is nothing to install -- state ownership positively
         instead of returning silently."""
         if self._mode == DefaultRouteMode.OBSERVE:
-            _at(changed, self._heartbeat)("[observe] default already via %s -- would own", gateway)
+            _log_at(changed, self._heartbeat)("[observe] default already via %s -- would own", gateway)
         else:
-            _at(changed, self._heartbeat)("owning default via %s", gateway)
+            _log_at(changed, self._heartbeat)("owning default via %s", gateway)
 
     def _confirm_no_default(self, changed, reason):
         """Steady-state no-default heartbeat: there is correctly no default to
         hold (backup / no lease / liveness-gated)."""
         if self._mode == DefaultRouteMode.OBSERVE:
-            _at(changed, self._heartbeat)("[observe] no default held (%s) -- as wanted", reason)
+            _log_at(changed, self._heartbeat)("[observe] no default held (%s) -- as wanted", reason)
         else:
-            _at(changed, self._heartbeat)("no default held (%s)", reason)
+            _log_at(changed, self._heartbeat)("no default held (%s)", reason)
 
     def _on_unknown_role(self):
         """An unreadable (is_master is None) probe: do not install when unsure,
@@ -420,8 +420,8 @@ class DefaultRouteReconciler:
 
     def _install(self, changed, gateway, replacing=None):
         if self._mode == DefaultRouteMode.OBSERVE:
-            _at(changed, self._heartbeat)("[observe] would install default via %s%s", gateway,
-                                          "" if replacing is None else f" (replacing {replacing})")
+            _log_at(changed, self._heartbeat)("[observe] would install default via %s%s", gateway,
+                                              "" if replacing is None else f" (replacing {replacing})")
             return
         # Replace atomically with `route change`, not delete-then-add. A bench
         # check on FreeBSD 14.3 confirmed both halves: `route change` to an on-link
@@ -446,8 +446,8 @@ class DefaultRouteReconciler:
 
     def _withdraw(self, changed, current, reason):
         if self._mode == DefaultRouteMode.OBSERVE:
-            _at(changed, self._heartbeat)("[observe] would withdraw default (currently via %s) -- %s",
-                                          current, reason)
+            _log_at(changed, self._heartbeat)("[observe] would withdraw default (currently via %s) -- %s",
+                                              current, reason)
             return
         _route(RouteCommand.DELETE, _DEFAULT)
         # Confirm the FIB, not the exit code: a silently failed delete would leave
@@ -752,7 +752,7 @@ class BackupEgressReconciler:
         if not route_set:
             return
         if self._mode == DefaultRouteMode.OBSERVE:
-            _at(changed, self._backup_heartbeat)(
+            _log_at(changed, self._backup_heartbeat)(
                 "[observe] would route backup egress via %s (%s)", gateway, " ".join(route_set))
             return
         have = self._fib_routes()
@@ -773,7 +773,7 @@ class BackupEgressReconciler:
         self._record_backup_ownership(gateway, state, route_set)
         if not pending:
             if not collisions:
-                _at(changed, self._backup_heartbeat)(
+                _log_at(changed, self._backup_heartbeat)(
                     "backup egress via %s (%s)", gateway, " ".join(route_set))
             return
         missing = [p for p in pending if state.get(self._net(p)) != gateway]
@@ -787,7 +787,7 @@ class BackupEgressReconciler:
         # did not happen: the reconcile master path uses the default, the shutdown
         # boundary passes "keeper stopping".
         if self._mode == DefaultRouteMode.OBSERVE:
-            _at(changed, self._backup_heartbeat)(
+            _log_at(changed, self._backup_heartbeat)(
                 "[observe] would remove backup egress (%s)", " ".join(removal_set))
             return
         have = self._fib_routes()
@@ -809,7 +809,7 @@ class BackupEgressReconciler:
         self._note_backup_collisions(collisions, None)
         if not present:
             self._prune_backup_ownership(have, removal_set)   # nothing of ours here -> drop stale gws
-            _at(changed, self._backup_heartbeat)("no backup egress (%s)", reason)
+            _log_at(changed, self._backup_heartbeat)("no backup egress (%s)", reason)
             return
         for prefix in present:
             _route(RouteCommand.DELETE, prefix)

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/leasekeeper/route.py
@@ -341,7 +341,7 @@ class DefaultRouteReconciler:
             else:
                 self._install(changed, gateway, replacing=have)
         else:
-            reason = self._no_default_reason(blocked, is_master, holds_lease)
+            reason = self._no_default_reason(blocked, is_master, holds_lease, bound)
             # A route-get failure (for any reason) also reads as None here, so we
             # skip the withdraw. Treating an unreadable table as "absent" is a
             # deliberate trade-off: an empty table -- the common quiet state on a
@@ -358,13 +358,16 @@ class DefaultRouteReconciler:
                 self._withdraw(changed, have, reason)
 
     @staticmethod
-    def _no_default_reason(blocked, is_master, holds_lease):
+    def _no_default_reason(blocked, is_master, holds_lease, bound):
         """Why the desired state is 'no default' -- the informative half of the
         backup/no-lease/liveness heartbeat and of a withdraw."""
         if blocked:
             return "liveness not confirmed (possible split-brain / dead WAN)"
         if not holds_lease:
-            return "no usable lease"
+            # `bound` separates a genuinely absent lease from a held lease whose ACK
+            # carried no usable option-3 gateway: both yield no default, but the log
+            # must not tell an operator holding a lease that there is none.
+            return "lease has no usable gateway" if bound else "no lease held"
         if is_master is not True:
             return "CARP backup"
         return "not owned"

--- a/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
+++ b/net/os-carp-vip-dhcp/src/opnsense/scripts/OPNsense/CarpVipDhcp/status.py
@@ -13,11 +13,11 @@ The heartbeat file is written by lease_keeper.py in one of two forms:
 """
 import json
 import os
-import re
 import time
 import xml.etree.ElementTree as ET
 
 from keeperconf import CONFFILE, keeper_id, keeper_records
+from leasekeeper.ifprobe import carp_roles
 from leasekeeper.syscmd import ifconfig, run
 
 CONFIG_XML = "/conf/config.xml"
@@ -123,14 +123,10 @@ def parse_heartbeat(path):
 
 
 def carp_states():
-    """Map vhid -> live CARP role (MASTER/BACKUP/INIT) from ifconfig."""
-    states = {}
-    out = ifconfig()
-    if out is None:
-        return states
-    for match in re.finditer(r"carp:\s+(\w+)\s+vhid\s+(\d+)", out):
-        states[match.group(2)] = match.group(1)
-    return states
+    """Map vhid -> live CARP role token (MASTER/BACKUP/INIT) from ifconfig, for
+    the status JSON. Shares the CARP-line parser with the keeper (ifprobe); the
+    token is passed through verbatim (any unrecognised state stays visible)."""
+    return carp_roles(ifconfig())
 
 
 def iface_names():

--- a/net/os-carp-vip-dhcp/tests/fakes.py
+++ b/net/os-carp-vip-dhcp/tests/fakes.py
@@ -52,7 +52,10 @@ class FakeRoute:
                 return self._reply(1, "", "netstat: routing table unavailable")
             return self._reply(0, self._netstat_body())
         if prog.endswith("ifconfig"):
-            return self._ifconfig(cmd[1])
+            # Only route._iface_ipv4 shells ifconfig here, always as
+            # `ifconfig -f inet:cidr <iface> inet` -> iface is the token before "inet".
+            iface = cmd[cmd.index("inet") - 1] if "inet" in cmd else cmd[-1]
+            return self._ifconfig(iface)
         return self._route(cmd)
 
     def _route(self, cmd):
@@ -94,12 +97,12 @@ class FakeRoute:
         return "\n".join(lines) + "\n"
 
     def _ifconfig(self, iface):
+        # Mirrors `ifconfig -f inet:cidr`: the address prints as A.B.C.D/NN.
         info = self.ifaces.get(iface)
         if info is None:
             return self._reply(1, "", f"ifconfig: interface {iface} does not exist")
         addr, prefixlen = info
-        mask = (0xffffffff << (32 - prefixlen)) & 0xffffffff if prefixlen else 0
-        body = f"{iface}: flags=8843<UP>\n\tinet {addr} netmask 0x{mask:08x} broadcast 0.0.0.0\n"
+        body = f"{iface}: flags=8843<UP>\n\tinet {addr}/{prefixlen} broadcast 0.0.0.0\n"
         return self._reply(0, body)
 
     @staticmethod

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -1453,7 +1453,7 @@ def test_carp_master_decision_from_ifconfig_text(lk):
 
 
 def test_carp_master_vhid_is_word_bounded(lk):
-    # The trailing space in CARP_MASTER_FMT stops vhid 199 matching 19 or 1990.
+    # ifprobe captures the whole vhid number, so 199 never reads as 19 or 1990.
     assert lk._carp_master("carp: MASTER vhid 19 advbase 1\n", "199") is False
     assert lk._carp_master("carp: MASTER vhid 1990 advbase 1\n", "199") is False
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -554,6 +554,15 @@ def test_wake_fileno_is_the_nonblocking_write_end(lk):
     assert keeper._wake_w.getblocking() is False
 
 
+def test_close_releases_the_wake_socket(lk):
+    # run() no longer closes the wake socket; the entry point calls close() AFTER
+    # set_wakeup_fd(-1) so a shutdown-window signal can never hit a closed fd.
+    keeper = _keeper(lk)
+    keeper.close()
+    with pytest.raises(OSError):
+        keeper._wake_w.send(b"\x00")   # write end is closed
+
+
 def test_id_opts_empty_by_default(lk):
     keeper = _keeper(lk)
     assert keeper._dhcp._id_opts == []
@@ -1396,6 +1405,7 @@ def _run_to_shutdown(lk, monkeypatch, *, master, initial):
     k._capture.stop = lambda: None
     k._signals.request_stop()          # exit at once -> straight to the shutdown path
     assert k.run() == 0
+    k.close()                          # mirror the entry point: close the wake socket after run()
     return fake
 
 

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -57,7 +57,7 @@ def _client(lk, id_opts=None, on_changed=None):
 def test_timing_derived(lk):
     c = _client(lk)
     c.binding.lease_secs = 1800
-    assert c.timing() == (900, 1575, "derived")
+    assert c.timing() == (900, 1575, lk.TimingSource.DERIVED)
 
 
 def test_timing_honours_server(lk):
@@ -65,7 +65,14 @@ def test_timing_honours_server(lk):
     c.binding.lease_secs = 1800
     c.binding.t1_server = 600
     c.binding.t2_server = 1200
-    assert c.timing() == (600, 1200, "server")
+    assert c.timing() == (600, 1200, lk.TimingSource.SERVER)
+
+
+def test_timing_source_tokens_are_wire_stable(lk):
+    # The heartbeat 'src=' token and log label: the StrEnum must format to the
+    # exact wire strings status.py parses (server/derived), not "TimingSource.X".
+    assert f"{lk.TimingSource.SERVER}" == "server"
+    assert f"{lk.TimingSource.DERIVED}" == "derived"
 
 
 def test_redora_max_bounded(lk):

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -525,7 +525,7 @@ def test_check_observed_rejects_wrong_server(lk, tmp_path):
 def test_observed_serviced_by_maintain_loop(lk, tmp_path):
     keeper = _observe_keeper(lk, tmp_path)
     keeper._follow._observed = _ack(lk, "100.64.4.60")
-    keeper._signal_wake()   # as the sniffer would -> loop returns at once
+    keeper._wake_loop()   # as the sniffer would -> loop returns at once
     keeper._sleep_interruptible(1)
     assert keeper.fired == ["100.64.4.60"]
     assert not _woken(keeper)   # the wake byte was drained -> the loop paces at 1s again
@@ -538,7 +538,7 @@ def test_peer_ack_wakes_and_is_serviced_end_to_end(lk, tmp_path):
     the loop does not then busy-spin (a leftover byte would make every
     subsequent select return at once)."""
     keeper = _observe_keeper(lk, tmp_path)
-    keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60"))   # real observe + real _signal_wake
+    keeper._on_dhcp_reply(_peer_ack(lk, "100.64.4.60"))   # real observe + real _wake_loop
     assert _woken(keeper)                    # the capture thread woke the loop
     keeper._sleep_interruptible(1)
     assert keeper.fired == ["100.64.4.60"]   # ...and the loop serviced the follow

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -171,7 +171,7 @@ def test_feed_wakes_the_waiting_sequence(lk):
     rx = _reply(lk, lk.ACK, "100.64.4.7")
     c.feed(rx)
     assert c._rx is rx
-    assert c._ev.is_set()        # the waiting _wait_for_dhcp_reply returns at once
+    assert c._reply_ready.is_set()        # the waiting _wait_for_dhcp_reply returns at once
 
 
 def test_fmt_reply_readable(lk):

--- a/net/os-carp-vip-dhcp/tests/test_daemon.py
+++ b/net/os-carp-vip-dhcp/tests/test_daemon.py
@@ -563,6 +563,93 @@ def test_close_releases_the_wake_socket(lk):
         keeper._wake_w.send(b"\x00")   # write end is closed
 
 
+def _stub_main(monkeypatch, keeper_cls, *argv_extra):
+    """Wire lease_keeper.main() for a spy test on a non-FreeBSD host: a fake Keeper,
+    a runnable capture backend, no-op signal wiring (with the POSIX-only SIGUSR
+    numbers faked in), and a synthetic argv. Returns the module so the caller can
+    also spy set_wakeup_fd."""
+    import lease_keeper  # noqa: E402  # pylint: disable=import-outside-toplevel
+    monkeypatch.setattr(lease_keeper, "_setup_logging", lambda _logfile: None)
+    monkeypatch.setattr(lease_keeper, "Keeper", keeper_cls)
+    monkeypatch.setattr(lease_keeper.BpfCapture, "unavailable_reason", staticmethod(lambda: None))
+    monkeypatch.setattr(lease_keeper.signal, "signal", lambda *_a: None)
+    monkeypatch.setattr(lease_keeper.signal, "SIGUSR1", 30, raising=False)
+    monkeypatch.setattr(lease_keeper.signal, "SIGUSR2", 31, raising=False)
+    monkeypatch.setattr("sys.argv", [
+        "lease_keeper", "--iface", "eth0", "--chaddr", CHADDR_STR,
+        "--pidfile", "", "--hbfile", "", "--logfile", "", *argv_extra])
+    return lease_keeper
+
+
+def test_main_run_unregisters_wakeup_fd_before_close(monkeypatch):
+    # The shutdown ordering (set_wakeup_fd(-1) BEFORE keeper.close()) must hold, or a
+    # signal in the window would hit a closed wake fd. Pin the whole sequence so a
+    # future move of either finally cannot silently reintroduce that race.
+    events = []
+
+    class _FakeKeeper:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def wake_fileno(self):
+            return 7
+
+        def run(self):
+            events.append("run")
+            return 0
+
+        def close(self):
+            events.append("close")
+
+    lease_keeper = _stub_main(monkeypatch, _FakeKeeper)
+    monkeypatch.setattr(lease_keeper.signal, "set_wakeup_fd", lambda fd: events.append(f"wakeupfd={fd}"))
+    assert lease_keeper.main() == 0
+    assert events == ["wakeupfd=7", "run", "wakeupfd=-1", "close"]
+
+
+def test_main_once_closes_keeper_without_arming_wakeup_fd(monkeypatch):
+    # --once must also close the keeper (its wake socketpair opened in __init__),
+    # even though it never arms set_wakeup_fd -- else a repeated in-process
+    # main(--once) leaks two fds per call.
+    events = []
+    armed = []
+
+    class _FakeKeeper:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def claim_once(self):
+            events.append("claim_once")
+            return 0
+
+        def close(self):
+            events.append("close")
+
+    lease_keeper = _stub_main(monkeypatch, _FakeKeeper, "--once")
+    monkeypatch.setattr(lease_keeper.signal, "set_wakeup_fd", armed.append)
+    assert lease_keeper.main() == 0
+    assert events == ["claim_once", "close"]   # closed after the one-shot claim
+    assert not armed                           # --once never armed the signal wakeup fd
+
+
+def test_read_loop_uses_its_own_buflen_arg(lk, monkeypatch):
+    # The bpf read size is the reader thread's own arg, not shared instance state, so
+    # a concurrent restart cannot rebind it under an old reader. Guard it: os.read is
+    # called with the arg buflen (reintroducing self._buflen would fail this).
+    cap = lk.BpfCapture("eth0", False, lambda _f: None, lambda _f: None)
+    reads = []
+    monkeypatch.setattr(select, "select", lambda r, _w, _x: ([r[0]], [], []))   # bpf fd readable
+
+    def _fake_read(_fd, n):
+        reads.append(n)
+        raise OSError("stop the loop after one read")
+    monkeypatch.setattr(os, "read", _fake_read)
+    monkeypatch.setattr(os, "close", lambda _fd: None)   # fd / wake_reader are fakes here
+    stop = types.SimpleNamespace(is_set=lambda: False)
+    cap._read_loop(fd=11, wake_reader=12, stop_event=stop, buflen=9000)
+    assert reads == [9000]
+
+
 def test_id_opts_empty_by_default(lk):
     keeper = _keeper(lk)
     assert keeper._dhcp._id_opts == []

--- a/net/os-carp-vip-dhcp/tests/test_ifprobe.py
+++ b/net/os-carp-vip-dhcp/tests/test_ifprobe.py
@@ -60,18 +60,22 @@ def test_carrier_up():
 
 
 def test_iface_ipv4():
+    # `ifconfig -f inet:cidr` prints the prefix inline; /24 plus /30 and /31 (the
+    # backup-egress peer-derivation cases) all parse.
     assert ifprobe.iface_ipv4(
-        "\tinet 100.64.4.7 netmask 0xffffff00 broadcast 100.64.4.255\n") == ("100.64.4.7", 24)
-    assert ifprobe.iface_ipv4("\tinet 10.0.0.1 netmask 0xfffffe00\n") == ("10.0.0.1", 23)
+        "\tinet 100.64.4.7/24 broadcast 100.64.4.255\n") == ("100.64.4.7", 24)
+    assert ifprobe.iface_ipv4("\tinet 10.0.0.2/30\n") == ("10.0.0.2", 30)
+    assert ifprobe.iface_ipv4("\tinet 10.0.0.2/31\n") == ("10.0.0.2", 31)
 
 
 def test_iface_ipv4_none_cases():
     assert ifprobe.iface_ipv4(None) is None
     assert ifprobe.iface_ipv4("") is None
     assert ifprobe.iface_ipv4("igc0: flags\n\tstatus: active\n") is None       # no inet
-    assert ifprobe.iface_ipv4("\tinet 100.64.4.7\n") is None                   # no netmask
-    assert ifprobe.iface_ipv4("\tinet nope netmask 0xffffff00\n") is None      # bad address
-    assert ifprobe.iface_ipv4("\tinet 100.64.4.7 netmask zzz\n") is None       # bad mask
+    assert ifprobe.iface_ipv4("\tinet 100.64.4.7\n") is None                   # no /NN (not -f cidr)
+    assert ifprobe.iface_ipv4("\tinet nope/24\n") is None                      # bad address
+    assert ifprobe.iface_ipv4("\tinet 100.64.4.7/33\n") is None                # prefix out of range
+    assert ifprobe.iface_ipv4("\tinet 100.64.4.7/xx\n") is None                # bad prefix
 
 
 def test_carp_role_values_are_the_ifconfig_tokens():

--- a/net/os-carp-vip-dhcp/tests/test_ifprobe.py
+++ b/net/os-carp-vip-dhcp/tests/test_ifprobe.py
@@ -23,6 +23,12 @@ def test_carp_roles_empty_on_none_blank_or_no_carp():
     assert not ifprobe.carp_roles("em0: flags\n\tstatus: active\n")   # no carp lines
 
 
+def test_carp_roles_keeps_a_non_word_role_token_whole():
+    # The lossless contract holds for a token with non-word characters too: \S+ keeps
+    # it whole rather than truncating (\w+ would stop at the '-' and drop the line).
+    assert ifprobe.carp_roles("\tcarp: PRE-INIT vhid 9 advbase 1\n") == {"9": "PRE-INIT"}
+
+
 def test_carp_roles_keeps_unrecognised_role():
     # An unknown role token is kept verbatim, not dropped, so a VIP never vanishes
     # from the status view (carp(4) only emits INIT/BACKUP/MASTER, but be lossless).
@@ -47,9 +53,11 @@ def test_is_carp_master():
 
 
 def test_is_carp_master_matches_vhid_exactly():
-    # 199 must never read as 19 or 1990 (the whole number is captured, not a prefix).
+    # 199 must never read as 19 or 1990 (the whole number is captured, not a prefix),
+    # and a trailing non-digit must not let "199x" read as vhid 199 (\b bounds it).
     assert ifprobe.is_carp_master("carp: MASTER vhid 19 advbase 1\n", "199") is False
     assert ifprobe.is_carp_master("carp: MASTER vhid 1990 advbase 1\n", "199") is False
+    assert ifprobe.is_carp_master("carp: MASTER vhid 199x advbase 1\n", "199") is False
 
 
 def test_carrier_up():
@@ -76,6 +84,7 @@ def test_iface_ipv4_none_cases():
     assert ifprobe.iface_ipv4("\tinet nope/24\n") is None                      # bad address
     assert ifprobe.iface_ipv4("\tinet 100.64.4.7/33\n") is None                # prefix out of range
     assert ifprobe.iface_ipv4("\tinet 100.64.4.7/xx\n") is None                # bad prefix
+    assert ifprobe.iface_ipv4("\tinet 2001:db8::1/32\n") is None               # IPv6 rejected
 
 
 def test_carp_role_values_are_the_ifconfig_tokens():

--- a/net/os-carp-vip-dhcp/tests/test_ifprobe.py
+++ b/net/os-carp-vip-dhcp/tests/test_ifprobe.py
@@ -59,6 +59,21 @@ def test_carrier_up():
     assert ifprobe.carrier_up(None) is None                                  # probe failed
 
 
+def test_iface_ipv4():
+    assert ifprobe.iface_ipv4(
+        "\tinet 100.64.4.7 netmask 0xffffff00 broadcast 100.64.4.255\n") == ("100.64.4.7", 24)
+    assert ifprobe.iface_ipv4("\tinet 10.0.0.1 netmask 0xfffffe00\n") == ("10.0.0.1", 23)
+
+
+def test_iface_ipv4_none_cases():
+    assert ifprobe.iface_ipv4(None) is None
+    assert ifprobe.iface_ipv4("") is None
+    assert ifprobe.iface_ipv4("igc0: flags\n\tstatus: active\n") is None       # no inet
+    assert ifprobe.iface_ipv4("\tinet 100.64.4.7\n") is None                   # no netmask
+    assert ifprobe.iface_ipv4("\tinet nope netmask 0xffffff00\n") is None      # bad address
+    assert ifprobe.iface_ipv4("\tinet 100.64.4.7 netmask zzz\n") is None       # bad mask
+
+
 def test_carp_role_values_are_the_ifconfig_tokens():
     # .value is what status.py puts on the wire (JSON); keep it the exact token.
     assert CarpRole.MASTER.value == "MASTER"

--- a/net/os-carp-vip-dhcp/tests/test_ifprobe.py
+++ b/net/os-carp-vip-dhcp/tests/test_ifprobe.py
@@ -54,10 +54,12 @@ def test_is_carp_master():
 
 def test_is_carp_master_matches_vhid_exactly():
     # 199 must never read as 19 or 1990 (the whole number is captured, not a prefix),
-    # and a trailing non-digit must not let "199x" read as vhid 199 (\b bounds it).
+    # and a trailing non-whitespace char must not let "199x" or "199-foo" read as vhid
+    # 199 (the number must be a complete whitespace-delimited token).
     assert ifprobe.is_carp_master("carp: MASTER vhid 19 advbase 1\n", "199") is False
     assert ifprobe.is_carp_master("carp: MASTER vhid 1990 advbase 1\n", "199") is False
     assert ifprobe.is_carp_master("carp: MASTER vhid 199x advbase 1\n", "199") is False
+    assert ifprobe.is_carp_master("carp: MASTER vhid 199-foo advbase 1\n", "199") is False
 
 
 def test_carrier_up():

--- a/net/os-carp-vip-dhcp/tests/test_ifprobe.py
+++ b/net/os-carp-vip-dhcp/tests/test_ifprobe.py
@@ -1,0 +1,66 @@
+"""Unit tests for ifprobe: parsing ifconfig(8) CARP-role and carrier text.
+
+The one parser both keeper.py (is a vhid master?) and status.py (map every vhid
+to its role for the GUI) now share, so their two former parsers cannot drift.
+Comments over docstrings.
+"""
+# pylint: disable=missing-function-docstring
+from leasekeeper import ifprobe  # sys.path via conftest  # type: ignore
+from leasekeeper.ifprobe import CarpRole
+
+
+def test_carp_roles_maps_every_vhid():
+    # The role token is passed through verbatim (plain str), keyed by vhid.
+    text = ("em0: flags\n\tcarp: MASTER vhid 149 advbase 1 advskew 0\n"
+            "em1: flags\n\tcarp: BACKUP vhid 20 advbase 1 advskew 100\n"
+            "em2: flags\n\tcarp: INIT vhid 30 advbase 1\n")
+    assert ifprobe.carp_roles(text) == {"149": "MASTER", "20": "BACKUP", "30": "INIT"}
+
+
+def test_carp_roles_empty_on_none_blank_or_no_carp():
+    assert not ifprobe.carp_roles(None)
+    assert not ifprobe.carp_roles("")
+    assert not ifprobe.carp_roles("em0: flags\n\tstatus: active\n")   # no carp lines
+
+
+def test_carp_roles_keeps_unrecognised_role():
+    # An unknown role token is kept verbatim, not dropped, so a VIP never vanishes
+    # from the status view (carp(4) only emits INIT/BACKUP/MASTER, but be lossless).
+    text = "\tcarp: WOBBLE vhid 7 advbase 1\n\tcarp: MASTER vhid 8 advbase 1\n"
+    assert ifprobe.carp_roles(text) == {"7": "WOBBLE", "8": "MASTER"}
+
+
+def test_carp_roles_tolerates_extra_whitespace():
+    assert ifprobe.carp_roles("carp:   MASTER   vhid   5 ") == {"5": "MASTER"}
+
+
+def test_is_carp_master():
+    m = "\tcarp: MASTER vhid 199 advbase 1\n"
+    assert ifprobe.is_carp_master(m, "199") is True
+    assert ifprobe.is_carp_master(m, 199) is True                 # int vhid coerced
+    assert ifprobe.is_carp_master("\tcarp: BACKUP vhid 199\n", "199") is False
+    # Populated text, but the requested vhid is not in it -> False (the .get miss
+    # path, distinct from the empty-text short-circuit below).
+    assert ifprobe.is_carp_master("\tcarp: MASTER vhid 5 advbase 1\n", "199") is False
+    assert ifprobe.is_carp_master("", "199") is False             # empty text present
+    assert ifprobe.is_carp_master(None, "199") is None            # probe failed
+
+
+def test_is_carp_master_matches_vhid_exactly():
+    # 199 must never read as 19 or 1990 (the whole number is captured, not a prefix).
+    assert ifprobe.is_carp_master("carp: MASTER vhid 19 advbase 1\n", "199") is False
+    assert ifprobe.is_carp_master("carp: MASTER vhid 1990 advbase 1\n", "199") is False
+
+
+def test_carrier_up():
+    assert ifprobe.carrier_up("igc0: flags\n\tstatus: active\n") is True
+    assert ifprobe.carrier_up("igc0: flags\n\tstatus: no carrier\n") is False
+    assert ifprobe.carrier_up("igc0: flags\n\t(no status line)\n") is None   # no status line
+    assert ifprobe.carrier_up(None) is None                                  # probe failed
+
+
+def test_carp_role_values_are_the_ifconfig_tokens():
+    # .value is what status.py puts on the wire (JSON); keep it the exact token.
+    assert CarpRole.MASTER.value == "MASTER"
+    assert CarpRole.BACKUP.value == "BACKUP"
+    assert CarpRole.INIT.value == "INIT"

--- a/net/os-carp-vip-dhcp/tests/test_logparse.py
+++ b/net/os-carp-vip-dhcp/tests/test_logparse.py
@@ -1,5 +1,7 @@
 """Unit tests for logparse.py log-line parsing (comments over docstrings)."""
 # pylint: disable=missing-function-docstring
+import json
+
 import logparse  # sys.path via conftest  # type: ignore
 
 
@@ -33,3 +35,42 @@ def test_keeper_meta_reads_name_keyed_conf(tmp_path, monkeypatch):
     meta = logparse.keeper_meta()
     assert meta["100_64_4_7"] == {"ip": "100.64.4.7", "vhid": "254"}
     assert meta["100_64_4_8"] == {"ip": "100.64.4.8", "vhid": "253"}
+
+
+def test_main_parses_tags_and_orders(tmp_path, monkeypatch, capsys):
+    # main() globs the per-keeper logs, parses each line, tags it with the keeper's
+    # ip/vhid, and emits newest-first JSON (the Diagnostics log-viewer feed).
+    (tmp_path / "carpvipdhcp-100_64_4_7.log").write_text(
+        "2026-07-06 12:00:00,100 INFO older line\n"
+        "2026-07-06 12:34:56,789 WARNING newer line\n"
+        "a bare continuation line with no timestamp\n")
+    monkeypatch.setattr(logparse, "LOG_GLOB", str(tmp_path / "carpvipdhcp-*.log"))
+    monkeypatch.setattr(logparse, "keeper_meta",
+                        lambda: {"100_64_4_7": {"ip": "100.64.4.7", "vhid": "254"}})
+    logparse.main()
+    records = json.loads(capsys.readouterr().out)
+    # newest-first: 12:34 WARNING, then 12:00 INFO, then the bare line (empty ts) last.
+    assert [r["timestamp"] for r in records] == ["2026-07-06 12:34:56", "2026-07-06 12:00:00", ""]
+    assert records[0]["level"] == "WARNING" and records[0]["message"] == "newer line"
+    assert records[0]["keeper"] == "100.64.4.7" and records[0]["vhid"] == "254"
+    assert records[2]["level"] == "" and "bare continuation" in records[2]["message"]
+
+
+def test_main_unknown_keeper_falls_back_to_id(tmp_path, monkeypatch, capsys):
+    # A log with no keeper.conf entry: keeper falls back to the filename id, vhid
+    # empty -- the viewer still shows the lines.
+    (tmp_path / "carpvipdhcp-1_2_3_4.log").write_text("2026-07-06 12:00:00 INFO x\n")
+    monkeypatch.setattr(logparse, "LOG_GLOB", str(tmp_path / "carpvipdhcp-*.log"))
+    monkeypatch.setattr(logparse, "keeper_meta", lambda: {})
+    logparse.main()
+    records = json.loads(capsys.readouterr().out)
+    assert records[0]["keeper"] == "1_2_3_4" and records[0]["vhid"] == ""
+
+
+def test_main_skips_unreadable_file(tmp_path, monkeypatch, capsys):
+    # An unreadable path matching the glob (here a directory) is skipped, not fatal.
+    (tmp_path / "carpvipdhcp-dir.log").mkdir()
+    monkeypatch.setattr(logparse, "LOG_GLOB", str(tmp_path / "carpvipdhcp-*.log"))
+    monkeypatch.setattr(logparse, "keeper_meta", lambda: {})
+    logparse.main()
+    assert not json.loads(capsys.readouterr().out)

--- a/net/os-carp-vip-dhcp/tests/test_route.py
+++ b/net/os-carp-vip-dhcp/tests/test_route.py
@@ -415,13 +415,24 @@ def test_liveness_withdraw_names_the_reason(lk, monkeypatch, caplog):
                for r in caplog.records)
 
 
-def test_no_default_reason_no_usable_lease(lk, monkeypatch, caplog):
-    # master but holding no lease: the no-default heartbeat names "no usable lease"
-    # (not "CARP backup"), so the operator sees WHY there is no default.
+def test_no_default_reason_no_lease_held(lk, monkeypatch, caplog):
+    # master but holding no lease at all: the no-default heartbeat names "no lease
+    # held" (not "CARP backup"), so the operator sees WHY there is no default.
     rec, _ = _rec(lk, monkeypatch, "enforce")
     with caplog.at_level("INFO", logger="lease-keeper"):
         rec.reconcile(True, False, None)
-    assert any("no default held (no usable lease)" in r.getMessage() for r in caplog.records)
+    assert any("no default held (no lease held)" in r.getMessage() for r in caplog.records)
+
+
+def test_no_default_reason_lease_without_gateway(lk, monkeypatch, caplog):
+    # master, a lease IS held (bound), but the ACK carried no usable option-3
+    # gateway: distinct from "no lease held" so the log does not tell an operator
+    # who has a lease that there is none.
+    rec, _ = _rec(lk, monkeypatch, "enforce")
+    with caplog.at_level("INFO", logger="lease-keeper"):
+        rec.reconcile(True, True, None)
+    assert any("no default held (lease has no usable gateway)" in r.getMessage()
+               for r in caplog.records)
 
 
 def test_gateway_change_relogs_ownership_at_info(lk, monkeypatch, caplog):

--- a/net/os-carp-vip-dhcp/tests/test_status.py
+++ b/net/os-carp-vip-dhcp/tests/test_status.py
@@ -165,3 +165,66 @@ def test_carp_states_empty_when_no_carp_interfaces(monkeypatch):
     monkeypatch.setattr(syscmd.subprocess, "run",
                         lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="em0: flags\n\tstatus: active\n"))
     assert not status.carp_states()
+
+
+# ---- iface_names: device -> friendly OPNsense name, parsed from config.xml.
+
+def test_iface_names_maps_device_to_descr(tmp_path, monkeypatch):
+    xml = tmp_path / "config.xml"
+    xml.write_text(
+        "<opnsense><interfaces>"
+        "<wan><if>igb0</if><descr>WAN</descr></wan>"
+        "<lan><if>igb1</if><descr></descr></lan>"      # blank descr -> the tag, upper-cased
+        "<opt1><descr>no if element</descr></opt1>"    # no <if> -> skipped
+        "</interfaces></opnsense>")
+    monkeypatch.setattr(status, "CONFIG_XML", str(xml))
+    assert status.iface_names() == {"igb0": "WAN", "igb1": "LAN"}
+
+
+def test_iface_names_empty_on_malformed_xml(tmp_path, monkeypatch):
+    bad = tmp_path / "config.xml"
+    bad.write_text("<opnsense><interfaces>")           # unclosed -> ParseError
+    monkeypatch.setattr(status, "CONFIG_XML", str(bad))
+    assert not status.iface_names()
+
+
+def test_iface_names_empty_when_file_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(status, "CONFIG_XML", str(tmp_path / "nope.xml"))   # OSError
+    assert not status.iface_names()
+
+
+def test_iface_names_empty_without_interfaces_section(tmp_path, monkeypatch):
+    xml = tmp_path / "config.xml"
+    xml.write_text("<opnsense></opnsense>")            # find('interfaces') -> None
+    monkeypatch.setattr(status, "CONFIG_XML", str(xml))
+    assert not status.iface_names()
+
+
+# ---- pid_alive: the live pid in a pidfile, or None. os.kill(pid, 0) is stubbed
+# where it must succeed (signal 0 checks liveness on FreeBSD but terminates the
+# process on Windows, where the tests also run).
+
+def test_pid_alive_returns_live_pid(tmp_path, monkeypatch):
+    monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)   # pid is alive
+    pidf = tmp_path / "live.pid"
+    pidf.write_text("4242")
+    assert status.pid_alive(str(pidf)) == 4242
+
+
+def test_pid_alive_none_when_process_gone(tmp_path, monkeypatch):
+    def boom(pid, sig):
+        raise ProcessLookupError                       # OSError: stale/foreign pid
+    monkeypatch.setattr(status.os, "kill", boom)
+    pidf = tmp_path / "stale.pid"
+    pidf.write_text("999999")
+    assert status.pid_alive(str(pidf)) is None
+
+
+def test_pid_alive_none_on_missing_file(tmp_path):
+    assert status.pid_alive(str(tmp_path / "absent.pid")) is None   # open -> OSError
+
+
+def test_pid_alive_none_on_garbled_pidfile(tmp_path):
+    bad = tmp_path / "bad.pid"
+    bad.write_text("not-a-pid")
+    assert status.pid_alive(str(bad)) is None                       # int() -> ValueError

--- a/net/os-carp-vip-dhcp/tests/test_status.py
+++ b/net/os-carp-vip-dhcp/tests/test_status.py
@@ -1,5 +1,6 @@
 """Unit tests for status.py heartbeat / keeper-id parsing (comments over docstrings)."""
 # pylint: disable=missing-function-docstring
+import json
 import time
 import types
 
@@ -228,3 +229,24 @@ def test_pid_alive_none_on_garbled_pidfile(tmp_path):
     bad = tmp_path / "bad.pid"
     bad.write_text("not-a-pid")
     assert status.pid_alive(str(bad)) is None                       # int() -> ValueError
+
+
+# ---- main(): wire carp_states()/iface_names() into read_keepers, in that order.
+
+def test_main_maps_carp_state_and_iface_name_onto_keeper(monkeypatch, capsys):
+    # main() must pass carp_states() and iface_names() to read_keepers in THAT
+    # order, and read_keepers must key them onto the keeper by vhid / iface. A
+    # swapped arg order or a broken .get would misassign the GUI feed.
+    rec = {"request": "100.64.4.7", "iface": "igb0", "chaddr": "aa",
+           "vhid": "149", "follow": "1", "arpnudge": "240"}
+    monkeypatch.setattr(status, "keeper_records", lambda conffile: [rec])
+    monkeypatch.setattr(status, "carp_states", lambda: {"149": "MASTER"})
+    monkeypatch.setattr(status, "iface_names", lambda: {"igb0": "WAN"})
+    monkeypatch.setattr(status, "carp_demotion", lambda: 0)
+    status.main()
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["carp_demotion"] == 0
+    keeper = doc["keepers"][0]
+    assert keeper["request"] == "100.64.4.7" and keeper["vhid"] == "149"
+    assert keeper["carp_state"] == "MASTER"    # from carp_states(), keyed by vhid
+    assert keeper["iface_name"] == "WAN"       # from iface_names(), keyed by iface


### PR DESCRIPTION
Refactor and hardening pass on the CarpVipDhcp lease-keeper. It started as one shared `ifconfig(8)` parser and grew to fold in the review-follow-up items that surfaced along the way: clarity renames, two concurrency-audit fixes, and small robustness/log improvements. Behaviour-preserving except where a change is explicitly a fix; every change is covered by tests.

## Shared ifconfig(8) parser (`ifprobe.py`)

`keeper.py` decided the CARP role by substring match, `status.py` parsed the same `ifconfig` output with its own regex, and `route._iface_ipv4` parsed the `inet` line itself. Three parsers of one text, free to drift. New `leasekeeper/ifprobe.py` (the read-side counterpart to `syscmd`, which runs the command) now owns all ifconfig-text parsing:

- `CarpRole` (`StrEnum`, like `constants.Phase`): the INIT / BACKUP / MASTER states.
- `carp_roles(text) -> {vhid: role}`: one regex, lossless (an unrecognised token is kept, not dropped, so a VIP never vanishes from the status view).
- `is_carp_master(text, vhid) -> True/False/None`: whole-vhid exact match (199 never reads as 19 or 1990); `None` only when the probe text is missing (distinct from present-but-not-master).
- `carrier_up(text)`: the interface carrier check.
- `iface_ipv4(text)`: the interface address/prefix parse.

`keeper` and `status.carp_states` delegate to it. The keeper's None/False/no-vhid contract is unchanged and the status JSON is byte-identical.

## `TimingSource` enum for the heartbeat `src` token

`DhcpClient.timing()` returned a bare `"server"`/`"derived"` string for where the lease timers came from. It is now a `TimingSource` `StrEnum` (in `constants`, beside `Phase`), typed at the producer. `StrEnum` formats to its wire token, so the heartbeat `src=` field and the log label stay byte-identical and `status.py` reads the raw token unchanged.

## Concurrency-audit fixes

- **wake-fd close ordering:** `signal.set_wakeup_fd(-1)` ran in `main`'s `finally` after `run()` had already closed the wake socket, so for a sub-millisecond shutdown window the C-level signal wakeup fd pointed at a closed (or, worst case, reused) fd. The wake-socket close moves into `keeper.close()`, which the entry point calls only after `set_wakeup_fd(-1)`, so unregister always precedes close.
- **bpf reader read size:** the reader thread read the bpf buffer size from shared `self._buflen`, which a concurrent capture restart's `_configure()` could rebind under a still-running old reader. It is now handed to the reader as a thread argument, like its fd / wake-pipe / stop-signal, so a restart can never change it out from under an old reader that outlived its `stop()`.

## Robustness and log accuracy

- **`ifconfig -f inet:cidr`:** `_iface_ipv4` requests the CIDR form so the address prints as `A.B.C.D/NN` and the prefix length is read directly, with no hex-netmask conversion. `iface_ipv4` parses that single form; text without a `/NN` yields `None` and the caller defers, as before. The output format was checked against a live FreeBSD 15.1 host.
- **no-default reason:** the "no default route" heartbeat logged `no usable lease` for two distinct states. It now names them separately (`no lease held` vs `lease has no usable gateway`), so the log never tells an operator holding a lease that there is none.

## Clarity renames (no behaviour change)

`_ReaderGen -> _ReaderGeneration`; cryptic locals (`a -> args`, `k -> keeper`, `b -> binding`, `still -> still_present`); cryptic fields (`_ev -> _reply_ready`, `_backup -> _cfg`, `_gw -> _logged_gw`); misleading functions (`_signal_wake -> _wake_loop`, `_carp_master_probe -> _nudge_is_master`, `_at -> _log_at`).

## Tests and verification

- 325 tests pass. New `tests/test_ifprobe.py` pins the parser; the existing keeper/status parse tests are retained as characterization tests. Added coverage for `logparse.main`, `status.iface_names` / `pid_alive`, and the `status.main` wiring.
- flake8 clean (max-line-length 120); pylint 10.00/10; pyright 0 errors.
- Reviewed for correctness, test coverage, and silent failures; findings folded in. Review follow-ups: the CARP regex now token-bounds the vhid and keeps a complete role token, `iface_ipv4` rejects a non-IPv4 address, and the `--once` path closes the keeper's wake socketpair.
- Version 1.13.5.
